### PR TITLE
Improve KG endpoints with tests

### DIFF
--- a/datacreek/server/app.py
+++ b/datacreek/server/app.py
@@ -4,15 +4,18 @@ Flask application for the Datacreek web interface.
 import os
 import json
 from pathlib import Path
-from typing import Dict, List, Any, Optional, Union
+from typing import Dict
 
-import flask
 from flask import Flask, render_template, request, redirect, url_for, jsonify, abort, flash
 from flask_wtf import FlaskForm
-from wtforms import StringField, TextAreaField, IntegerField, SelectField, FileField, SubmitField
-from wtforms.validators import DataRequired, Optional as OptionalValidator
+from wtforms import StringField, IntegerField, SelectField, FileField, SubmitField
+from wtforms.validators import DataRequired
 
-from datacreek.utils.config import load_config, get_llm_provider, get_path_config
+from datacreek.utils.config import (
+    load_config,
+    get_llm_provider,
+    get_neo4j_config,
+)
 from datacreek.core.create import process_file
 from datacreek.core.curate import curate_qa_pairs
 from datacreek.core.ingest import (
@@ -20,6 +23,8 @@ from datacreek.core.ingest import (
     ingest_into_dataset,
 )
 from datacreek.core.dataset import DatasetBuilder
+from datacreek.core.knowledge_graph import KnowledgeGraph
+from neo4j import GraphDatabase
 from datacreek.pipelines import DatasetType
 
 app = Flask(__name__)
@@ -36,6 +41,17 @@ DEFAULT_GENERATED_DIR.mkdir(parents=True, exist_ok=True)
 
 # Load SDK config
 config = load_config()
+
+
+def get_neo4j_driver():
+    """Return a Neo4j driver using config or environment variables."""
+    cfg = get_neo4j_config(config)
+    uri = os.getenv("NEO4J_URI", cfg.get("uri"))
+    user = os.getenv("NEO4J_USER", cfg.get("user"))
+    password = os.getenv("NEO4J_PASSWORD", cfg.get("password"))
+    if not uri or not user or not password:
+        return None
+    return GraphDatabase.driver(uri, auth=(user, password))
 
 # In-memory store of datasets being built
 DATASETS: Dict[str, DatasetBuilder] = {}
@@ -129,6 +145,20 @@ def dataset_graph(name: str):
     return jsonify(ds.graph.to_dict())
 
 
+@app.get('/datasets/<name>/search')
+def dataset_search(name: str):
+    """Return node ids matching the query."""
+    ds = DATASETS.get(name)
+    if not ds:
+        abort(404)
+    query = request.args.get('q')
+    node_type = request.args.get('type', 'chunk')
+    if not query:
+        return jsonify([])
+    ids = ds.graph.search(query, node_type=node_type)
+    return jsonify(ids)
+
+
 @app.post('/datasets/<name>/ingest')
 def dataset_ingest(name: str):
     """Ingest a file or URL into the dataset knowledge graph."""
@@ -148,6 +178,36 @@ def dataset_ingest(name: str):
     except Exception as e:  # pragma: no cover - flash message only
         flash(f'Error ingesting document: {e}', 'danger')
 
+    return redirect(url_for('dataset_detail', name=name))
+
+
+@app.post('/datasets/<name>/save_neo4j')
+def save_dataset_neo4j(name: str):
+    """Persist the dataset graph to Neo4j."""
+    ds = DATASETS.get(name)
+    if not ds:
+        abort(404)
+    driver = get_neo4j_driver()
+    if not driver:
+        abort(500, description='Neo4j not configured')
+    ds.graph.to_neo4j(driver)
+    driver.close()
+    flash('Graph saved to Neo4j', 'success')
+    return redirect(url_for('dataset_detail', name=name))
+
+
+@app.post('/datasets/<name>/load_neo4j')
+def load_dataset_neo4j(name: str):
+    """Load the dataset graph from Neo4j."""
+    ds = DATASETS.get(name)
+    if not ds:
+        abort(404)
+    driver = get_neo4j_driver()
+    if not driver:
+        abort(500, description='Neo4j not configured')
+    ds.graph = KnowledgeGraph.from_neo4j(driver)
+    driver.close()
+    flash('Graph loaded from Neo4j', 'success')
     return redirect(url_for('dataset_detail', name=name))
 
 
@@ -228,7 +288,6 @@ def curate():
     if form.validate_on_submit():
         try:
             input_file = form.input_file.data
-            num_pairs = form.num_pairs.data
             model = form.model.data or None
             api_base = form.api_base.data or None
             
@@ -299,7 +358,7 @@ def view_file(file_path):
             has_conversations = 'conversations' in file_content
             has_summary = 'summary' in file_content
             
-        except Exception as e:
+        except Exception:
             # If JSON parsing fails, treat as text
             with open(full_path, 'r') as f:
                 file_content = f.read()
@@ -380,7 +439,7 @@ def ingest():
             if input_type == 'file' and temp_path.exists():
                 try:
                     temp_path.unlink()
-                except:
+                except Exception:
                     pass
             
             flash(f'Successfully parsed document! Output saved to: {output_path}', 'success')
@@ -428,7 +487,7 @@ def qa_json(file_path):
         with open(full_path, 'r') as f:
             data = json.load(f)
         return jsonify(data)
-    except:
+    except Exception:
         abort(500)
         
 @app.route('/api/edit_item/<path:file_path>', methods=['POST'])

--- a/datacreek/server/templates/dataset_detail.html
+++ b/datacreek/server/templates/dataset_detail.html
@@ -53,6 +53,10 @@
   </div>
   <div class="tab-pane fade" id="kg" role="tabpanel">
     <div class="mb-2">
+      <div class="input-group mb-2">
+        <input type="text" class="form-control" id="searchInput" placeholder="Search">
+        <button class="btn btn-outline-secondary" id="searchBtn">Search</button>
+      </div>
       <div class="form-check form-check-inline">
         <input class="form-check-input" type="checkbox" id="toggleDocs" checked>
         <label class="form-check-label" for="toggleDocs">Documents</label>
@@ -61,8 +65,26 @@
         <input class="form-check-input" type="checkbox" id="toggleChunks" checked>
         <label class="form-check-label" for="toggleChunks">Chunks</label>
       </div>
+      <div id="sourceFilters" class="d-inline-block ms-2"></div>
     </div>
-    <div id="graph" style="height: 600px;"></div>
+    <div class="row">
+      <div class="col-md-8">
+        <div id="graph" style="height: 600px;"></div>
+        <div class="mt-2">
+          <form class="d-inline" method="post" action="{{ url_for('save_dataset_neo4j', name=dataset.name) }}">
+            <button type="submit" class="btn btn-sm btn-secondary">Save to Neo4j</button>
+          </form>
+          <form class="d-inline" method="post" action="{{ url_for('load_dataset_neo4j', name=dataset.name) }}">
+            <button type="submit" class="btn btn-sm btn-secondary">Load from Neo4j</button>
+          </form>
+          <button id="resetView" class="btn btn-sm btn-secondary">Reset View</button>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <h6>Node Details</h6>
+        <pre id="nodeDetails" class="border p-2 small"></pre>
+      </div>
+    </div>
   </div>
   <div class="tab-pane fade" id="gen" role="tabpanel">
     <p class="text-muted">Generation parameters placeholder.</p>
@@ -80,39 +102,81 @@
 {{ super() }}
 <script>
 const container = document.getElementById('graph');
+let Graph; let graphData;
 fetch("{{ url_for('dataset_graph', name=dataset.name) }}")
   .then(res => res.json())
   .then(data => {
+    graphData = data;
     const DOC_COLOR = '#1f77b4';
     const CHUNK_COLOR = '#ff7f0e';
-    const Graph = ForceGraph3D()(container)
+    const REL_COLORS = { has_chunk: '#999' };
+    Graph = ForceGraph3D()(container)
       .graphData(data)
       .nodeLabel(n => `${n.id} (${n.type})`)
-      .linkColor(() => '#999');
+      .onNodeClick(node => {
+        document.getElementById('nodeDetails').textContent = JSON.stringify(node, null, 2);
+        const distance = 60;
+        const distRatio = 1 + distance / Math.hypot(node.x, node.y, node.z);
+        Graph.cameraPosition({x: node.x * distRatio, y: node.y * distRatio, z: node.z * distRatio}, node, 1000);
+      })
+      .linkColor(l => REL_COLORS[l.relation] || '#666');
+
+    const sources = [...new Set(data.nodes.map(n => n.source).filter(Boolean))];
+    const srcContainer = document.getElementById('sourceFilters');
+    sources.forEach(src => {
+      const id = 'src_' + src.replace(/[^a-zA-Z0-9]/g, '_');
+      srcContainer.insertAdjacentHTML('beforeend',
+        `<div class="form-check form-check-inline"><input class="form-check-input source-toggle" type="checkbox" id="${id}" data-src="${src}" checked><label class="form-check-label" for="${id}">${src}</label></div>`
+      );
+    });
+    srcContainer.addEventListener('change', applyFilters);
 
     function applyFilters() {
       const showDocs = document.getElementById('toggleDocs').checked;
       const showChunks = document.getElementById('toggleChunks').checked;
+      const allowedSources = Array.from(document.querySelectorAll('.source-toggle:checked')).map(el => el.dataset.src);
       Graph
         .nodeColor(node => {
+          if (!allowedSources.includes(node.source)) return '#ccc';
           if (node.type === 'document' && !showDocs) return '#ccc';
           if (node.type === 'chunk' && !showChunks) return '#ccc';
           return node.type === 'document' ? DOC_COLOR : CHUNK_COLOR;
         })
         .linkColor(link => {
-          const sType = typeof link.source === 'object' ? link.source.type : data.nodes.find(n => n.id === link.source).type;
-          const tType = typeof link.target === 'object' ? link.target.type : data.nodes.find(n => n.id === link.target).type;
+          const s = typeof link.source === 'object' ? link.source : graphData.nodes.find(n => n.id === link.source);
+          const t = typeof link.target === 'object' ? link.target : graphData.nodes.find(n => n.id === link.target);
+          if (!allowedSources.includes(s.source) || !allowedSources.includes(t.source)) return '#ccc';
+          const sType = s.type; const tType = t.type;
           if ((sType === 'document' && !showDocs) || (sType === 'chunk' && !showChunks) ||
               (tType === 'document' && !showDocs) || (tType === 'chunk' && !showChunks)) {
             return '#ccc';
           }
-          return '#999';
+          return REL_COLORS[link.relation] || '#666';
         });
     }
 
     applyFilters();
     document.getElementById('toggleDocs').addEventListener('change', applyFilters);
     document.getElementById('toggleChunks').addEventListener('change', applyFilters);
+    document.getElementById('resetView').addEventListener('click', () => { Graph.zoomToFit(400); document.getElementById('nodeDetails').textContent = ''; });
+    document.getElementById('searchBtn').addEventListener('click', () => {
+      const q = document.getElementById('searchInput').value.trim();
+      if (!q) return;
+      fetch(`{{ url_for('dataset_search', name=dataset.name) }}?q=` + encodeURIComponent(q))
+        .then(res => res.json())
+        .then(ids => {
+          const showDocs = document.getElementById('toggleDocs').checked;
+          const showChunks = document.getElementById('toggleChunks').checked;
+          const allowedSources = Array.from(document.querySelectorAll('.source-toggle:checked')).map(el => el.dataset.src);
+          Graph.nodeColor(node => {
+            if (ids.includes(node.id)) return '#e41a1c';
+            if (!allowedSources.includes(node.source)) return '#ccc';
+            if (node.type === 'document' && !showDocs) return '#ccc';
+            if (node.type === 'chunk' && !showChunks) return '#ccc';
+            return node.type === 'document' ? DOC_COLOR : CHUNK_COLOR;
+          });
+        });
+    });
   });
 </script>
 {% endblock %}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,9 @@
 from datacreek.server.app import app, DATASETS
 from datacreek.core.dataset import DatasetBuilder
 from datacreek.pipelines import DatasetType
+from datacreek.core.knowledge_graph import KnowledgeGraph
 
+import datacreek.server.app as app_module
 
 def test_dataset_graph_route():
     ds = DatasetBuilder(DatasetType.QA, name="demo")
@@ -15,6 +17,20 @@ def test_dataset_graph_route():
         data = res.get_json()
         assert len(data["nodes"]) == 2
         assert len(data["edges"]) == 1
+    DATASETS.clear()
+
+
+def test_dataset_search_route():
+    ds = DatasetBuilder(DatasetType.QA, name="demo")
+    ds.add_document("d1", source="s")
+    ds.add_chunk("d1", "c1", "hello world")
+    DATASETS["demo"] = ds
+
+    with app.test_client() as client:
+        res = client.get("/datasets/demo/search", query_string={"q": "hello"})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data == ["c1"]
     DATASETS.clear()
 
 
@@ -33,4 +49,47 @@ def test_dataset_ingest_route(tmp_path):
         )
         assert res.status_code == 200
         assert ds.search_chunks("hello") == ["doc1_chunk_0"]
