### PR TITLE
Add tool and conversation dataset pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,22 @@ prompts:
     ---
 ```
 
+Each dataset you create owns its own knowledge graph. During ingestion the
+selected documents are inserted into this graph and linked to their original
+source.  Generation steps query this cleaned graph instead of the raw files.
+The graph exposes simple search helpers so you can explore the content:
+
+```python
+from datacreek import DatasetBuilder, DatasetType
+
+ds = DatasetBuilder(DatasetType.QA, name="example")
+ds.add_document("doc1", source="paper.pdf")
+ds.add_chunk("doc1", "c1", "hello world")
+print(ds.search("hello"))  # ["c1"]
+print(ds.search_documents("paper"))  # ["doc1"]
+print(ds.get_chunks_for_document("doc1"))  # ["c1"]
+```
+
 ### Mental Model:
 
 ```mermaid
@@ -227,6 +243,31 @@ graph LR
     Save --> Alpaca[Alpaca Format]
     Save --> FT[Fine-Tuning Format]
     Save --> ChatML[ChatML Format]
+```
+
+## Dataset Generation Pipelines
+
+After ingestion, parsed content is placed into a knowledge graph. Generation
+pipelines operate on this graph and are specialized for different training goals.
+
+| Dataset type | Compatible trainings |
+|--------------|---------------------|
+| `qa`         | SFT, DPO, ORPO, DPO+SFT, PPO, RRHF, RLAIF, GRPO |
+| `cot`        | SFT, DPO, ORPO, DPO+SFT, RRHF |
+| `vqa`        | SFT |
+| `text`       | CPT |
+| `kg`         | SFT, DPO, ORPO, DPO+SFT, PPO, RRHF, RLAIF, GRPO |
+| `pref_pair`  | PPO, DPO, ORPO, DPO+SFT, RLAIF |
+| `pref_list`  | GRPO, RRHF |
+| `tool`       | SFT, DPO, ORPO, DPO+SFT, PPO, RRHF, RLAIF, GRPO |
+| `conversation` | SFT, DPO, ORPO, DPO+SFT, PPO, RRHF, RLAIF, GRPO |
+| `multi_tool` | SFT, DPO, ORPO, DPO+SFT, PPO, RRHF, RLAIF, GRPO |
+
+You can query pipelines programmatically:
+
+```python
+from datacreek import get_pipelines_for_training, TrainingGoal
+print(get_pipelines_for_training(TrainingGoal.SFT))
 ```
 
 ## Troubleshooting FAQs:

--- a/datacreek/__init__.py
+++ b/datacreek/__init__.py
@@ -3,9 +3,32 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-"""
-Datacreek: tools for preparing synthetic data for LLM fine-tuning
-"""
+"""Datacreek: tools for preparing synthetic data for LLM fine-tuning."""
 
 __version__ = "0.0.1"
 
+from .pipelines import (
+    GenerationPipeline,
+    TrainingGoal,
+    DatasetType,
+    PIPELINES,
+    get_pipeline,
+    get_trainings_for_dataset,
+    get_dataset_types_for_training,
+    get_pipelines_for_training,
+)
+from .core.knowledge_graph import KnowledgeGraph
+from .core.dataset import DatasetBuilder
+
+__all__ = [
+    "GenerationPipeline",
+    "TrainingGoal",
+    "DatasetType",
+    "PIPELINES",
+    "get_pipeline",
+    "get_trainings_for_dataset",
+    "get_dataset_types_for_training",
+    "get_pipelines_for_training",
+    "KnowledgeGraph",
+    "DatasetBuilder",
+]

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .knowledge_graph import KnowledgeGraph
+from ..pipelines import DatasetType
+
+
+@dataclass
+class DatasetBuilder:
+    """Manage a dataset under construction with its own knowledge graph."""
+
+    dataset_type: DatasetType
+    name: Optional[str] = None
+    graph: KnowledgeGraph = field(default_factory=KnowledgeGraph)
+
+    def add_document(self, doc_id: str, source: str) -> None:
+        """Insert a document node in the dataset graph."""
+        self.graph.add_document(doc_id, source)
+
+    def add_chunk(
+        self, doc_id: str, chunk_id: str, text: str, source: Optional[str] = None
+    ) -> None:
+        """Insert a chunk node in the dataset graph."""
+        self.graph.add_chunk(doc_id, chunk_id, text, source)
+
+    def search_chunks(self, query: str) -> list[str]:
+        return self.graph.search_chunks(query)
+
+    def search(self, query: str, node_type: str = "chunk") -> list[str]:
+        return self.graph.search(query, node_type=node_type)
+
+    def search_documents(self, query: str) -> list[str]:
+        return self.graph.search_documents(query)
+
+    def get_chunks_for_document(self, doc_id: str) -> list[str]:
+        return self.graph.get_chunks_for_document(doc_id)

--- a/datacreek/core/knowledge_graph.py
+++ b/datacreek/core/knowledge_graph.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+import networkx as nx
+
+
+@dataclass
+class KnowledgeGraph:
+    """Simple wrapper storing documents and chunks with source info."""
+
+    graph: nx.DiGraph = field(default_factory=nx.DiGraph)
+
+    def add_document(self, doc_id: str, source: str) -> None:
+        self.graph.add_node(doc_id, type="document", source=source)
+
+    def add_chunk(
+        self, doc_id: str, chunk_id: str, text: str, source: Optional[str] = None
+    ) -> None:
+        if source is None:
+            source = self.graph.nodes[doc_id].get("source")
+        self.graph.add_node(chunk_id, type="chunk", text=text, source=source)
+        self.graph.add_edge(doc_id, chunk_id, relation="has_chunk")
+
+    def search(self, query: str, node_type: str = "chunk") -> list[str]:
+        """Return node IDs of the given type matching the query.
+
+        For chunks we search in the ``text`` attribute while documents are
+        matched against their id or ``source``.
+        """
+
+        query_lower = query.lower()
+        results: list[str] = []
+        for node, data in self.graph.nodes(data=True):
+            if data.get("type") != node_type:
+                continue
+            if node_type == "document":
+                if query_lower in node.lower() or query_lower in str(data.get("source", "")).lower():
+                    results.append(node)
+            else:
+                if query_lower in str(data.get("text", "")).lower():
+                    results.append(node)
+        return results
+
+    def search_chunks(self, query: str) -> list[str]:
+        """Return chunk IDs containing the query string."""
+
+        return self.search(query, node_type="chunk")
+
+    def search_documents(self, query: str) -> list[str]:
+        """Return document IDs whose id or source matches the query."""
+
+        return self.search(query, node_type="document")
+
+    def get_chunks_for_document(self, doc_id: str) -> list[str]:
+        """Return all chunk IDs that belong to the given document."""
+
+        return [
+            tgt for src, tgt, data in self.graph.edges(doc_id, data=True) if data.get("relation") == "has_chunk"
+        ]

--- a/datacreek/pipelines.py
+++ b/datacreek/pipelines.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List
+
+
+class TrainingGoal(str, Enum):
+    """Supported training objectives."""
+
+    SFT = "sft"
+    CPT = "cpt"
+    RLAIF = "rlaif"
+    GRPO = "grpo"
+    PPO = "ppo"
+    DPO = "dpo"
+    ORPO = "orpo"
+    DPO_SFT = "dpo_sft"
+    RRHF = "rrhf"
+
+
+class DatasetType(str, Enum):
+    """Type of dataset produced by generation pipelines."""
+
+    QA = "qa"
+    COT = "cot"
+    VQA = "vqa"
+    TEXT = "text"
+    KG = "kg"
+    PREF_PAIR = "pref_pair"
+    PREF_LIST = "pref_list"
+    TOOL = "tool"
+    CONVERSATION = "conversation"
+    MULTI_TOOL = "multi_tool"
+
+
+@dataclass
+class GenerationPipeline:
+    """Definition of a generation pipeline."""
+
+    dataset_type: DatasetType
+    steps: List[str]
+    compatible_trainings: List[TrainingGoal]
+    description: str
+
+
+PIPELINES: Dict[DatasetType, GenerationPipeline] = {
+    DatasetType.QA: GenerationPipeline(
+        dataset_type=DatasetType.QA,
+        steps=["ingest", "to_kg", "generate_qa", "curate", "save"],
+        compatible_trainings=[
+            TrainingGoal.SFT,
+            TrainingGoal.DPO,
+            TrainingGoal.ORPO,
+            TrainingGoal.DPO_SFT,
+            TrainingGoal.PPO,
+            TrainingGoal.RRHF,
+            TrainingGoal.RLAIF,
+            TrainingGoal.GRPO,
+        ],
+        description="Question-answer pairs for instruction tuning and preference based training.",
+    ),
+    DatasetType.COT: GenerationPipeline(
+        dataset_type=DatasetType.COT,
+        steps=["ingest", "to_kg", "generate_cot", "curate", "save"],
+        compatible_trainings=[
+            TrainingGoal.SFT,
+            TrainingGoal.DPO,
+            TrainingGoal.ORPO,
+            TrainingGoal.DPO_SFT,
+            TrainingGoal.RRHF,
+        ],
+        description="Chain-of-thought traces to teach stepwise reasoning.",
+    ),
+    DatasetType.VQA: GenerationPipeline(
+        dataset_type=DatasetType.VQA,
+        steps=["ingest", "to_kg", "generate_vqa", "curate", "save"],
+        compatible_trainings=[TrainingGoal.SFT],
+        description="Visual question answering pairs.",
+    ),
+    DatasetType.TEXT: GenerationPipeline(
+        dataset_type=DatasetType.TEXT,
+        steps=["ingest", "to_kg", "save"],
+        compatible_trainings=[TrainingGoal.CPT],
+        description="Raw text corpus for continual pre-training.",
+    ),
+    DatasetType.KG: GenerationPipeline(
+        dataset_type=DatasetType.KG,
+        steps=["ingest", "to_kg", "generate_from_kg", "curate", "save"],
+        compatible_trainings=[
+            TrainingGoal.SFT,
+            TrainingGoal.DPO,
+            TrainingGoal.ORPO,
+            TrainingGoal.DPO_SFT,
+            TrainingGoal.PPO,
+            TrainingGoal.RRHF,
+            TrainingGoal.RLAIF,
+            TrainingGoal.GRPO,
+        ],
+        description="Question answering data generated from a knowledge graph.",
+    ),
+    DatasetType.PREF_PAIR: GenerationPipeline(
+        dataset_type=DatasetType.PREF_PAIR,
+        steps=["ingest", "to_kg", "generate_candidates", "label_pairs", "save"],
+        compatible_trainings=[
+            TrainingGoal.PPO,
+            TrainingGoal.DPO,
+            TrainingGoal.ORPO,
+            TrainingGoal.DPO_SFT,
+            TrainingGoal.RLAIF,
+        ],
+        description="Pairwise preferences for reward-model and preference-based training.",
+    ),
+    DatasetType.PREF_LIST: GenerationPipeline(
+        dataset_type=DatasetType.PREF_LIST,
+        steps=["ingest", "to_kg", "generate_candidates", "rank_responses", "save"],
+        compatible_trainings=[TrainingGoal.GRPO, TrainingGoal.RRHF],
+        description="Listwise ranked responses for GRPO or RRHF.",
+    ),
+    DatasetType.TOOL: GenerationPipeline(
+        dataset_type=DatasetType.TOOL,
+        steps=["ingest", "to_kg", "generate_tool_call", "curate", "save"],
+        compatible_trainings=[
+            TrainingGoal.SFT,
+            TrainingGoal.DPO,
+            TrainingGoal.ORPO,
+            TrainingGoal.DPO_SFT,
+            TrainingGoal.PPO,
+            TrainingGoal.RRHF,
+            TrainingGoal.RLAIF,
+            TrainingGoal.GRPO,
+        ],
+        description="Single tool-calling demonstrations with integrated results.",
+    ),
+    DatasetType.CONVERSATION: GenerationPipeline(
+        dataset_type=DatasetType.CONVERSATION,
+        steps=["ingest", "to_kg", "generate_conversation", "curate", "save"],
+        compatible_trainings=[
+            TrainingGoal.SFT,
+            TrainingGoal.DPO,
+            TrainingGoal.ORPO,
+            TrainingGoal.DPO_SFT,
+            TrainingGoal.PPO,
+            TrainingGoal.RRHF,
+            TrainingGoal.RLAIF,
+            TrainingGoal.GRPO,
+        ],
+        description="Multi-turn conversations for dialogue training.",
+    ),
+    DatasetType.MULTI_TOOL: GenerationPipeline(
+        dataset_type=DatasetType.MULTI_TOOL,
+        steps=["ingest", "to_kg", "generate_multi_tool", "curate", "save"],
+        compatible_trainings=[
+            TrainingGoal.SFT,
+            TrainingGoal.DPO,
+            TrainingGoal.ORPO,
+            TrainingGoal.DPO_SFT,
+            TrainingGoal.PPO,
+            TrainingGoal.RRHF,
+            TrainingGoal.RLAIF,
+            TrainingGoal.GRPO,
+        ],
+        description="Sequential multi-tool use traces for complex tasks.",
+    ),
+}
+
+
+def get_pipeline(dataset_type: DatasetType) -> GenerationPipeline:
+    """Return pipeline information for a dataset type."""
+
+    if dataset_type not in PIPELINES:
+        raise KeyError(f"Unknown dataset type: {dataset_type}")
+    return PIPELINES[dataset_type]
+
+
+def get_trainings_for_dataset(dataset_type: DatasetType) -> List[TrainingGoal]:
+    """Return compatible trainings for a dataset type."""
+
+    return get_pipeline(dataset_type).compatible_trainings
+
+
+def get_dataset_types_for_training(goal: TrainingGoal) -> List[DatasetType]:
+    """Return dataset types that can be used for the given training goal."""
+
+    return [
+        pipeline.dataset_type
+        for pipeline in PIPELINES.values()
+        if goal in pipeline.compatible_trainings
+    ]
+
+
+def get_pipelines_for_training(goal: TrainingGoal) -> List[GenerationPipeline]:
+    """Return generation pipelines compatible with the given training goal."""
+
+    return [pipeline for pipeline in PIPELINES.values() if goal in pipeline.compatible_trainings]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "openai>=1.0.0",
     "fastapi>=0.111.0",
     "uvicorn>=0.27.0",
+    "networkx>=3.0",
 ]
 
 # These fields appear in pip show

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -1,0 +1,23 @@
+from datacreek.core.dataset import DatasetBuilder
+from datacreek.pipelines import DatasetType
+
+
+def test_dataset_has_its_own_graph():
+    ds1 = DatasetBuilder(DatasetType.QA, name="ds1")
+    ds2 = DatasetBuilder(DatasetType.QA, name="ds2")
+    ds1.add_document("doc1", source="a")
+    ds1.add_chunk("doc1", "c1", "hello")
+
+    assert ds1.search("hello") == ["c1"]
+    # second dataset should be empty
+    assert ds2.search("hello") == []
+
+
+def test_dataset_search_wrappers():
+    ds = DatasetBuilder(DatasetType.QA)
+    ds.add_document("d", source="s")
+    ds.add_chunk("d", "c", "text")
+    assert ds.search_chunks("text") == ["c"]
+    assert ds.search_documents("d") == ["d"]
+    assert ds.get_chunks_for_document("d") == ["c"]
+

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,0 +1,39 @@
+from datacreek.core.knowledge_graph import KnowledgeGraph
+
+
+def test_add_document_and_chunk():
+    kg = KnowledgeGraph()
+    kg.add_document("doc1", source="paper.pdf")
+    kg.add_chunk("doc1", "chunk1", "hello")
+
+    assert kg.graph.nodes["doc1"]["source"] == "paper.pdf"
+    assert kg.graph.nodes["chunk1"]["source"] == "paper.pdf"
+    assert ("doc1", "chunk1") in kg.graph.edges
+
+
+def test_search_chunks():
+    kg = KnowledgeGraph()
+    kg.add_document("doc1", source="paper.pdf")
+    kg.add_chunk("doc1", "c1", "hello world")
+    kg.add_chunk("doc1", "c2", "another line")
+
+    matches = kg.search_chunks("world")
+    assert matches == ["c1"]
+
+
+def test_generic_search():
+    kg = KnowledgeGraph()
+    kg.add_document("doc1", source="paper.pdf")
+    kg.add_chunk("doc1", "c1", "hello world")
+    assert kg.search("hello") == ["c1"]
+
+
+def test_document_helpers():
+    kg = KnowledgeGraph()
+    kg.add_document("doc1", source="paper.pdf")
+    kg.add_document("guide", source="guide.txt")
+    kg.add_chunk("doc1", "c1", "text1")
+    kg.add_chunk("doc1", "c2", "text2")
+
+    assert set(kg.search_documents("doc")) == {"doc1"}
+    assert kg.get_chunks_for_document("doc1") == ["c1", "c2"]

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,0 +1,53 @@
+from datacreek.pipelines import (
+    DatasetType,
+    TrainingGoal,
+    get_trainings_for_dataset,
+    get_dataset_types_for_training,
+    get_pipelines_for_training,
+)
+
+
+def test_get_trainings_for_dataset():
+    qa_trainings = get_trainings_for_dataset(DatasetType.QA)
+    assert TrainingGoal.SFT in qa_trainings
+    assert TrainingGoal.CPT not in qa_trainings
+
+    text_trainings = get_trainings_for_dataset(DatasetType.TEXT)
+    assert text_trainings == [TrainingGoal.CPT]
+
+    pair_trainings = get_trainings_for_dataset(DatasetType.PREF_PAIR)
+    assert TrainingGoal.DPO in pair_trainings
+    assert TrainingGoal.GRPO not in pair_trainings
+
+    kg_trainings = get_trainings_for_dataset(DatasetType.KG)
+    assert TrainingGoal.SFT in kg_trainings
+    assert TrainingGoal.CPT not in kg_trainings
+
+    tool_trainings = get_trainings_for_dataset(DatasetType.TOOL)
+    assert TrainingGoal.SFT in tool_trainings
+    assert TrainingGoal.CPT not in tool_trainings
+
+
+def test_reverse_mapping():
+    qa_datasets = get_dataset_types_for_training(TrainingGoal.SFT)
+    assert DatasetType.QA in qa_datasets
+    assert DatasetType.TEXT not in qa_datasets
+
+    cpt_pipes = get_pipelines_for_training(TrainingGoal.CPT)
+    assert len(cpt_pipes) == 1
+    assert cpt_pipes[0].dataset_type == DatasetType.TEXT
+
+    rrhf_datasets = get_dataset_types_for_training(TrainingGoal.RRHF)
+    assert DatasetType.PREF_LIST in rrhf_datasets
+
+    sft_datasets = get_dataset_types_for_training(TrainingGoal.SFT)
+    assert DatasetType.KG in sft_datasets
+    assert DatasetType.TOOL in sft_datasets
+    assert DatasetType.CONVERSATION in sft_datasets
+    assert DatasetType.MULTI_TOOL in sft_datasets
+
+
+def test_pipelines_include_kg_step():
+    for pipeline in get_pipelines_for_training(TrainingGoal.SFT):
+        if pipeline.dataset_type != DatasetType.TEXT:
+            assert pipeline.steps[1] == "to_kg"


### PR DESCRIPTION
## Summary
- define new dataset types for tool-calling, multi-turn conversations, and multi-tool use
- map the new pipelines to the knowledge-graph ingestion flow
- update documentation tables
- extend unit tests for new dataset types
- expose a basic search feature on the `KnowledgeGraph`
- provide search helpers for knowledge graph
- add DatasetBuilder to maintain per-dataset knowledge graphs
- add functions to search documents and list chunks

## Testing
- `pip install -e .`
- `pip install sqlalchemy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68598df2a628832fb0e4283e2b1ca730