### PR TITLE
Remove temp file use in ingestion

### DIFF
--- a/datacreek/core/create.py
+++ b/datacreek/core/create.py
@@ -22,7 +22,7 @@ def read_json(file_path):
 
 
 def process_file(
-    file_path: str,
+    file_path: Optional[str],
     output_dir: str,
     config_path: Optional[Path] = None,
     api_base: Optional[str] = None,
@@ -31,6 +31,7 @@ def process_file(
     num_pairs: Optional[int] = None,
     verbose: bool = False,
     provider: Optional[str] = None,
+    document_text: Optional[str] = None,
 ) -> str:
     """Process a file to generate content
     
@@ -63,13 +64,17 @@ def process_file(
     print(f"L Using {client.provider} provider")
     
     # Generate base filename for output
-    base_name = os.path.splitext(os.path.basename(file_path))[0]
+    if file_path:
+        base_name = os.path.splitext(os.path.basename(file_path))[0]
+    else:
+        base_name = "input"
     
     # Generate content based on type
     if content_type == "qa":
         generator = QAGenerator(client, config_path)
 
-        document_text = read_json(file_path)
+        if document_text is None:
+            document_text = read_json(file_path)
         
         # Get num_pairs from args or config
         if num_pairs is None:
@@ -110,7 +115,8 @@ def process_file(
     elif content_type == "summary":
         generator = QAGenerator(client, config_path)
 
-        document_text = read_json(file_path)
+        if document_text is None:
+            document_text = read_json(file_path)
         
         # Generate just the summary
         summary = generator.generate_summary(document_text)
@@ -132,7 +138,8 @@ def process_file(
         # Initialize the CoT generator
         generator = COTGenerator(client, config_path)
 
-        document_text = read_json(file_path)
+        if document_text is None:
+            document_text = read_json(file_path)
         
         # Get num_examples from args or config
         if num_pairs is None:
@@ -170,7 +177,8 @@ def process_file(
         # Initialize the CoT generator
         generator = COTGenerator(client, config_path)
 
-        document_text = read_json(file_path)
+        if document_text is None:
+            document_text = read_json(file_path)
         
         # Get max_examples from args or config
         max_examples = None

--- a/datacreek/core/ingest.py
+++ b/datacreek/core/ingest.py
@@ -60,49 +60,17 @@ def process_file(
     """Process a file using the appropriate parser
     
     Args:
-        file_path: Path to the file or URL to parse
-        output_dir: Directory to save parsed text (if None, uses config)
-        output_name: Custom filename for output (if None, uses original name)
+        file_path: Path or URL of the resource to parse
+        output_dir: Ignored, kept for backward compatibility
+        output_name: Ignored, kept for backward compatibility
         config: Configuration dictionary (if None, uses default)
-    
+
     Returns:
-        Path to the output file
+        Raw text content extracted from the source
     """
-    # Create output directory if it doesn't exist
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir, exist_ok=True)
-    
     # Determine parser based on file type
     parser = determine_parser(file_path, config)
-    
+
     # Parse the file
     content = parser.parse(file_path)
-    
-    # Generate output filename if not provided
-    if not output_name:
-        if file_path.startswith(('http://', 'https://')):
-            # Extract filename from URL
-            if 'youtube.com' in file_path or 'youtu.be' in file_path:
-                # Use video ID for YouTube URLs
-                import re
-                video_id = re.search(r'(?:v=|\.be/)([^&]+)', file_path).group(1)
-                output_name = f"youtube_{video_id}.txt"
-            else:
-                # Use domain for other URLs
-                from urllib.parse import urlparse
-                domain = urlparse(file_path).netloc.replace('.', '_')
-                output_name = f"{domain}.txt"
-        else:
-            # Use original filename with .txt extension
-            base_name = os.path.basename(file_path)
-            output_name = os.path.splitext(base_name)[0] + '.txt'
-    
-    # Ensure .txt extension
-    if not output_name.endswith('.txt'):
-        output_name += '.txt'
-    
-    # Save the content
-    output_path = os.path.join(output_dir, output_name)
-    parser.save(content, output_path)
-    
-    return output_path
+    return content

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,7 +27,7 @@ def test_ingest(tmp_path):
 
 def test_full_pipeline(monkeypatch, tmp_path):
     # stub generation to avoid real LLM calls
-    def dummy_generate(path, content_type, output_dir, *args, **kwargs):
+    def dummy_generate(path, output_dir, *args, document_text=None, **kwargs):
         out = Path(output_dir) / "gen.json"
         with open(out, "w") as f:
             json.dump({"qa_pairs": [{"question": "q", "answer": "a"}]}, f)


### PR DESCRIPTION
## Summary
- store raw ingestion content directly in the DB
- let dataset generation read text from DB
- adjust tests for new ingestion behaviour

## Testing
- `pip install -e .`
- `pip install sqlalchemy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68597599ff04832fb3e5ceded8bdeb32