### PR TITLE
Improve KG endpoints with tests

### DIFF
--- a/datacreek/server/templates/dataset_detail.html
+++ b/datacreek/server/templates/dataset_detail.html
@@ -53,6 +53,10 @@
   </div>
   <div class="tab-pane fade" id="kg" role="tabpanel">
     <div class="mb-2">
+      <div class="input-group mb-2">
+        <input type="text" class="form-control" id="searchInput" placeholder="Search">
+        <button class="btn btn-outline-secondary" id="searchBtn">Search</button>
+      </div>
       <div class="form-check form-check-inline">
         <input class="form-check-input" type="checkbox" id="toggleDocs" checked>
         <label class="form-check-label" for="toggleDocs">Documents</label>
@@ -61,8 +65,26 @@
         <input class="form-check-input" type="checkbox" id="toggleChunks" checked>
         <label class="form-check-label" for="toggleChunks">Chunks</label>
       </div>
+      <div id="sourceFilters" class="d-inline-block ms-2"></div>
     </div>
-    <div id="graph" style="height: 600px;"></div>
+    <div class="row">
+      <div class="col-md-8">
+        <div id="graph" style="height: 600px;"></div>
+        <div class="mt-2">
+          <form class="d-inline" method="post" action="{{ url_for('save_dataset_neo4j', name=dataset.name) }}">
+            <button type="submit" class="btn btn-sm btn-secondary">Save to Neo4j</button>
+          </form>
+          <form class="d-inline" method="post" action="{{ url_for('load_dataset_neo4j', name=dataset.name) }}">
+            <button type="submit" class="btn btn-sm btn-secondary">Load from Neo4j</button>
+          </form>
+          <button id="resetView" class="btn btn-sm btn-secondary">Reset View</button>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <h6>Node Details</h6>
+        <pre id="nodeDetails" class="border p-2 small"></pre>
+      </div>
+    </div>
   </div>
   <div class="tab-pane fade" id="gen" role="tabpanel">
     <p class="text-muted">Generation parameters placeholder.</p>
@@ -80,39 +102,81 @@
 {{ super() }}
 <script>
 const container = document.getElementById('graph');
+let Graph; let graphData;
 fetch("{{ url_for('dataset_graph', name=dataset.name) }}")
   .then(res => res.json())
   .then(data => {
+    graphData = data;
     const DOC_COLOR = '#1f77b4';
     const CHUNK_COLOR = '#ff7f0e';
-    const Graph = ForceGraph3D()(container)
+    const REL_COLORS = { has_chunk: '#999' };
+    Graph = ForceGraph3D()(container)
       .graphData(data)
       .nodeLabel(n => `${n.id} (${n.type})`)
-      .linkColor(() => '#999');
+      .onNodeClick(node => {
+        document.getElementById('nodeDetails').textContent = JSON.stringify(node, null, 2);
+        const distance = 60;
+        const distRatio = 1 + distance / Math.hypot(node.x, node.y, node.z);
+        Graph.cameraPosition({x: node.x * distRatio, y: node.y * distRatio, z: node.z * distRatio}, node, 1000);
+      })
+      .linkColor(l => REL_COLORS[l.relation] || '#666');
+
+    const sources = [...new Set(data.nodes.map(n => n.source).filter(Boolean))];
+    const srcContainer = document.getElementById('sourceFilters');
+    sources.forEach(src => {
+      const id = 'src_' + src.replace(/[^a-zA-Z0-9]/g, '_');
+      srcContainer.insertAdjacentHTML('beforeend',
+        `<div class="form-check form-check-inline"><input class="form-check-input source-toggle" type="checkbox" id="${id}" data-src="${src}" checked><label class="form-check-label" for="${id}">${src}</label></div>`
+      );
+    });
+    srcContainer.addEventListener('change', applyFilters);
 
     function applyFilters() {
       const showDocs = document.getElementById('toggleDocs').checked;
       const showChunks = document.getElementById('toggleChunks').checked;
+      const allowedSources = Array.from(document.querySelectorAll('.source-toggle:checked')).map(el => el.dataset.src);
       Graph
         .nodeColor(node => {
+          if (!allowedSources.includes(node.source)) return '#ccc';
           if (node.type === 'document' && !showDocs) return '#ccc';
           if (node.type === 'chunk' && !showChunks) return '#ccc';
           return node.type === 'document' ? DOC_COLOR : CHUNK_COLOR;
         })
         .linkColor(link => {
-          const sType = typeof link.source === 'object' ? link.source.type : data.nodes.find(n => n.id === link.source).type;
-          const tType = typeof link.target === 'object' ? link.target.type : data.nodes.find(n => n.id === link.target).type;
+          const s = typeof link.source === 'object' ? link.source : graphData.nodes.find(n => n.id === link.source);
+          const t = typeof link.target === 'object' ? link.target : graphData.nodes.find(n => n.id === link.target);
+          if (!allowedSources.includes(s.source) || !allowedSources.includes(t.source)) return '#ccc';
+          const sType = s.type; const tType = t.type;
           if ((sType === 'document' && !showDocs) || (sType === 'chunk' && !showChunks) ||
               (tType === 'document' && !showDocs) || (tType === 'chunk' && !showChunks)) {
             return '#ccc';
           }
-          return '#999';
+          return REL_COLORS[link.relation] || '#666';
         });
     }
 
     applyFilters();
     document.getElementById('toggleDocs').addEventListener('change', applyFilters);
     document.getElementById('toggleChunks').addEventListener('change', applyFilters);
+    document.getElementById('resetView').addEventListener('click', () => { Graph.zoomToFit(400); document.getElementById('nodeDetails').textContent = ''; });
+    document.getElementById('searchBtn').addEventListener('click', () => {
+      const q = document.getElementById('searchInput').value.trim();
+      if (!q) return;
+      fetch(`{{ url_for('dataset_search', name=dataset.name) }}?q=` + encodeURIComponent(q))
+        .then(res => res.json())
+        .then(ids => {
+          const showDocs = document.getElementById('toggleDocs').checked;
+          const showChunks = document.getElementById('toggleChunks').checked;
+          const allowedSources = Array.from(document.querySelectorAll('.source-toggle:checked')).map(el => el.dataset.src);
+          Graph.nodeColor(node => {
+            if (ids.includes(node.id)) return '#e41a1c';
+            if (!allowedSources.includes(node.source)) return '#ccc';
+            if (node.type === 'document' && !showDocs) return '#ccc';
+            if (node.type === 'chunk' && !showChunks) return '#ccc';
+            return node.type === 'document' ? DOC_COLOR : CHUNK_COLOR;
+          });
+        });
+    });
   });
 </script>
 {% endblock %}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,9 @@
 from datacreek.server.app import app, DATASETS
 from datacreek.core.dataset import DatasetBuilder
 from datacreek.pipelines import DatasetType
