### PR TITLE
Add async-only API and dataset management

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -20,6 +20,10 @@
 
 Datacreek is a toolkit for preparing high-quality synthetic datasets to fine-tune Large Language Models (LLMs). The primary interface is a REST API that exposes each step of the data preparation workflow.
 
+All routes are asynchronous. Launch ingestion, generation, curation or saving through `/tasks/ingest`, `/tasks/generate`, `/tasks/curate` and `/tasks/save` and monitor progress via `/tasks/{task_id}`.
+Datasets created by these jobs can be managed with `/datasets` (create, update, delete and download) and every request requires an `X-API-Key` header associated with a user.
+Background jobs are handled by Celery. Configure `CELERY_BROKER_URL` and `CELERY_RESULT_BACKEND` to use an external broker such as Redis.
+
 
 ### Design:
 
@@ -718,7 +722,10 @@ ds.add_chunk("doc1", "c1", "hello world")
 matches = ds.search("world")
 doc_matches = ds.search_documents("paper")
 chunk_ids = ds.get_chunks_for_document("doc1")
-``` 
+
+# Clone the dataset to try different curation strategies
+ds_copy = ds.clone(name="copy")
+```
 
 | Dataset type | Compatible trainings |
 |--------------|---------------------|

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Optional
+from copy import deepcopy
 
 from .knowledge_graph import KnowledgeGraph
 from ..pipelines import DatasetType
@@ -36,3 +37,7 @@ class DatasetBuilder:
 
     def get_chunks_for_document(self, doc_id: str) -> list[str]:
         return self.graph.get_chunks_for_document(doc_id)
+
+    def clone(self, name: Optional[str] = None) -> "DatasetBuilder":
+        """Return a deep copy of this dataset with a new optional name."""
+        return DatasetBuilder(self.dataset_type, name, deepcopy(self.graph))

--- a/datacreek/schemas.py
+++ b/datacreek/schemas.py
@@ -2,7 +2,6 @@ from pydantic import BaseModel
 
 class UserCreate(BaseModel):
     username: str
-    api_key: str
 
 class UserOut(BaseModel):
     id: int
@@ -40,3 +39,16 @@ class CurateParams(BaseModel):
 class SaveParams(BaseModel):
     ds_id: int
     fmt: str = "jsonl"
+
+
+class UserWithKey(UserOut):
+    api_key: str
+
+
+class DatasetCreate(BaseModel):
+    source_id: int
+    path: str
+
+
+class DatasetUpdate(BaseModel):
+    path: str | None = None

--- a/datacreek/server/templates/base.html
+++ b/datacreek/server/templates/base.html
@@ -89,6 +89,9 @@
                         <a class="nav-link" href="{{ url_for('files') }}">File Browser</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('datasets') }}">Datasets</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('upload') }}">Upload File</a>
                     </li>
                 </ul>

--- a/datacreek/server/templates/dataset_detail.html
+++ b/datacreek/server/templates/dataset_detail.html
@@ -1,0 +1,41 @@
+{% extends 'base.html' %}
+
+{% block title %}Dataset {{ dataset.name }}{% endblock %}
+
+{% block content %}
+<h2>{{ dataset.name }}</h2>
+<ul class="nav nav-tabs" id="myTab" role="tablist">
+  <li class="nav-item" role="presentation">
+    <button class="nav-link active" id="raw-tab" data-bs-toggle="tab" data-bs-target="#raw" type="button" role="tab">Donnée brute</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="kg-tab" data-bs-toggle="tab" data-bs-target="#kg" type="button" role="tab">Knowledge Graph</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="gen-tab" data-bs-toggle="tab" data-bs-target="#gen" type="button" role="tab">Génération</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="cur-tab" data-bs-toggle="tab" data-bs-target="#cur" type="button" role="tab">Curation</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="exp-tab" data-bs-toggle="tab" data-bs-target="#exp" type="button" role="tab">Exportation</button>
+  </li>
+</ul>
+<div class="tab-content mt-3">
+  <div class="tab-pane fade show active" id="raw" role="tabpanel">
+    <p class="text-muted">Manage raw data here.</p>
+  </div>
+  <div class="tab-pane fade" id="kg" role="tabpanel">
+    <p class="text-muted">Knowledge graph visualisation placeholder.</p>
+  </div>
+  <div class="tab-pane fade" id="gen" role="tabpanel">
+    <p class="text-muted">Generation parameters placeholder.</p>
+  </div>
+  <div class="tab-pane fade" id="cur" role="tabpanel">
+    <p class="text-muted">Curation operations placeholder.</p>
+  </div>
+  <div class="tab-pane fade" id="exp" role="tabpanel">
+    <p class="text-muted">Export options placeholder.</p>
+  </div>
+</div>
+{% endblock %}

