### PR TITLE
Refactor DB config and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ The service exposes `/ingest`, `/generate`, `/curate` and `/save` routes that co
 ## Configuration
 
 The toolkit uses a YAML configuration file (default: `configs/config.yaml`).
+Database connection settings can be provided either through the
+`DATABASE_URL` environment variable or a `database.url` entry in the YAML
+file. By default a local SQLite file `datacreek.db` is used, but you can
+point this to any SQLAlchemy compatible database.
+
+### Database initialization
+
+Run `python -m datacreek.cli init-db` to create the tables before starting the
+server if they do not already exist.
 
 You can override any value by providing a custom YAML file to the server.
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -18,6 +18,10 @@ paths:
     cleaned: "data/cleaned"     # Where cleaned content is saved
     final: "data/final"         # Where final formatted content is saved
 
+# Database configuration
+database:
+  url: "sqlite:///./datacreek.db"
+
 # LLM Provider configuration
 llm:
   # Provider selection: "vllm" or "api-endpoint"

--- a/datacreek/api.py
+++ b/datacreek/api.py
@@ -1,42 +1,27 @@
-from fastapi import FastAPI, Depends, HTTPException
-from sqlalchemy import create_engine, Column, Integer, String, Text, ForeignKey
-from sqlalchemy.orm import sessionmaker, declarative_base, Session
 from pathlib import Path
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
 
 from datacreek.core.ingest import process_file as ingest_file
 from datacreek.core.create import process_file as generate_data
 from datacreek.core.curate import curate_qa_pairs
 from datacreek.core.save_as import convert_format
-import os
+from datacreek.db import SessionLocal, init_db, User, SourceData, Dataset
+from datacreek.schemas import (
+    UserCreate,
+    UserOut,
+    SourceCreate,
+    SourceOut,
+    GenerateParams,
+    DatasetOut,
+    CurateParams,
+    SaveParams,
+)
+from datacreek.services import create_user, create_source, create_dataset
 
-DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///./datacreek.db")
-engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-Base = declarative_base()
-
-class User(Base):
-    __tablename__ = "users"
-    id = Column(Integer, primary_key=True, index=True)
-    username = Column(String, unique=True, index=True)
-    api_key = Column(String, unique=True, index=True)
-
-class SourceData(Base):
-    __tablename__ = "sources"
-    id = Column(Integer, primary_key=True, index=True)
-    owner_id = Column(Integer, ForeignKey("users.id"))
-    path = Column(String)
-    content = Column(Text)
-
-class Dataset(Base):
-    __tablename__ = "datasets"
-    id = Column(Integer, primary_key=True, index=True)
-    owner_id = Column(Integer, ForeignKey("users.id"))
-    source_id = Column(Integer, ForeignKey("sources.id"))
-    path = Column(String)
-
-Base.metadata.create_all(bind=engine)
-
+init_db()
 app = FastAPI(title="Datacreek API")
+
 
 def get_db():
     db = SessionLocal()
@@ -45,55 +30,63 @@ def get_db():
     finally:
         db.close()
 
-@app.post("/users", summary="Create a user")
-def create_user(username: str, api_key: str, db: Session = Depends(get_db)):
-    user = User(username=username, api_key=api_key)
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return {"id": user.id}
 
-@app.post("/ingest", summary="Ingest a file")
-def ingest(path: str, name: str | None = None, db: Session = Depends(get_db)):
-    content = ingest_file(path, None, name, None)
-    src = SourceData(owner_id=None, path=path, content=content)
-    db.add(src)
-    db.commit()
-    db.refresh(src)
-    return {"id": src.id}
+@app.post("/users", response_model=UserOut, summary="Create a user")
+def create_user_route(payload: UserCreate, db: Session = Depends(get_db)):
+    user = create_user(db, payload.username, payload.api_key)
+    return user
 
-@app.post("/generate", summary="Generate dataset from source")
-def generate(src_id: int, content_type: str = "qa", num_pairs: int | None = None, db: Session = Depends(get_db)):
-    src = db.get(SourceData, src_id)
+
+@app.post("/ingest", response_model=SourceOut, summary="Ingest a file")
+def ingest(payload: SourceCreate, db: Session = Depends(get_db)):
+    content = ingest_file(payload.path, None, payload.name, None)
+    src = create_source(db, None, payload.path, content)
+    return src
+
+
+@app.post("/generate", response_model=DatasetOut, summary="Generate dataset from source")
+def generate(params: GenerateParams, db: Session = Depends(get_db)):
+    src = db.get(SourceData, params.src_id)
     if not src:
         raise HTTPException(status_code=404, detail="Source not found")
     output_dir = Path("data/generated")
     output_dir.mkdir(parents=True, exist_ok=True)