+from datacreek.core.knowledge_graph import KnowledgeGraph
 
+import datacreek.server.app as app_module
 
 def test_dataset_graph_route():
     ds = DatasetBuilder(DatasetType.QA, name="demo")
@@ -15,6 +17,20 @@ def test_dataset_graph_route():
         data = res.get_json()
         assert len(data["nodes"]) == 2
         assert len(data["edges"]) == 1
+    DATASETS.clear()
+
+
+def test_dataset_search_route():
+    ds = DatasetBuilder(DatasetType.QA, name="demo")
+    ds.add_document("d1", source="s")
+    ds.add_chunk("d1", "c1", "hello world")
+    DATASETS["demo"] = ds
+
+    with app.test_client() as client:
+        res = client.get("/datasets/demo/search", query_string={"q": "hello"})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data == ["c1"]
     DATASETS.clear()
 
 
@@ -33,4 +49,47 @@ def test_dataset_ingest_route(tmp_path):
         )
         assert res.status_code == 200
         assert ds.search_chunks("hello") == ["doc1_chunk_0"]
+    DATASETS.clear()
+
+
+def test_save_dataset_neo4j(monkeypatch):
+    ds = DatasetBuilder(DatasetType.QA, name="demo")
+    ds.add_document("d1", source="s")
+    DATASETS["demo"] = ds
+
+    called = {}
+    def fake_to_neo4j(self, driver, clear=True):
+        called['called'] = True
+    monkeypatch.setattr(KnowledgeGraph, "to_neo4j", fake_to_neo4j)
+
+    class DummyDriver:
+        def close(self):
+            pass
+    monkeypatch.setattr(app_module, "get_neo4j_driver", lambda: DummyDriver())
+
+    with app.test_client() as client:
+        res = client.post("/datasets/demo/save_neo4j")
+        assert res.status_code == 302
+    assert called.get('called')
+    DATASETS.clear()
+
+
+def test_load_dataset_neo4j(monkeypatch):
+    ds = DatasetBuilder(DatasetType.QA, name="demo")
+    ds.add_document("d1", source="s")
+    DATASETS["demo"] = ds
+
+    new_graph = KnowledgeGraph()
+    new_graph.add_document("n", source="a")
+    monkeypatch.setattr(KnowledgeGraph, "from_neo4j", staticmethod(lambda driver: new_graph))
+
+    class DummyDriver:
+        def close(self):
+            pass
+    monkeypatch.setattr(app_module, "get_neo4j_driver", lambda: DummyDriver())
+
+    with app.test_client() as client:
+        res = client.post("/datasets/demo/load_neo4j")
+        assert res.status_code == 302
+    assert ds.graph is new_graph
     DATASETS.clear()


### PR DESCRIPTION
## Summary
- extend dataset detail page with search, filtering, and Neo4j controls
- add API routes for KG search and Neo4j persistence
- test search route and Neo4j endpoints

## Testing
- `pip install fastapi fakeredis networkx neo4j flask flask-wtf wtforms pydantic celery redis sqlalchemy`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a44869994832fadb4fb72e13af878