+    DATASETS.clear()
+
+
+def test_save_dataset_neo4j(monkeypatch):
+    ds = DatasetBuilder(DatasetType.QA, name="demo")
+    ds.add_document("d1", source="s")
+    DATASETS["demo"] = ds
+
+    called = {}
+    def fake_to_neo4j(self, driver, clear=True):
+        called['called'] = True
+    monkeypatch.setattr(KnowledgeGraph, "to_neo4j", fake_to_neo4j)
+
+    class DummyDriver:
+        def close(self):
+            pass
+    monkeypatch.setattr(app_module, "get_neo4j_driver", lambda: DummyDriver())
+
+    with app.test_client() as client:
+        res = client.post("/datasets/demo/save_neo4j")
+        assert res.status_code == 302
+    assert called.get('called')
+    DATASETS.clear()
+
+
+def test_load_dataset_neo4j(monkeypatch):
+    ds = DatasetBuilder(DatasetType.QA, name="demo")
+    ds.add_document("d1", source="s")
+    DATASETS["demo"] = ds
+
+    new_graph = KnowledgeGraph()
+    new_graph.add_document("n", source="a")
+    monkeypatch.setattr(KnowledgeGraph, "from_neo4j", staticmethod(lambda driver: new_graph))
+
+    class DummyDriver:
+        def close(self):
+            pass
+    monkeypatch.setattr(app_module, "get_neo4j_driver", lambda: DummyDriver())
+
+    with app.test_client() as client:
+        res = client.post("/datasets/demo/load_neo4j")
+        assert res.status_code == 302
+    assert ds.graph is new_graph
     DATASETS.clear()


### PR DESCRIPTION
## Summary
- extend dataset detail page with search, filtering, and Neo4j controls
- add API routes for KG search and Neo4j persistence
- test search route and Neo4j endpoints
- clean unused imports and fix exception handling

## Testing
- `pip install fastapi fakeredis networkx neo4j flask flask-wtf wtforms pydantic celery redis sqlalchemy`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a44869994832fadb4fb72e13af878