-    out = generate_data(None, str(output_dir), None, None, None, content_type, num_pairs, False, document_text=src.content)
-    ds = Dataset(owner_id=None, source_id=src_id, path=out)
-    db.add(ds)
-    db.commit()
-    db.refresh(ds)
-    return {"id": ds.id, "path": out}
+    out = generate_data(
+        None,
+        str(output_dir),
+        None,
+        None,
+        None,
+        params.content_type,
+        params.num_pairs,
+        False,
+        document_text=src.content,
+    )
+    ds = create_dataset(db, None, params.src_id, out)
+    return ds
 
-@app.post("/curate", summary="Curate a dataset")
-def curate(ds_id: int, threshold: float | None = None, db: Session = Depends(get_db)):
-    ds = db.get(Dataset, ds_id)
+
+@app.post("/curate", response_model=DatasetOut, summary="Curate a dataset")
+def curate(params: CurateParams, db: Session = Depends(get_db)):
+    ds = db.get(Dataset, params.ds_id)
     if not ds:
         raise HTTPException(status_code=404, detail="Dataset not found")
     output_path = Path(ds.path).with_name(Path(ds.path).stem + "_curated.json")
-    curate_qa_pairs(ds.path, str(output_path), threshold, None, None, None, False)
+    curate_qa_pairs(ds.path, str(output_path), params.threshold, None, None, None, False)
     ds.path = str(output_path)
     db.commit()
-    return {"id": ds.id, "path": ds.path}
+    db.refresh(ds)
+    return ds
 
-@app.post("/save", summary="Convert dataset format")
-def save(ds_id: int, fmt: str = "jsonl", db: Session = Depends(get_db)):
-    ds = db.get(Dataset, ds_id)
+
+@app.post("/save", response_model=DatasetOut, summary="Convert dataset format")
+def save(params: SaveParams, db: Session = Depends(get_db)):
+    ds = db.get(Dataset, params.ds_id)
     if not ds:
         raise HTTPException(status_code=404, detail="Dataset not found")
-    out = convert_format(ds.path, None, fmt, {}, "json")
+    out = convert_format(ds.path, None, params.fmt, {}, "json")
     ds.path = out
     db.commit()
-    return {"id": ds.id, "path": out}
+    db.refresh(ds)
+    return ds
 

--- a/datacreek/cli.py
+++ b/datacreek/cli.py
@@ -8,6 +8,15 @@ def serve(host: str = "127.0.0.1", port: int = 8000):
     """Run the REST API server."""
     uvicorn.run("datacreek.api:app", host=host, port=port, reload=True)
 
+
+@app_cli.command()
+def init_db_cmd() -> None:
+    """Create database tables."""
+    from datacreek.db import init_db
+
+    init_db()
+    typer.echo("Database initialized")
+
 @app_cli.command()
 def test():
     """Run the unit test suite."""
@@ -16,3 +25,4 @@ def test():
 
 if __name__ == "__main__":
     app_cli()
+

--- a/datacreek/db.py
+++ b/datacreek/db.py
@@ -1,0 +1,57 @@
+import os
+from sqlalchemy import create_engine, Column, Integer, String, Text, ForeignKey
+from sqlalchemy.orm import declarative_base, sessionmaker, relationship
+
+from datacreek.utils.config import load_config
+
+def get_database_url() -> str:
+    """Return DB connection string from env or config."""
+    env_url = os.environ.get("DATABASE_URL")
+    if env_url:
+        return env_url
+    try:
+        cfg = load_config()
+        return cfg.get("database", {}).get("url", "sqlite:///./datacreek.db")
+    except Exception:
+        return "sqlite:///./datacreek.db"
+
+
+DATABASE_URL = get_database_url()
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    api_key = Column(String, unique=True, index=True, nullable=False)
+
+    sources = relationship("SourceData", back_populates="owner")
+    datasets = relationship("Dataset", back_populates="owner")
+
+class SourceData(Base):
+    __tablename__ = "sources"
+    id = Column(Integer, primary_key=True, index=True)
+    owner_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    path = Column(String, nullable=False)
+    content = Column(Text, nullable=False)
+
+    owner = relationship("User", back_populates="sources")
+    datasets = relationship("Dataset", back_populates="source")
+
+class Dataset(Base):
+    __tablename__ = "datasets"
+    id = Column(Integer, primary_key=True, index=True)
+    owner_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    source_id = Column(Integer, ForeignKey("sources.id"), nullable=False)
+    path = Column(String, nullable=False)
+
+    owner = relationship("User", back_populates="datasets")
+    source = relationship("SourceData", back_populates="datasets")
+
+def init_db() -> None:
+    """Create database tables."""
+    Base.metadata.create_all(bind=engine)