--- a/datacreek/server/templates/datasets.html
+++ b/datacreek/server/templates/datasets.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+
+{% block title %}Datasets{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col-md-6">
+    <div class="card mb-4">
+      <div class="card-header"><h2>Create Dataset</h2></div>
+      <div class="card-body">
+        <form method="post">
+          {{ form.hidden_tag() }}
+          <div class="mb-3">{{ form.name.label }} {{ form.name(class='form-control') }}</div>
+          <div class="mb-3">{{ form.dataset_type.label }} {{ form.dataset_type(class='form-select') }}</div>
+          {{ form.submit(class='btn btn-primary') }}
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card mb-4">
+      <div class="card-header"><h2>Your Datasets</h2></div>
+      <div class="card-body">
+        {% if datasets %}
+        <ul class="list-group">
+          {% for name, ds in datasets.items() %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <a href="{{ url_for('dataset_detail', name=name) }}">{{ name }}</a>
+            <form method="post" action="{{ url_for('delete_dataset', name=name) }}" style="display:inline">
+              <button class="btn btn-sm btn-danger">Delete</button>
+            </form>
+            <form method="post" action="{{ url_for('copy_dataset', name=name) }}" style="display:inline" class="ms-2">
+              <button class="btn btn-sm btn-secondary">Copy</button>
+            </form>
+          </li>
+          {% endfor %}
+        </ul>
+        {% else %}
+        <p class="text-muted">No datasets yet.</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/datacreek/tasks.py
+++ b/datacreek/tasks.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from celery import Celery
+
+from datacreek.db import SessionLocal, Dataset, SourceData
+from datacreek.services import create_source, create_dataset
+from datacreek.core.ingest import process_file as ingest_file
+from datacreek.core.create import process_file as generate_data
+from datacreek.core.curate import curate_qa_pairs
+from datacreek.core.save_as import convert_format
+
+
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "memory://")
+CELERY_BACKEND_URL = os.environ.get("CELERY_RESULT_BACKEND", "cache+memory://")
+
+celery_app = Celery("datacreek", broker=CELERY_BROKER_URL, backend=CELERY_BACKEND_URL)
+celery_app.conf.accept_content = ["json"]
+celery_app.conf.task_serializer = "json"
+celery_app.conf.result_serializer = "json"
+celery_app.conf.task_always_eager = os.environ.get("CELERY_TASK_ALWAYS_EAGER", "false").lower() in {"1", "true"}
+celery_app.conf.task_store_eager_result = True
+
+
+@celery_app.task
+def ingest_task(user_id: int, path: str) -> dict:
+    with SessionLocal() as db:
+        content = ingest_file(path)
+        src = create_source(db, user_id, path, content)
+        return {"id": src.id}
+
+
+@celery_app.task
+def generate_task(user_id: int, src_id: int, content_type: str, num_pairs: int | None) -> dict:
+    with SessionLocal() as db:
+        src = db.get(SourceData, src_id)
+        if not src or src.owner_id != user_id:
+            raise RuntimeError("Source not found")
+        output_dir = Path("data/generated")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        out = generate_data(
+            None,
+            str(output_dir),
+            None,
+            None,
+            None,
+            content_type,
+            num_pairs,
+            False,
+            document_text=src.content,
+        )
+        ds = create_dataset(db, user_id, src_id, out)
+        return {"id": ds.id}
+
+
+@celery_app.task
+def curate_task(user_id: int, ds_id: int, threshold: float | None) -> dict:
+    with SessionLocal() as db:
+        ds = db.get(Dataset, ds_id)
+        if not ds or ds.owner_id != user_id:
+            raise RuntimeError("Dataset not found")
+        output_path = Path(ds.path).with_name(Path(ds.path).stem + "_curated.json")
+        curate_qa_pairs(ds.path, str(output_path), threshold, None, None, None, False)
+        ds.path = str(output_path)
+        db.commit()
+        db.refresh(ds)
+        return {"id": ds.id}
+
+
+@celery_app.task
+def save_task(user_id: int, ds_id: int, fmt: str) -> dict:
+    with SessionLocal() as db:
+        ds = db.get(Dataset, ds_id)
+        if not ds or ds.owner_id != user_id:
+            raise RuntimeError("Dataset not found")
+        out = convert_format(ds.path, None, fmt, {}, "json")
+        ds.path = out
+        db.commit()
+        db.refresh(ds)
+        return {"id": ds.id}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "fastapi>=0.111.0",
     "uvicorn>=0.27.0",
     "networkx>=3.0",
+    "celery>=5.3.6",
 ]
 
 # These fields appear in pip show

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -21,3 +21,15 @@ def test_dataset_search_wrappers():
     assert ds.search_documents("d") == ["d"]
     assert ds.get_chunks_for_document("d") == ["c"]
 
+
+def test_dataset_clone():
+    ds = DatasetBuilder(DatasetType.QA, name="orig")
+    ds.add_document("d", source="s")
+    ds.add_chunk("d", "c1", "text")
+    clone = ds.clone(name="copy")
+    clone.add_chunk("d", "c2", "more")
+
+    # original should not have the new chunk
+    assert ds.search("more") == []
+    assert clone.search("more") == ["c2"]
+


### PR DESCRIPTION
## Summary
- generate API keys for users and require `X-API-Key` header
- expose dataset CRUD and download endpoints
- remove synchronous API routes, use `/tasks/*` exclusively
- document new async workflow and dataset management
- update tests for API key auth and dataset routes
- switch background tasks to Celery
- document Celery configuration

## Testing
- `pip install -e .`
- `pip install sqlalchemy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859e514afc0832fb2ff80b56de0d788