### PR TITLE
Add dataset ingestion to web UI

### DIFF
--- a/datacreek/server/templates/dataset_detail.html
+++ b/datacreek/server/templates/dataset_detail.html
@@ -2,6 +2,11 @@
 
 {% block title %}Dataset {{ dataset.name }}{% endblock %}
 
+{% block extra_head %}
+<script src="https://unpkg.com/3d-force-graph@1.77.0/dist/3d-force-graph.min.js"></script>
+<style>#graph{height:600px}</style>
+{% endblock %}
+
 {% block content %}
 <h2>{{ dataset.name }}</h2>
 <ul class="nav nav-tabs" id="myTab" role="tablist">
@@ -23,10 +28,41 @@
 </ul>
 <div class="tab-content mt-3">
   <div class="tab-pane fade show active" id="raw" role="tabpanel">
-    <p class="text-muted">Manage raw data here.</p>
+    <form class="mb-3" method="post" action="{{ url_for('dataset_ingest', name=dataset.name) }}">
+      <div class="mb-3">
+        <label for="inputPath" class="form-label">Path or URL</label>
+        <input type="text" class="form-control" id="inputPath" name="input_path" placeholder="/path/to/file or URL" required>
+      </div>
+      <div class="mb-3">
+        <label for="docId" class="form-label">Document ID (optional)</label>
+        <input type="text" class="form-control" id="docId" name="doc_id">
+      </div>
+      <button type="submit" class="btn btn-primary">Ingest</button>
+    </form>
+
+    {% if dataset.graph.graph.nodes %}
+    <h5>Documents</h5>
+    <ul>
+    {% for node, data in dataset.graph.graph.nodes(data=True) if data.type == 'document' %}
+      <li>{{ node }} ({{ dataset.graph.get_chunks_for_document(node)|length }} chunks)</li>
+    {% endfor %}
+    </ul>
+    {% else %}
+    <p class="text-muted">No documents yet.</p>
+    {% endif %}
   </div>
   <div class="tab-pane fade" id="kg" role="tabpanel">
-    <p class="text-muted">Knowledge graph visualisation placeholder.</p>
+    <div class="mb-2">
+      <div class="form-check form-check-inline">
+        <input class="form-check-input" type="checkbox" id="toggleDocs" checked>
+        <label class="form-check-label" for="toggleDocs">Documents</label>
+      </div>
+      <div class="form-check form-check-inline">
+        <input class="form-check-input" type="checkbox" id="toggleChunks" checked>
+        <label class="form-check-label" for="toggleChunks">Chunks</label>
+      </div>
+    </div>
+    <div id="graph" style="height: 600px;"></div>
   </div>
   <div class="tab-pane fade" id="gen" role="tabpanel">
     <p class="text-muted">Generation parameters placeholder.</p>
@@ -38,4 +74,45 @@
     <p class="text-muted">Export options placeholder.</p>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+const container = document.getElementById('graph');
+fetch("{{ url_for('dataset_graph', name=dataset.name) }}")
+  .then(res => res.json())
+  .then(data => {
+    const DOC_COLOR = '#1f77b4';
+    const CHUNK_COLOR = '#ff7f0e';
+    const Graph = ForceGraph3D()(container)
+      .graphData(data)
+      .nodeLabel(n => `${n.id} (${n.type})`)
+      .linkColor(() => '#999');
+
+    function applyFilters() {
+      const showDocs = document.getElementById('toggleDocs').checked;
+      const showChunks = document.getElementById('toggleChunks').checked;
+      Graph
+        .nodeColor(node => {
+          if (node.type === 'document' && !showDocs) return '#ccc';
+          if (node.type === 'chunk' && !showChunks) return '#ccc';
+          return node.type === 'document' ? DOC_COLOR : CHUNK_COLOR;
+        })
+        .linkColor(link => {
+          const sType = typeof link.source === 'object' ? link.source.type : data.nodes.find(n => n.id === link.source).type;
+          const tType = typeof link.target === 'object' ? link.target.type : data.nodes.find(n => n.id === link.target).type;
+          if ((sType === 'document' && !showDocs) || (sType === 'chunk' && !showChunks) ||
+              (tType === 'document' && !showDocs) || (tType === 'chunk' && !showChunks)) {
+            return '#ccc';
+          }
+          return '#999';
+        });
+    }
+
+    applyFilters();
+    document.getElementById('toggleDocs').addEventListener('change', applyFilters);
+    document.getElementById('toggleChunks').addEventListener('change', applyFilters);
+  });
+</script>
 {% endblock %}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,36 @@
+from datacreek.server.app import app, DATASETS
+from datacreek.core.dataset import DatasetBuilder
+from datacreek.pipelines import DatasetType
+
+
+def test_dataset_graph_route():
+    ds = DatasetBuilder(DatasetType.QA, name="demo")
+    ds.add_document("d1", source="s")
+    ds.add_chunk("d1", "c1", "text")
+    DATASETS["demo"] = ds
+
+    with app.test_client() as client:
+        res = client.get("/datasets/demo/graph")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert len(data["nodes"]) == 2
+        assert len(data["edges"]) == 1
+    DATASETS.clear()
+
+
+def test_dataset_ingest_route(tmp_path):
+    ds = DatasetBuilder(DatasetType.TEXT, name="demo")
+    DATASETS["demo"] = ds
+
+    f = tmp_path / "doc.txt"
+    f.write_text("hello world")
+
+    with app.test_client() as client:
+        res = client.post(
+            "/datasets/demo/ingest",
+            data={"input_path": str(f), "doc_id": "doc1"},
+            follow_redirects=True,
+        )
+        assert res.status_code == 200
+        assert ds.search_chunks("hello") == ["doc1_chunk_0"]
+    DATASETS.clear()


### PR DESCRIPTION
## Summary
- add `/datasets/<name>/ingest` route to ingest files into a dataset
- allow uploading a path/URL on the dataset detail page and list ingested documents
- test ingestion route

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a363bf2e8832f9362524300faafbe