--- a/datacreek/schemas.py
+++ b/datacreek/schemas.py
@@ -1,0 +1,42 @@
+from pydantic import BaseModel
+
+class UserCreate(BaseModel):
+    username: str
+    api_key: str
+
+class UserOut(BaseModel):
+    id: int
+    username: str
+
+    class Config:
+        from_attributes = True
+
+class SourceCreate(BaseModel):
+    path: str
+    name: str | None = None
+
+class SourceOut(BaseModel):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+class GenerateParams(BaseModel):
+    src_id: int
+    content_type: str = "qa"
+    num_pairs: int | None = None
+
+class DatasetOut(BaseModel):
+    id: int
+    path: str
+
+    class Config:
+        from_attributes = True
+
+class CurateParams(BaseModel):
+    ds_id: int
+    threshold: float | None = None
+
+class SaveParams(BaseModel):
+    ds_id: int
+    fmt: str = "jsonl"

--- a/datacreek/services.py
+++ b/datacreek/services.py
@@ -1,0 +1,32 @@
+from hashlib import sha256
+from sqlalchemy.orm import Session
+
+from datacreek.db import User, SourceData, Dataset
+
+
+def hash_key(api_key: str) -> str:
+    return sha256(api_key.encode()).hexdigest()
+
+
+def create_user(db: Session, username: str, api_key: str) -> User:
+    user = User(username=username, api_key=hash_key(api_key))
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def create_source(db: Session, owner_id: int | None, path: str, content: str) -> SourceData:
+    src = SourceData(owner_id=owner_id, path=path, content=content)
+    db.add(src)
+    db.commit()
+    db.refresh(src)
+    return src
+
+
+def create_dataset(db: Session, owner_id: int | None, source_id: int, path: str) -> Dataset:
+    ds = Dataset(owner_id=owner_id, source_id=source_id, path=path)
+    db.add(ds)
+    db.commit()
+    db.refresh(ds)
+    return ds

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,8 @@ from fastapi.testclient import TestClient
 
 os.environ["DATABASE_URL"] = "sqlite:///test.db"
 from datacreek.api import app
+from datacreek.db import SessionLocal, User, SourceData, Dataset
+from datacreek.services import hash_key
 
 client = TestClient(app)
 
@@ -13,16 +15,25 @@ def teardown_module(module):
         os.remove("test.db")
 
 def test_create_user():
-    res = client.post("/users", params={"username": "alice", "api_key": "key"})
+    res = client.post("/users", json={"username": "alice", "api_key": "key"})
     assert res.status_code == 200
-    assert "id" in res.json()
+    user_id = res.json()["id"]
+    with SessionLocal() as db:
+        user = db.get(User, user_id)
+        assert user is not None
+        assert user.username == "alice"
+        assert user.api_key == hash_key("key")
 
 def test_ingest(tmp_path):
     text_file = tmp_path / "example.txt"
     text_file.write_text("hello")
-    res = client.post("/ingest", params={"path": str(text_file)})
+    res = client.post("/ingest", json={"path": str(text_file)})
     assert res.status_code == 200
-    assert "id" in res.json()
+    src_id = res.json()["id"]
+    with SessionLocal() as db:
+        src = db.get(SourceData, src_id)
+        assert src is not None
+        assert src.path == str(text_file)
 
 
 def test_full_pipeline(monkeypatch, tmp_path):
@@ -38,7 +49,7 @@ def test_full_pipeline(monkeypatch, tmp_path):
         return output_path
 
     def dummy_save(input_path, output_path, fmt, cfg, storage):
-        out = Path(tmp_path) / "final.json"
+        out = Path(tmp_path) / f"final.{fmt}"
         Path(out).write_text(Path(input_path).read_text())
         return str(out)
 
@@ -49,15 +60,20 @@ def test_full_pipeline(monkeypatch, tmp_path):
     src_file = tmp_path / "src.txt"
     src_file.write_text("hi")
 
-    res = client.post("/ingest", params={"path": str(src_file)})
+    res = client.post("/ingest", json={"path": str(src_file)})
     src_id = res.json()["id"]
 
-    res = client.post("/generate", params={"src_id": src_id})
+    res = client.post("/generate", json={"src_id": src_id})
     assert res.status_code == 200
     ds_id = res.json()["id"]
 
-    res = client.post("/curate", params={"ds_id": ds_id})
+    res = client.post("/curate", json={"ds_id": ds_id})
     assert res.status_code == 200
 
-    res = client.post("/save", params={"ds_id": ds_id, "fmt": "jsonl"})
+    res = client.post("/save", json={"ds_id": ds_id, "fmt": "jsonl"})
     assert res.status_code == 200
+
+    with SessionLocal() as db:
+        ds = db.get(Dataset, ds_id)
+        assert ds is not None
+        assert ds.path.endswith("jsonl")


### PR DESCRIPTION
## Summary
- fetch database URL from config when not set in environment
- expose `init-db` command in CLI for setting up tables
- document database config options and initialization steps
- store hashed API key and verify in tests

## Testing
- `pip install -q pydantic fastapi sqlalchemy uvicorn pytest httpx pyyaml requests rich`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598692aed0832fb1f53617f3833c43