### PR TITLE
Enhance ingest and KG handling

### DIFF
--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,4 +1,5 @@
 from datacreek import DatasetBuilder, DatasetType, ingest_file, to_kg
+import pytest
 
 def test_ingest_to_kg(tmp_path):
     text_file = tmp_path / "sample.txt"
@@ -10,4 +11,26 @@ def test_ingest_to_kg(tmp_path):
 
     assert ds.search_chunks("Hello")
     assert ds.get_chunks_for_document("doc1")
+
+
+def test_to_kg_no_index_build(tmp_path):
+    text_file = tmp_path / "sample.txt"
+    text_file.write_text("Hello world")
+
+    ds = DatasetBuilder(DatasetType.TEXT)
+    text = ingest_file(str(text_file))
+    to_kg(text, ds, "doc1", build_index=False)
+
+    assert ds.graph.index._vectorizer is None
+    # calling search should auto-build the index
+    assert ds.search_chunks("Hello") == ["doc1_chunk_0"]
+
+
+def test_determine_parser_errors(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        ingest_file(str(tmp_path / "missing.txt"))
+    bad_file = tmp_path / "file.badext"
+    bad_file.write_text("x")
+    with pytest.raises(ValueError):
+        ingest_file(str(bad_file))
 

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,4 +1,5 @@
 from datacreek.core.knowledge_graph import KnowledgeGraph
+import pytest
 
 
 def test_add_document_and_chunk():
@@ -47,3 +48,13 @@ def test_embedding_search():
     kg.index.build()
     results = kg.search_embeddings("hello", k=1)
     assert results[0] == "c1"
+
+
+def test_duplicate_checks():
+    kg = KnowledgeGraph()
+    kg.add_document("d", source="s")
+    with pytest.raises(ValueError):
+        kg.add_document("d", source="s")
+    kg.add_chunk("d", "c1", "text")
+    with pytest.raises(ValueError):
+        kg.add_chunk("d", "c1", "text")


### PR DESCRIPTION
## Summary
- add logging in ingestion helpers
- allow deferring index building
- check for duplicate nodes in knowledge graph
- make Neo4j export optional clearing
- extend ingestion and graph tests
- document `build_index` parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a1e1594e8832f9aa66b7111122161