### PR TITLE
Add chunking and retrieval utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ vllm:
 generation:
   temperature: 0.7
   chunk_size: 4000
+  chunk_method: sliding  # basic|sliding|semantic
+  retrieval_top_k: 3
   num_pairs: 25
 
 curate:
@@ -141,6 +143,15 @@ api-endpoint:
 ### Customizing Configuration
 
 Create a custom configuration file and pass it via the `X-Config-Path` header:
+
+The `generation` section now exposes advanced chunking and retrieval options:
+
+```
+generation:
+  chunk_method: semantic  # or "sliding" for fixed windows
+  similarity_drop: 0.25   # threshold when using semantic splitting
+  retrieval_top_k: 5      # number of chunks fetched using embeddings
+```
 
 ```bash
 curl -X POST localhost:8000/tasks/ingest \

--- a/datacreek/config.yaml
+++ b/datacreek/config.yaml
@@ -50,6 +50,9 @@ generation:
   top_p: 0.95        # Nucleus sampling parameter
   chunk_size: 4000   # Size of text chunks for processing
   overlap: 200       # Overlap between chunks to maintain context
+  chunk_method: sliding  # Options: basic|sliding|semantic
+  similarity_drop: 0.3   # Threshold for semantic splitting
+  retrieval_top_k: 3     # Number of chunks to retrieve for QA generation
   max_tokens: 4096   # Maximum tokens in LLM responses
   num_pairs: 25      # Default number of QA pairs to generate
   num_cot_examples: 5  # Default number of Chain of Thought examples to generate

--- a/datacreek/utils/chunking.py
+++ b/datacreek/utils/chunking.py
@@ -1,0 +1,57 @@
+"""Advanced text chunking utilities."""
+
+from typing import List
+from sklearn.feature_extraction.text import TfidfVectorizer
+import numpy as np
+
+
+def sliding_window_chunks(text: str, window_size: int, overlap: int) -> List[str]:
+    """Split ``text`` using a fixed-size sliding window with overlap."""
+    if window_size <= 0:
+        raise ValueError("window_size must be positive")
+    if overlap >= window_size:
+        raise ValueError("overlap must be smaller than window_size")
+
+    chunks = []
+    start = 0
+    length = len(text)
+    while start < length:
+        end = min(start + window_size, length)
+        chunks.append(text[start:end])
+        if end == length:
+            break
+        start = end - overlap
+    return chunks
+
+
+def semantic_chunk_split(
+    text: str, max_tokens: int, similarity_drop: float = 0.3
+) -> List[str]:
+    """Split text into semantically coherent chunks.
+
+    This uses a naive TF‑IDF embedding of sentences and creates a new chunk
+    whenever the cosine similarity between adjacent sentences drops below
+    ``similarity_drop`` or the chunk would exceed ``max_tokens`` characters.
+    """
+    sentences = [s.strip() for s in text.split(".") if s.strip()]
+    if not sentences:
+        return []
+
+    vectorizer = TfidfVectorizer().fit(sentences)
+    embeddings = vectorizer.transform(sentences).toarray()
+
+    chunks = []
+    current = sentences[0]
+    current_len = len(current)
+    for i in range(1, len(sentences)):
+        sim = np.dot(embeddings[i - 1], embeddings[i])
+        if current_len + len(sentences[i]) > max_tokens or sim < similarity_drop:
+            chunks.append(current.strip())
+            current = sentences[i]
+            current_len = len(current)
+        else:
+            current += ". " + sentences[i]
+            current_len += len(sentences[i]) + 2
+    if current:
+        chunks.append(current.strip())
+    return chunks

--- a/datacreek/utils/retrieval.py
+++ b/datacreek/utils/retrieval.py
@@ -1,0 +1,46 @@
+"""Embedding-based retrieval utilities using TF-IDF."""
+
+from __future__ import annotations
+
+from typing import List, Dict, Optional
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.neighbors import NearestNeighbors
+import numpy as np
+
+
+class EmbeddingIndex:
+    """Maintain a simple in-memory retrieval index."""
+
+    def __init__(self) -> None:
+        self.texts: List[str] = []
+        self.ids: List[str] = []
+        self._vectorizer: Optional[TfidfVectorizer] = None
+        self._matrix: Optional[np.ndarray] = None
+        self._nn: Optional[NearestNeighbors] = None
+
+    def add(self, chunk_id: str, text: str) -> None:
+        self.ids.append(chunk_id)
+        self.texts.append(text)
+
+    def build(self) -> None:
+        if not self.texts:
+            return
+        self._vectorizer = TfidfVectorizer().fit(self.texts)
+        self._matrix = self._vectorizer.transform(self.texts)
+        self._nn = NearestNeighbors(metric="cosine")
+        self._nn.fit(self._matrix)
+
+    def search(self, query: str, k: int = 5) -> List[int]:
+        if not self.texts:
+            return []
+        if self._vectorizer is None:
+            self.build()
+        query_vec = self._vectorizer.transform([query])
+        distances, indices = self._nn.kneighbors(query_vec, n_neighbors=min(k, len(self.ids)))
+        return indices[0].tolist()
+
+    def get_text(self, idx: int) -> str:
+        return self.texts[idx]
+
+    def get_id(self, idx: int) -> str:
+        return self.ids[idx]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "uvicorn>=0.27.0",
     "networkx>=3.0",
     "celery>=5.3.6",
+    "SQLAlchemy>=2.0",
+    "scikit-learn>=1.7.0",
 ]
 
 # These fields appear in pip show

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,14 @@
+from datacreek.utils.chunking import sliding_window_chunks, semantic_chunk_split
+
+
+def test_sliding_window_chunks():
+    text = "abcdefghij" * 10
+    chunks = sliding_window_chunks(text, window_size=10, overlap=2)
+    assert chunks[0] == text[:10]
+    assert chunks[1].startswith(text[8:18])
+
+
+def test_semantic_chunk_split():
+    text = "Sentence one. Sentence two related. Different topic."
+    chunks = semantic_chunk_split(text, max_tokens=50, similarity_drop=0.5)
+    assert len(chunks) >= 2

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -37,3 +37,13 @@ def test_document_helpers():
 
     assert set(kg.search_documents("doc")) == {"doc1"}
     assert kg.get_chunks_for_document("doc1") == ["c1", "c2"]
+
+
+def test_embedding_search():
+    kg = KnowledgeGraph()
+    kg.add_document("d", source="s")
+    kg.add_chunk("d", "c1", "hello world")
+    kg.add_chunk("d", "c2", "another world")
+    kg.index.build()
+    results = kg.search_embeddings("hello", k=1)
+    assert results[0] == "c1"


### PR DESCRIPTION
## Summary
- implement advanced chunking utils (`sliding_window_chunks`, `semantic_chunk_split`)
- add TF-IDF embedding retrieval with neighbor-aware search
- integrate retrieval into `KnowledgeGraph` and `QAGenerator`
- extend configuration and docs for new options
- add missing dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859f5ccf610832fbb91edd10acc7cff