### PR TITLE
Add configurable generation settings and CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,12 @@ The `generation` section now exposes advanced chunking and retrieval options:
 generation:
   chunk_method: semantic  # or "sliding" for fixed windows
   similarity_drop: 0.25   # threshold when using semantic splitting
-  retrieval_top_k: 5      # number of chunks fetched using embeddings
+    retrieval_top_k: 5      # number of chunks fetched using embeddings
 ```
+
+Most options can also be overridden with environment variables. For example set
+`GEN_TEMPERATURE=0.5` to change the default temperature, or `LLM_MODEL` to use a
+different model without editing the YAML file.
 
 ```bash
 curl -X POST localhost:8000/tasks/ingest \
@@ -209,6 +213,17 @@ for file in data/pdf/*.pdf; do
   curl -X POST localhost:8000/tasks/save -d "ds_id=1&fmt=chatml" -H "X-API-Key: <key>"
 done
 ```
+
+### Command Line Generation
+
+You can also generate data directly without running the REST API.
+
+```bash
+python -m datacreek.cli generate ./docs/paper.txt --content-type qa \
+    --model llama-3 --temperature 0.6 --output-dir out
+```
+
+Pass `--prompt-file` to override the default prompt template for the run.
 
 ## Advanced Usage
 

--- a/datacreek/__init__.py
+++ b/datacreek/__init__.py
@@ -20,6 +20,7 @@ from .pipelines import (
 from .core.knowledge_graph import KnowledgeGraph
 from .core.dataset import DatasetBuilder
 from .core.ingest import process_file as ingest_file, to_kg, ingest_into_dataset
+from .config_models import GenerationSettings
 
 __all__ = [
     "GenerationPipeline",
@@ -35,5 +36,5 @@ __all__ = [
     "ingest_file",
     "to_kg",
     "ingest_into_dataset",
+    "GenerationSettings",
 ]
-

--- a/datacreek/cli.py
+++ b/datacreek/cli.py
@@ -1,12 +1,49 @@
 import typer
 import uvicorn
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+from datacreek.core.create import process_file
+
 
 app_cli = typer.Typer(help="Command line utilities for managing the datacreek application")
+
 
 @app_cli.command()
 def serve(host: str = "127.0.0.1", port: int = 8000):
     """Run the REST API server."""
     uvicorn.run("datacreek.api:app", host=host, port=port, reload=True)
+
+
+@app_cli.command()
+def generate(
+    file: Path = typer.Argument(..., exists=True, help="Input file"),
+    output_dir: Path = typer.Option("output", help="Directory for results"),
+    content_type: str = typer.Option("qa", help="Type: qa|summary|cot|cot-enhance"),
+    model: Optional[str] = typer.Option(None, help="Model name"),
+    provider: Optional[str] = typer.Option(None, help="LLM provider"),
+    api_base: Optional[str] = typer.Option(None, help="Custom API base"),
+    temperature: Optional[float] = typer.Option(None, help="Generation temperature"),
+    prompt_file: Optional[Path] = typer.Option(None, help="Override prompt file"),
+    num_pairs: Optional[int] = typer.Option(None, help="Number of pairs/examples"),
+):
+    """Run content generation from the command line."""
+    overrides: Dict[str, Any] = {}
+    if temperature is not None:
+        overrides.setdefault("generation", {})["temperature"] = temperature
+    if prompt_file:
+        overrides.setdefault("prompts", {})[f"{content_type}_generation"] = prompt_file.read_text()
+
+    process_file(
+        file_path=str(file),
+        output_dir=str(output_dir),
+        api_base=api_base,
+        model=model,
+        provider=provider,
+        content_type=content_type,
+        num_pairs=num_pairs,
+        config_overrides=overrides if overrides else None,
+    )
 
 
 @app_cli.command()
@@ -17,12 +54,14 @@ def init_db_cmd() -> None:
     init_db()
     typer.echo("Database initialized")
 
+
 @app_cli.command()
 def test():
     """Run the unit test suite."""
     import pytest
+
     raise SystemExit(pytest.main(["-q"]))
+
 
 if __name__ == "__main__":
     app_cli()
-

--- a/datacreek/config.yaml
+++ b/datacreek/config.yaml
@@ -48,6 +48,9 @@ ingest:
 generation:
   temperature: 0.7   # Higher = more creative, lower = more deterministic
   top_p: 0.95        # Nucleus sampling parameter
+  frequency_penalty: 0.0  # Discourage repeating tokens
+  presence_penalty: 0.0   # Encourage mentioning new tokens
+  stop: null              # Optional stop sequences
   chunk_size: 4000   # Size of text chunks for processing
   overlap: 200       # Overlap between chunks to maintain context
   chunk_method: sliding  # Options: basic|sliding|semantic

--- a/datacreek/config_models.py
+++ b/datacreek/config_models.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict, Any
+
+
+@dataclass
+class GenerationSettings:
+    """Configuration options controlling LLM generation."""
+
+    temperature: float = 0.7
+    top_p: float = 0.95
+    chunk_size: int = 4000
+    overlap: int = 200
+    chunk_method: str = "sliding"
+    similarity_drop: float = 0.3
+    retrieval_top_k: int = 3
+    max_tokens: int = 4096
+    num_pairs: int = 25
+    num_cot_examples: int = 5
+    num_cot_enhance_examples: Optional[int] = None
+    batch_size: int = 32
+    frequency_penalty: float = 0.0
+    presence_penalty: float = 0.0
+    stop: Optional[List[str]] = field(default=None)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GenerationSettings":
+        """Create ``GenerationSettings`` from a raw dictionary."""
+        defaults = cls()
+        return cls(**{k: data.get(k, getattr(defaults, k)) for k in cls.__dataclass_fields__})
+
+    def update(self, overrides: Dict[str, Any]) -> None:
+        """Update fields from a dictionary of overrides."""
+        for key, value in overrides.items():
+            if hasattr(self, key) and value is not None:
+                setattr(self, key, value)

--- a/datacreek/core/create.py
+++ b/datacreek/core/create.py
@@ -14,9 +14,10 @@ from datacreek.generators.qa_generator import QAGenerator
 from datacreek.generators.vqa_generator import VQAGenerator
 from datacreek.utils.config import get_generation_config
 
+
 def read_json(file_path):
     # Read the file
-    with open(file_path, 'r', encoding='utf-8') as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         document_text = f.read()
     return document_text
 
@@ -35,7 +36,7 @@ def process_file(
     config_overrides: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Process a file to generate content
-    
+
     Args:
         file_path: Path to the text file to process
         output_dir: Directory to save generated content
@@ -45,121 +46,114 @@ def process_file(
         content_type: Type of content to generate (qa, summary, cot)
         num_pairs: Target number of QA pairs to generate
         threshold: Quality threshold for filtering (1-10)
-    
+
     Returns:
         Path to the output file
     """
     # Create output directory if it doesn't exist
     # The reason for having this directory logic for now is explained in context.py
     os.makedirs(output_dir, exist_ok=True)
-    
+
     # Initialize LLM client
     client = LLMClient(
-        config_path=config_path,
-        provider=provider,
-        api_base=api_base,
-        model_name=model
+        config_path=config_path, provider=provider, api_base=api_base, model_name=model
     )
-    
+
     # Debug: Print which provider is being used
     print(f"L Using {client.provider} provider")
-    
+
     # Generate base filename for output
     if file_path:
         base_name = os.path.splitext(os.path.basename(file_path))[0]
     else:
         base_name = "input"
-    
+
     # Generate content based on type
     if content_type == "qa":
         generator = QAGenerator(client, config_path, config_overrides=config_overrides)
 
         if document_text is None:
             document_text = read_json(file_path)
-        
+
         # Get num_pairs from args or config
         if num_pairs is None:
             config = client.config
             generation_config = get_generation_config(config)
-            num_pairs = generation_config.get("num_pairs", 25)
-        
+            num_pairs = generation_config.num_pairs
+
         # Process document
-        result = generator.process_document(
-            document_text,
-            num_pairs=num_pairs,
-            verbose=verbose
-        )
-        
+        result = generator.process_document(document_text, num_pairs=num_pairs, verbose=verbose)
+
         # Save output
         output_path = os.path.join(output_dir, f"{base_name}_qa_pairs.json")
         print(f"Saving result to {output_path}")
-        
+
         # First, let's save a basic test file to confirm the directory is writable
         test_path = os.path.join(output_dir, "test_write.json")
         try:
-            with open(test_path, 'w', encoding='utf-8') as f:
+            with open(test_path, "w", encoding="utf-8") as f:
                 f.write('{"test": "data"}')
             print(f"Successfully wrote test file to {test_path}")
         except Exception as e:
             print(f"Error writing test file: {e}")
-            
+
         # Now save the actual result
         try:
-            with open(output_path, 'w', encoding='utf-8') as f:
+            with open(output_path, "w", encoding="utf-8") as f:
                 json.dump(result, f, indent=2)
             print(f"Successfully wrote result to {output_path}")
         except Exception as e:
             print(f"Error writing result file: {e}")
-        
+
         return output_path
-    
+
     elif content_type == "summary":
         generator = QAGenerator(client, config_path, config_overrides=config_overrides)
 
         if document_text is None:
             document_text = read_json(file_path)
-        
+
         # Generate just the summary
         summary = generator.generate_summary(document_text)
-        
+
         # Save output
         output_path = os.path.join(output_dir, f"{base_name}_summary.json")
-        with open(output_path, 'w', encoding='utf-8') as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump({"summary": summary}, f, indent=2)
-        
+
         return output_path
-    
+
     # So there are two separate categories of CoT
     # Simply CoT maps to "Hey I want CoT being generated"
     # CoT-enhance maps to "Please enhance my dataset with CoT"
-    
+
     elif content_type == "cot":
         from datacreek.generators.cot_generator import COTGenerator
-        
+
         # Initialize the CoT generator
         generator = COTGenerator(client, config_path, config_overrides=config_overrides)
 
         if document_text is None:
             document_text = read_json(file_path)
-        
+
         # Get num_examples from args or config
         if num_pairs is None:
             config = client.config
             generation_config = get_generation_config(config)
-            num_pairs = generation_config.get("num_cot_examples", 5)
-        
+            num_pairs = generation_config.num_cot_examples
+
         # Process document to generate CoT examples
         result = generator.process_document(
             document_text,
             num_examples=num_pairs,
-            include_simple_steps=verbose  # More detailed if verbose is enabled
+            include_simple_steps=verbose,  # More detailed if verbose is enabled
         )
-        
+
         # Save output
         output_path = os.path.join(output_dir, f"{base_name}_cot_examples.json")
-        with open(output_path, 'w', encoding='utf-8') as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(result, f, indent=2)
-        
+
         if verbose:
             # Print some example content
             if result.get("cot_examples") and len(result.get("cot_examples", [])) > 0:
@@ -168,19 +162,19 @@ def process_file(
                 print(f"Question: {first_example.get('question', '')}")
                 print(f"Reasoning (first 100 chars): {first_example.get('reasoning', '')[:100]}...")
                 print(f"Answer: {first_example.get('answer', '')}")
-        
+
         return output_path
-        
+
     elif content_type == "cot-enhance":
         from datacreek.generators.cot_generator import COTGenerator
         from tqdm import tqdm
-        
+
         # Initialize the CoT generator
         generator = COTGenerator(client, config_path, config_overrides=config_overrides)
 
         if document_text is None:
             document_text = read_json(file_path)
-        
+
         # Get max_examples from args or config
         max_examples = None
         if num_pairs is not None:
@@ -189,23 +183,23 @@ def process_file(
             config = client.config
             generation_config = get_generation_config(config)
             # Get the config value (will be None by default, meaning enhance all)
-            max_examples = generation_config.get("num_cot_enhance_examples")
-        
+            max_examples = generation_config.num_cot_enhance_examples
+
         # Instead of parsing as text, load the file as JSON with conversations
         try:
-            with open(file_path, 'r', encoding='utf-8') as f:
+            with open(file_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            
+
             # Handle different dataset formats
             # First, check for QA pairs format (the most common input format)
             if isinstance(data, dict) and "qa_pairs" in data:
                 # QA pairs format from "create qa" command (make this the primary format)
                 from datacreek.utils.llm_processing import convert_to_conversation_format
-                
+
                 qa_pairs = data.get("qa_pairs", [])
                 if verbose:
                     print(f"Converting {len(qa_pairs)} QA pairs to conversation format")
-                
+
                 conv_list = convert_to_conversation_format(qa_pairs)
                 # Wrap each conversation in the expected format
                 conversations = [{"conversations": conv} for conv in conv_list]
@@ -215,11 +209,15 @@ def process_file(
                 # Single conversation with a conversations array
                 conversations = [data]
                 is_single_conversation = True
-            elif isinstance(data, list) and all("conversations" in item for item in data if isinstance(item, dict)):
+            elif isinstance(data, list) and all(
+                "conversations" in item for item in data if isinstance(item, dict)
+            ):
                 # Array of conversation objects, each with a conversations array
                 conversations = data
                 is_single_conversation = False
-            elif isinstance(data, list) and all(isinstance(msg, dict) and "from" in msg for msg in data):
+            elif isinstance(data, list) and all(
+                isinstance(msg, dict) and "from" in msg for msg in data
+            ):
                 # Direct list of messages for a single conversation
                 conversations = [{"conversations": data}]
                 is_single_conversation = True
@@ -227,38 +225,44 @@ def process_file(
                 # Try to handle as a generic list of conversations
                 conversations = data
                 is_single_conversation = False
-            
+
             # Limit the number of conversations if needed
             if max_examples is not None and len(conversations) > max_examples:
                 if verbose:
-                    print(f"Limiting to {max_examples} conversations (from {len(conversations)} total)")
+                    print(
+                        f"Limiting to {max_examples} conversations (from {len(conversations)} total)"
+                    )
                 conversations = conversations[:max_examples]
-            
+
             if verbose:
                 print(f"Found {len(conversations)} conversation(s) to enhance")
-            
+
             # Process each conversation
             enhanced_conversations = []
-            
+
             for i, conversation in enumerate(tqdm(conversations, desc="Enhancing conversations")):
                 # Check if this item has a conversations field
                 if isinstance(conversation, dict) and "conversations" in conversation:
                     conv_messages = conversation["conversations"]
-                    
+
                     # Validate messages format
                     if not isinstance(conv_messages, list):
                         print(f"Warning: conversations field is not a list in item {i}, skipping")
                         enhanced_conversations.append(conversation)  # Keep original
                         continue
-                    
+
                     # Enhance this conversation's messages
                     if verbose:
                         print(f"Debug - Conv_messages type: {type(conv_messages)}")
-                        print(f"Debug - Conv_messages structure: {conv_messages[:1] if isinstance(conv_messages, list) else 'Not a list'}")
-                    
+                        print(
+                            f"Debug - Conv_messages structure: {conv_messages[:1] if isinstance(conv_messages, list) else 'Not a list'}"
+                        )
+
                     # Always include simple steps when enhancing QA pairs
-                    enhanced_messages = generator.enhance_with_cot(conv_messages, include_simple_steps=True)
-                    
+                    enhanced_messages = generator.enhance_with_cot(
+                        conv_messages, include_simple_steps=True
+                    )
+
                     # Handle nested bug
                     if enhanced_messages and isinstance(enhanced_messages, list):
                         # Nested bug
@@ -266,7 +270,7 @@ def process_file(
                             if verbose:
                                 print(f"Debug - Flattening nested array response")
                             enhanced_messages = enhanced_messages[0]
-                    
+
                     # Create enhanced conversation with same structure
                     enhanced_conv = conversation.copy()
                     enhanced_conv["conversations"] = enhanced_messages
@@ -274,37 +278,36 @@ def process_file(
                 else:
                     # Not the expected format, just keep original
                     enhanced_conversations.append(conversation)
-            
+
             # Save enhanced conversations
             output_path = os.path.join(output_dir, f"{base_name}_enhanced.json")
-            
-            with open(output_path, 'w', encoding='utf-8') as f:
+
+            with open(output_path, "w", encoding="utf-8") as f:
                 if is_single_conversation and len(enhanced_conversations) == 1:
                     # Save the single conversation
                     json.dump(enhanced_conversations[0], f, indent=2)
                 else:
                     # Save the array of conversations
                     json.dump(enhanced_conversations, f, indent=2)
-            
+
             if verbose:
                 print(f"Enhanced {len(enhanced_conversations)} conversation(s)")
-                
+
             return output_path
-            
+
         except json.JSONDecodeError:
-            raise ValueError(f"Failed to parse {file_path} as JSON. For cot-enhance, input must be a valid JSON file.")
+            raise ValueError(
+                f"Failed to parse {file_path} as JSON. For cot-enhance, input must be a valid JSON file."
+            )
     elif content_type == "vqa_add_reasoning":
         # Initialize the VQA generator
         generator = VQAGenerator(client, config_path)
-        
+
         # Process the dataset
         output_path = generator.process_dataset(
-            dataset_source=file_path,
-            output_dir=output_dir,
-            num_examples=num_pairs,
-            verbose=verbose
+            dataset_source=file_path, output_dir=output_dir, num_examples=num_pairs, verbose=verbose
         )
-        
+
         return output_path
 
     else:

--- a/datacreek/core/ingest.py
+++ b/datacreek/core/ingest.py
@@ -21,12 +21,13 @@ from datacreek.parsers import (
 
 logger = logging.getLogger(__name__)
 
+
 def determine_parser(file_path: str, config: Dict[str, Any]):
     """Return a parser instance for the given resource."""
     # Check if it's a URL
-    if file_path.startswith(('http://', 'https://')):
+    if file_path.startswith(("http://", "https://")):
         # YouTube URL
-        if 'youtube.com' in file_path or 'youtu.be' in file_path:
+        if "youtube.com" in file_path or "youtu.be" in file_path:
             return YouTubeParser()
         # HTML URL
         else:
@@ -42,6 +43,7 @@ def determine_parser(file_path: str, config: Dict[str, Any]):
 
     logger.error("File not found: %s", file_path)
     raise FileNotFoundError(f"File not found: {file_path}")
+
 
 def process_file(
     file_path: str,
@@ -94,10 +96,10 @@ def to_kg(
 
     chunks = split_into_chunks(
         text,
-        chunk_size=gen_cfg.get("chunk_size", 4000),
-        overlap=gen_cfg.get("overlap", 200),
-        method=gen_cfg.get("chunk_method"),
-        similarity_drop=gen_cfg.get("similarity_drop", 0.3),
+        chunk_size=gen_cfg.chunk_size,
+        overlap=gen_cfg.overlap,
+        method=gen_cfg.chunk_method,
+        similarity_drop=gen_cfg.similarity_drop,
     )
 
     dataset.add_document(doc_id, source=doc_id)
@@ -121,4 +123,3 @@ def ingest_into_dataset(
     doc_id = doc_id or Path(file_path).stem
     to_kg(text, dataset, doc_id, config, build_index=True)
     return doc_id
-

--- a/datacreek/generators/cot_generator.py
+++ b/datacreek/generators/cot_generator.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from datacreek.models.llm_client import LLMClient
 from datacreek.utils.config import get_prompt, get_generation_config
 
+
 class COTGenerator:
     """Generates chain-of-thought reasoning examples"""
 
@@ -32,169 +33,174 @@ class COTGenerator:
 
         if config_overrides:
             from datacreek.utils.config import merge_configs
+
             base_cfg = merge_configs(base_cfg, config_overrides)
 
         self.config = base_cfg
         self.generation_config = get_generation_config(self.config)
-    
+
     def parse_json_output(self, output_text: str) -> Optional[List[Dict]]:
         """Parse JSON from LLM output text"""
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
+        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
         output_text = output_text.strip()
-        
+
         # Try to extract JSON array
         json_match = re.search(r"\[.*\]", output_text, re.DOTALL)
         if json_match:
             output_text = json_match.group(0)
-        
+
         try:
             # Handle quoted JSON
             if output_text.startswith('"') and output_text.endswith('"'):
                 output_text = json.loads(output_text)
-            
+
             # Load the JSON
             result = json.loads(output_text)
-            
+
             # Ensure it's a list
             if not isinstance(result, list):
                 if verbose:
                     print("Warning: Expected a list but got another type")
                 return None
-            
+
             return result
         except json.JSONDecodeError as e:
             if verbose:
                 print(f"Error parsing output: {e}")
             return None
-    
-    def generate_cot_examples(self, document_text: str, num_examples: int = None) -> List[Dict[str, Any]]:
+
+    def generate_cot_examples(
+        self, document_text: str, num_examples: int = None
+    ) -> List[Dict[str, Any]]:
         """Generate chain-of-thought reasoning examples"""
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
-        
+        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+
         # Get default num_examples from config if not provided
         if num_examples is None:
-            num_examples = self.generation_config.get("num_cot_examples", 5)
-        
+            num_examples = self.generation_config.num_cot_examples
+
         # Get the prompt template
         prompt_template = get_prompt(self.config, "cot_generation")
-        
+
         # Format the prompt
-        prompt = prompt_template.format(
-            num_examples=num_examples,
-            text=document_text
-        )
-        
+        prompt = prompt_template.format(num_examples=num_examples, text=document_text)
+
         # Generate examples
-        temperature = self.generation_config.get("temperature", 0.7)
-        max_tokens = self.generation_config.get("max_tokens", 4096)
-        
+        temperature = self.generation_config.temperature
+        max_tokens = self.generation_config.max_tokens
+
         if verbose:
             print(f"Generating {num_examples} CoT examples...")
-        
+
         messages = [{"role": "system", "content": prompt}]
         response = self.client.chat_completion(
-            messages, 
-            temperature=temperature,
-            max_tokens=max_tokens
+            messages, temperature=temperature, max_tokens=max_tokens
         )
-        
+
         # Parse response
         examples = self.parse_json_output(response)
-        
+
         if examples is None:
             if verbose:
                 print("Failed to parse CoT examples, returning empty list")
             return []
-        
+
         if verbose:
             print(f"Successfully generated {len(examples)} CoT examples")
-        
+
         return examples
-    
-    def enhance_with_cot(self, conversations: List[Dict], include_simple_steps: bool = False) -> List[Dict]:
+
+    def enhance_with_cot(
+        self, conversations: List[Dict], include_simple_steps: bool = False
+    ) -> List[Dict]:
         """Enhance existing conversations with CoT reasoning"""
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
-        
+        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+
         # Get the prompt template
         prompt_template = get_prompt(self.config, "cot_enhancement")
-        
+
         if verbose:
             print(f"Debug - Conversations to enhance structure: {type(conversations)}")
-            print(f"Debug - First conversation: {json.dumps(conversations[0] if conversations else {}, indent=2)[:100]}...")
-        
+            print(
+                f"Debug - First conversation: {json.dumps(conversations[0] if conversations else {}, indent=2)[:100]}..."
+            )
+
         # Format the prompt
         conversation_str = json.dumps(conversations, ensure_ascii=False, indent=2)
         prompt = prompt_template.format(
-            conversations=conversation_str,
-            include_simple_steps=str(include_simple_steps).lower()
+            conversations=conversation_str, include_simple_steps=str(include_simple_steps).lower()
         )
-        
+
         # Generate enhanced conversations
-        temperature = self.generation_config.get("temperature", 0.2)
-        max_tokens = self.generation_config.get("max_tokens", 4096)
-        
+        temperature = self.generation_config.temperature
+        max_tokens = self.generation_config.max_tokens
+
         if verbose:
             print(f"Enhancing {len(conversations)} conversations with CoT...")
-        
+
         messages = [{"role": "system", "content": prompt}]
         response = self.client.chat_completion(
-            messages, 
-            temperature=temperature,
-            max_tokens=max_tokens
+            messages, temperature=temperature, max_tokens=max_tokens
         )
-        
+
         # Parse response
         enhanced_conversations = self.parse_json_output(response)
-        
+
         if enhanced_conversations is None:
             if verbose:
                 print("Failed to parse enhanced conversations, returning original")
             return conversations
-        
+
         if verbose:
             print(f"Successfully enhanced conversations with CoT")
-        
+
         return enhanced_conversations
-    
-    def process_document(self, document_text: str, num_examples: int = None, include_simple_steps: bool = False) -> Dict[str, Any]:
+
+    def process_document(
+        self, document_text: str, num_examples: int = None, include_simple_steps: bool = False
+    ) -> Dict[str, Any]:
         """Process a document to generate CoT examples"""
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
-        
+        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+
         # Set the verbose environment variable
         if verbose:
-            os.environ['SDK_VERBOSE'] = 'true'
+            os.environ["SDK_VERBOSE"] = "true"
         else:
-            os.environ['SDK_VERBOSE'] = 'false'
-        
+            os.environ["SDK_VERBOSE"] = "false"
+
         # Generate summary first (helpful context)
         summary = self.client.chat_completion(
-            [{"role": "system", "content": "Summarize this document in 2-3 sentences."},
-             {"role": "user", "content": document_text}], 
-            temperature=0.1
+            [
+                {"role": "system", "content": "Summarize this document in 2-3 sentences."},
+                {"role": "user", "content": document_text},
+            ],
+            temperature=0.1,
         )
-        
+
         # Generate CoT examples
         examples = self.generate_cot_examples(document_text, num_examples)
-        
+
         # Format into simple conversation format as well
         conversations = []
         for example in examples:
             if "question" in example and "reasoning" in example and "answer" in example:
                 conv = [
-                    {"role": "system", "content": "You are a helpful assistant that provides detailed explanations."},
+                    {
+                        "role": "system",
+                        "content": "You are a helpful assistant that provides detailed explanations.",
+                    },
                     {"role": "user", "content": example["question"]},
-                    {"role": "assistant", "content": f"Let me think through this step by step:\n\n{example['reasoning']}\n\nSo the answer is: {example['answer']}"}
+                    {
+                        "role": "assistant",
+                        "content": f"Let me think through this step by step:\n\n{example['reasoning']}\n\nSo the answer is: {example['answer']}",
+                    },
                 ]
                 conversations.append(conv)
-        
+
         # Prepare result
-        result = {
-            "summary": summary,
-            "cot_examples": examples,
-            "conversations": conversations
-        }
-        
+        result = {"summary": summary, "cot_examples": examples, "conversations": conversations}
+
         # Print stats
         print(f"Generated {len(examples)} chain-of-thought examples")
-        
+
         return result

--- a/datacreek/generators/qa_generator.py
+++ b/datacreek/generators/qa_generator.py
@@ -15,8 +15,13 @@ from rich.progress import Progress, BarColumn, TextColumn, TimeElapsedColumn, Ti
 from datacreek.models.llm_client import LLMClient
 from datacreek.utils.text import split_into_chunks
 from datacreek.core.knowledge_graph import KnowledgeGraph
-from datacreek.utils.llm_processing import parse_qa_pairs, parse_ratings, convert_to_conversation_format
+from datacreek.utils.llm_processing import (
+    parse_qa_pairs,
+    parse_ratings,
+    convert_to_conversation_format,
+)
 from datacreek.utils.config import load_config, get_generation_config, get_curate_config, get_prompt
+
 
 class QAGenerator:
     def __init__(
@@ -34,35 +39,35 @@ class QAGenerator:
         self.config = load_config(config_path)
         if config_overrides:
             from datacreek.utils.config import merge_configs
+
             self.config = merge_configs(self.config, config_overrides)
 
         # Get specific configurations
         self.generation_config = get_generation_config(self.config)
         self.curate_config = get_curate_config(self.config)
-    
+
     def generate_summary(self, document_text: str) -> str:
         """Generate a summary of the document"""
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
+        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
         if verbose:
             print("Generating document summary...")
-        
+
         # Get summary prompt from config
         prompt = get_prompt(self.config, "summary")
-        
+
         messages = [
             {"role": "system", "content": prompt},
-            {"role": "user", "content": document_text}
+            {"role": "user", "content": document_text},
         ]
-        
+
         summary = self.client.chat_completion(
-            messages, 
-            temperature=0.1  # Use lower temperature for summaries
+            messages, temperature=0.1  # Use lower temperature for summaries
         )
-        
+
         if verbose:
             print(f"Summary generated ({len(summary)} chars)")
         return summary
-    
+
     def generate_qa_pairs(
         self,
         document_text: str,
@@ -71,17 +76,17 @@ class QAGenerator:
         query: Optional[str] = None,
     ) -> List[Dict[str, str]]:
         """Generate QA pairs from the document using batched processing"""
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
-        
+        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+
         # Get generation config
-        chunk_size = self.generation_config.get("chunk_size", 4000)
-        temperature = self.generation_config.get("temperature", 0.7)
-        overlap = self.generation_config.get("overlap", 200)
-        batch_size = self.generation_config.get("batch_size", 32)
-        chunk_method = self.generation_config.get("chunk_method")
-        similarity_drop = self.generation_config.get("similarity_drop", 0.3)
-        top_k = self.generation_config.get("retrieval_top_k", 3)
-        
+        chunk_size = self.generation_config.chunk_size
+        temperature = self.generation_config.temperature
+        overlap = self.generation_config.overlap
+        batch_size = self.generation_config.batch_size
+        chunk_method = self.generation_config.chunk_method
+        similarity_drop = self.generation_config.similarity_drop
+        top_k = self.generation_config.retrieval_top_k
+
         # Split text into chunks
         chunks = split_into_chunks(
             document_text,
@@ -101,39 +106,41 @@ class QAGenerator:
         if query and self.kg:
             selected_ids = self.kg.search_embeddings(query, k=top_k)
             chunks = [self.kg.graph.nodes[c]["text"] for c in selected_ids if c in self.kg.graph]
-        
+
         if verbose:
             print(f"Generating QA pairs...")
             print(f"Document split into {len(chunks)} chunks")
             print(f"Using batch size of {batch_size}")
-        
+
         all_qa_pairs = []
         pairs_per_chunk = max(1, round(num_pairs / len(chunks)))
-        
+
         # Get QA generation prompt template
         qa_prompt_template = get_prompt(self.config, "qa_generation")
-        
+
         # Prepare all message batches
         all_messages = []
         for i, chunk in enumerate(chunks):
             # Format the prompt with summary and text
             qa_prompt = qa_prompt_template.format(
-                num_pairs=pairs_per_chunk,
-                summary=summary[:100],
-                text=chunk
+                num_pairs=pairs_per_chunk, summary=summary[:100], text=chunk
             )
-            
-            messages = [
-                {"role": "system", "content": qa_prompt}
-            ]
+
+            messages = [{"role": "system", "content": qa_prompt}]
             all_messages.append(messages)
-        
+
         print(f"Processing {len(chunks)} chunks to generate QA pairs...")
-        
+
         # Set up progress tracking based on verbose mode
         if verbose:
-            from rich.progress import Progress, BarColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn
-            
+            from rich.progress import (
+                Progress,
+                BarColumn,
+                TextColumn,
+                TimeElapsedColumn,
+                TimeRemainingColumn,
+            )
+
             progress_columns = [
                 TextColumn("[progress.description]{task.description}"),
                 BarColumn(),
@@ -141,101 +148,100 @@ class QAGenerator:
                 TimeElapsedColumn(),
                 TimeRemainingColumn(),
             ]
-            
+
             progress_ctx = Progress(*progress_columns)
             generate_task = progress_ctx.add_task(f"Generating QA pairs", total=len(chunks))
             progress_ctx.start()
         else:
             progress_ctx = None
             generate_task = None
-        
+
         # Process in batches
         for batch_start in range(0, len(chunks), batch_size):
             batch_end = min(batch_start + batch_size, len(chunks))
             batch_messages = all_messages[batch_start:batch_end]
             current_batch_size = len(batch_messages)
-            
-            batch_num = batch_start//batch_size + 1
-            total_batches = (len(chunks) + batch_size - 1)//batch_size
-            
+
+            batch_num = batch_start // batch_size + 1
+            total_batches = (len(chunks) + batch_size - 1) // batch_size
+
             # Simple progress indicator for non-verbose mode
             if not verbose:
                 print(f"Processing batch {batch_num}/{total_batches}...", end="\r")
             else:
-                print(f"Processing batch {batch_num}/{total_batches} with {current_batch_size} chunks")
-            
+                print(
+                    f"Processing batch {batch_num}/{total_batches} with {current_batch_size} chunks"
+                )
+
             try:
                 # Process the batch
                 batch_responses = self.client.batch_completion(
-                    batch_messages,
-                    temperature=temperature,
-                    batch_size=batch_size
+                    batch_messages, temperature=temperature, batch_size=batch_size
                 )
-                
+
                 # Process each response in the batch
                 for j, response in enumerate(batch_responses):
                     chunk_index = batch_start + j
                     chunk_pairs = parse_qa_pairs(response)
                     all_qa_pairs.extend(chunk_pairs)
-                    
+
                     if verbose:
                         print(f"  Generated {len(chunk_pairs)} pairs from chunk {chunk_index+1}")
-                
+
                 # Update progress bar if in verbose mode
                 if progress_ctx and generate_task:
                     progress_ctx.update(generate_task, advance=current_batch_size)
-                
+
             except Exception as e:
                 if verbose:
                     print(f"  Error processing batch {batch_num}: {str(e)}")
-                
+
                 # Update progress bar if in verbose mode
                 if progress_ctx and generate_task:
                     progress_ctx.update(generate_task, advance=current_batch_size)
-        
+
         # Stop progress bar if in verbose mode
         if progress_ctx:
             progress_ctx.stop()
-        
+
         # Clear the progress line in non-verbose mode
         if not verbose:
             print(" " * 80, end="\r")
             print("Batch processing complete.")
-        
+
         # Always print summary information, even in non-verbose mode
         print(f"Generated {len(all_qa_pairs)} QA pairs total")
         return all_qa_pairs
-    
-    def rate_qa_pairs(self, 
-                    qa_pairs: List[Dict[str, str]], 
-                    summary: str, 
-                    threshold: Optional[float] = None) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+
+    def rate_qa_pairs(
+        self, qa_pairs: List[Dict[str, str]], summary: str, threshold: Optional[float] = None
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
         """Rate and filter QA pairs by quality"""
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
-        
+        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+
         if not qa_pairs:
             return [], {"total": 0, "filtered": 0, "retention_rate": 0, "avg_score": 0}
-        
+
         # Get threshold from args, then config, then default
         if threshold is None:
             threshold = self.curate_config.get("threshold", 7.0)
-            
+
         if verbose:
             print(f"Evaluating {len(qa_pairs)} pairs...")
-        
+
         # Get rating config
         batch_size = self.curate_config.get("batch_size", 8)
         temperature = self.curate_config.get("temperature", 0.1)
-        
+
         # Get rating prompt template
         rating_prompt_template = get_prompt(self.config, "qa_rating")
-        
+
         # Process in batches
-        batches = [qa_pairs[i:i+batch_size] for i in range(0, len(qa_pairs), batch_size)]
-        
+        batches = [qa_pairs[i : i + batch_size] for i in range(0, len(qa_pairs), batch_size)]
+
         rated_pairs = []
         total_score = 0
-        
+
         # Create progress bar
         progress_columns = [
             TextColumn("[progress.description]{task.description}"),
@@ -244,77 +250,68 @@ class QAGenerator:
             TimeElapsedColumn(),
             TimeRemainingColumn(),
         ]
-        
+
         with Progress(*progress_columns) as progress:
             rating_task = progress.add_task(f"Rating QA pairs", total=len(batches))
-            
+
             for i, batch in enumerate(batches):
                 if verbose:
                     print(f"Rating batch {i+1}/{len(batches)}...")
                 batch_json = json.dumps(batch, indent=2)
-                
+
                 # Format the rating prompt with pairs
                 rating_prompt = rating_prompt_template.format(pairs=batch_json)
-                
-                messages = [
-                    {"role": "system", "content": rating_prompt}
-                ]
-                
+
+                messages = [{"role": "system", "content": rating_prompt}]
+
                 try:
-                    response = self.client.chat_completion(
-                        messages, 
-                        temperature=temperature
-                    )
-                    
+                    response = self.client.chat_completion(messages, temperature=temperature)
+
                     rated_batch = parse_ratings(response)
-                    
+
                     for pair in rated_batch:
                         if "rating" in pair:
                             total_score += pair["rating"]
                             if pair["rating"] >= threshold:
                                 rated_pairs.append(pair)
-                
+
                 except Exception as e:
                     if verbose:
                         print(f"Error rating batch {i+1}: {str(e)}")
-                
+
                 time.sleep(0.5)  # Avoid rate limits
                 progress.update(rating_task, advance=1)
-        
+
         # Calculate metrics
         metrics = {
             "total": len(qa_pairs),
             "filtered": len(rated_pairs),
             "retention_rate": round(len(rated_pairs) / len(qa_pairs), 2) if qa_pairs else 0,
-            "avg_score": round(total_score / len(qa_pairs), 1) if qa_pairs else 0
+            "avg_score": round(total_score / len(qa_pairs), 1) if qa_pairs else 0,
         }
-        
+
         # Always print summary information, even in non-verbose mode
         print(f"Keeping {len(rated_pairs)} out of {len(qa_pairs)} pairs (threshold: {threshold})")
         print(f"Average score: {metrics['avg_score']}")
         return rated_pairs, metrics
-    
-    def process_document(self, 
-                       document_text: str, 
-                       num_pairs: int = 25, 
-                       verbose: bool = False) -> Dict[str, Any]:
+
+    def process_document(
+        self, document_text: str, num_pairs: int = 25, verbose: bool = False
+    ) -> Dict[str, Any]:
         """Process a document to generate QA pairs without rating"""
         # Set the verbose environment variable
         if verbose:
-            os.environ['SDK_VERBOSE'] = 'true'
+            os.environ["SDK_VERBOSE"] = "true"
         else:
-            os.environ['SDK_VERBOSE'] = 'false'
-        
+            os.environ["SDK_VERBOSE"] = "false"
+
         # Generate summary
         summary = self.generate_summary(document_text)
-        
+
         # Generate QA pairs
         qa_pairs = self.generate_qa_pairs(document_text, summary, num_pairs=num_pairs)
-        
+
         # Prepare result - no rating at this stage
-        result = {
-            "summary": summary,
-            "qa_pairs": qa_pairs
-        }
-        
+        result = {"summary": summary, "qa_pairs": qa_pairs}
+
         return result

--- a/datacreek/generators/vqa_generator.py
+++ b/datacreek/generators/vqa_generator.py
@@ -18,53 +18,59 @@ from pathlib import Path
 from datacreek.models.llm_client import LLMClient
 from datacreek.utils.config import load_config, get_generation_config
 
+
 class VQAGenerator:
     """Generates Visual Question Answering data with reasoning"""
-    
-    def __init__(self, 
-                 client: LLMClient,
-                 config_path: Optional[Path] = None):
+
+    def __init__(self, client: LLMClient, config_path: Optional[Path] = None):
         """Initialize the VQA Generator with an LLM client and optional config"""
         self.client = client
-        
+
         # Load config
-        self.config = load_config(str(config_path) if config_path else None) if config_path else client.config
-        
+        self.config = (
+            load_config(str(config_path) if config_path else None) if config_path else client.config
+        )
+
         # Get specific configurations
         self.generation_config = get_generation_config(self.config)
-    
+
     def encode_image_base64(self, image):
         """Encode an image in base64 format"""
         import io
         import base64
+
         buffered = io.BytesIO()
         image.save(buffered, format="PNG")
-        return base64.b64encode(buffered.getvalue()).decode('utf-8')
-    
+        return base64.b64encode(buffered.getvalue()).decode("utf-8")
+
     def transform(self, messages):
         """Transform messages by adding reasoning to VQA data"""
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
-        
+        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+
         # Get prompt from config
         prompt = self.config.get("prompt", "")
-        
+
         # Get generation config
-        temperature = self.generation_config.get("temperature", 0.7)
-        max_tokens = self.generation_config.get("max_tokens", 1024)
-        batch_size = self.generation_config.get("batch_size", 32)
-        
+        temperature = self.generation_config.temperature
+        max_tokens = self.generation_config.max_tokens
+        batch_size = self.generation_config.batch_size
+
         # Process the messages from the dataset
         # Create a list of message sets for the model
         messages_list = []
-        
-        for i in range(len(messages['image'])):
-            image = messages['image'][i]
-            query = messages['query'][i]
-            label = messages['label'][i][0] if isinstance(messages['label'][i], list) else messages['label'][i]
-            
+
+        for i in range(len(messages["image"])):
+            image = messages["image"][i]
+            query = messages["query"][i]
+            label = (
+                messages["label"][i][0]
+                if isinstance(messages["label"][i], list)
+                else messages["label"][i]
+            )
+
             # Encode the image
             image_base64 = self.encode_image_base64(image)
-            
+
             # Prepare the messages for the API request
             message_set = [
                 {
@@ -80,42 +86,44 @@ class VQAGenerator:
                         },
                         {"type": "text", "text": f"{query} Final answer: {label}"},
                     ],
-                }
+                },
             ]
             messages_list.append(message_set)
-        
+
         if verbose:
             print(f"Processing {len(messages_list)} VQA items...")
-            
+
         # Use the client's batch_completion method instead of our own async implementation
         results = self.client.batch_completion(
             message_batches=messages_list,
             temperature=temperature,
             max_tokens=max_tokens,
-            batch_size=batch_size
+            batch_size=batch_size,
         )
-        
+
         for i, response in enumerate(results):
             # Update the messages with the response
-            messages['label'][i] = response
-            
+            messages["label"][i] = response
+
             if verbose and i < 2:  # Show first two examples in verbose mode
                 print(f"Example {i+1}:")
                 print(f"Query: {messages['query'][i]}")
                 print(f"Response: {response[:100]}..." if len(response) > 100 else response)
                 print()
-        
+
         return messages
-    
-    def process_dataset(self, 
-                       dataset_source,
-                       output_dir: str,
-                       num_examples: Optional[int] = None,
-                       input_split: Optional[str] = None,
-                       output_split: Optional[str] = None,
-                       verbose: bool = False) -> str:
+
+    def process_dataset(
+        self,
+        dataset_source,
+        output_dir: str,
+        num_examples: Optional[int] = None,
+        input_split: Optional[str] = None,
+        output_split: Optional[str] = None,
+        verbose: bool = False,
+    ) -> str:
         """Process a dataset to add reasoning to VQA data
-        
+
         Args:
             dataset_source: Dataset source (path or HuggingFace dataset ID)
             output_dir: Directory to save the processed dataset
@@ -123,24 +131,26 @@ class VQAGenerator:
             input_split: Dataset split to use as input
             output_split: Dataset split to use for output
             verbose: Whether to print verbose output
-            
+
         Returns:
             Path to the output dataset
         """
         # Set the verbose environment variable
         if verbose:
-            os.environ['SDK_VERBOSE'] = 'true'
+            os.environ["SDK_VERBOSE"] = "true"
         else:
-            os.environ['SDK_VERBOSE'] = 'false'
-            
+            os.environ["SDK_VERBOSE"] = "false"
+
         try:
             # Try to load from file
             try:
                 from datasets import Dataset
             except ImportError:
-                raise ImportError("The 'datasets' package is required for this functionality. Please install it using 'pip install datasets'.")
+                raise ImportError(
+                    "The 'datasets' package is required for this functionality. Please install it using 'pip install datasets'."
+                )
             try:
-                with open(dataset_source, 'r', encoding='utf-8') as f:
+                with open(dataset_source, "r", encoding="utf-8") as f:
                     input_data = f.read()
                 dataset = Dataset.from_dict(json.loads(input_data))
             except FileNotFoundError as e:
@@ -149,7 +159,9 @@ class VQAGenerator:
                     from huggingface_hub import HfApi
                     from datasets import load_dataset
                 except ImportError:
-                    raise ImportError("The 'huggingface_hub' and 'datasets' packages are required for this functionality. Please install them using 'pip install huggingface_hub datasets'.")
+                    raise ImportError(
+                        "The 'huggingface_hub' and 'datasets' packages are required for this functionality. Please install them using 'pip install huggingface_hub datasets'."
+                    )
 
                 hf_api = HfApi()
                 if hf_api.repo_exists(repo_id=dataset_source, repo_type="dataset"):
@@ -157,11 +169,11 @@ class VQAGenerator:
                 else:
                     # Uplevel error
                     raise e
-                    
+
             # Get input split from config if not provided
             if input_split is None:
                 input_split = self.config.get("input_split", None)
-                
+
             # Get output split from config if not provided
             if output_split is None:
                 output_split = self.config.get("output_split", None)
@@ -169,29 +181,29 @@ class VQAGenerator:
             # Use the specified split if provided
             if input_split is not None:
                 dataset = dataset[input_split]
-                
+
             # Get max_examples from args or config
             max_examples = num_examples
             if max_examples is not None and max_examples > 0:
                 # Limit the dataset size
                 dataset = dataset.select(range(min(max_examples, len(dataset))))
-                
+
             if verbose:
                 print(f"Processing {len(dataset)} examples from dataset")
 
             # Get batch size from config
-            batch_size = self.generation_config.get("batch_size", 32)
-            
+            batch_size = self.generation_config.batch_size
+
             if verbose:
                 print(f"Using batch size of {batch_size} for dataset processing")
-                
+
             # Process the dataset
             ds = dataset.map(
                 self.transform,
                 batch_size=batch_size,
                 batched=True,
             )
-            
+
             # Create output directory if it doesn't exist
             os.makedirs(output_dir, exist_ok=True)
 
@@ -199,24 +211,24 @@ class VQAGenerator:
             if output_split is not None:
                 # Create the split directory
                 os.makedirs(f"{output_dir}/{output_split}", exist_ok=True)
-                
+
                 # Write output that can be loaded back in with load_dataset
                 ds.to_parquet(f"{output_dir}/{output_split}/data.parquet")
                 meta_data = {"splits": [output_split]}
-                with open(f'{output_dir}/dataset_dict.json', 'w') as f:
+                with open(f"{output_dir}/dataset_dict.json", "w") as f:
                     f.write(json.dumps(meta_data, indent=4))
-                    
+
                 output_path = f"{output_dir}/{output_split}/data.parquet"
             else:
                 # Just dump it in a parquet file
                 ds.to_parquet(f"{output_dir}/data.parquet")
                 output_path = f"{output_dir}/data.parquet"
-                
+
             if verbose:
                 print(f"Saved processed dataset to {output_path}")
-                
+
             return output_path
-            
+
         except Exception as e:
             print(f"Error processing dataset: {e}")
             raise

--- a/datacreek/models/llm_client.py
+++ b/datacreek/models/llm_client.py
@@ -23,22 +23,28 @@ logger = logging.getLogger(__name__)
 try:
     from openai import OpenAI
     from openai.types.chat import ChatCompletion
+
     OPENAI_AVAILABLE = True
 except ImportError:
     OPENAI_AVAILABLE = False
-    logger.warning("OpenAI package not installed. To use API endpoint provider, install with 'pip install openai>=1.0.0'")
+    logger.warning(
+        "OpenAI package not installed. To use API endpoint provider, install with 'pip install openai>=1.0.0'"
+    )
+
 
 class LLMClient:
-    def __init__(self, 
-                 config_path: Optional[Path] = None,
-                 provider: Optional[str] = None,
-                 api_base: Optional[str] = None, 
-                 api_key: Optional[str] = None,
-                 model_name: Optional[str] = None,
-                 max_retries: Optional[int] = None,
-                 retry_delay: Optional[float] = None):
+    def __init__(
+        self,
+        config_path: Optional[Path] = None,
+        provider: Optional[str] = None,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+        model_name: Optional[str] = None,
+        max_retries: Optional[int] = None,
+        retry_delay: Optional[float] = None,
+    ):
         """Initialize an LLM client that supports multiple providers
-        
+
         Args:
             config_path: Path to config file (if None, uses default)
             provider: Override provider from config ('vllm' or 'api-endpoint')
@@ -50,76 +56,102 @@ class LLMClient:
         """
         # Load config
         self.config = load_config(config_path)
-        
-        # Determine provider (with CLI override taking precedence)
-        self.provider = provider or get_llm_provider(self.config)
-        
-        if self.provider == 'api-endpoint':
+
+        # Determine provider with environment variable override
+        self.provider = provider or os.environ.get("LLM_PROVIDER") or get_llm_provider(self.config)
+
+        if self.provider == "api-endpoint":
             if not OPENAI_AVAILABLE:
-                raise ImportError("OpenAI package is not installed. Install with 'pip install openai>=1.0.0'")
-            
+                raise ImportError(
+                    "OpenAI package is not installed. Install with 'pip install openai>=1.0.0'"
+                )
+
             # Load API endpoint configuration
             api_endpoint_config = get_openai_config(self.config)
-            
-            # Set parameters, with CLI overrides taking precedence
-            self.api_base = api_base or api_endpoint_config.get('api_base')
-            
+
+            # Set parameters, with CLI/ENV overrides taking precedence
+            self.api_base = (
+                api_base or os.environ.get("LLM_API_BASE") or api_endpoint_config.get("api_base")
+            )
+
             # Check for environment variables
-            api_endpoint_key = os.environ.get('API_ENDPOINT_KEY')
+            api_endpoint_key = os.environ.get("API_ENDPOINT_KEY")
             logger.debug(
                 "API_ENDPOINT_KEY from environment: %s",
-                'Found' if api_endpoint_key else 'Not found'
+                "Found" if api_endpoint_key else "Not found",
             )
-            
+
             # Set API key with priority: CLI arg > env var > config
-            self.api_key = api_key or api_endpoint_key or api_endpoint_config.get('api_key')
+            self.api_key = api_key or api_endpoint_key or api_endpoint_config.get("api_key")
             logger.debug(
                 "Using API key: %s",
-                'From CLI' if api_key else 'From env var' if api_endpoint_key else 'From config' if api_endpoint_config.get('api_key') else 'None'
+                (
+                    "From CLI"
+                    if api_key
+                    else (
+                        "From env var"
+                        if api_endpoint_key
+                        else "From config" if api_endpoint_config.get("api_key") else "None"
+                    )
+                ),
             )
-            
+
             if not self.api_key and not self.api_base:  # Only require API key for official API
-                raise ValueError("API key is required for API endpoint provider. Set in config or API_ENDPOINT_KEY env var.")
-            
-            self.model = model_name or api_endpoint_config.get('model')
-            self.max_retries = max_retries or api_endpoint_config.get('max_retries')
-            self.retry_delay = retry_delay or api_endpoint_config.get('retry_delay')
-            
+                raise ValueError(
+                    "API key is required for API endpoint provider. Set in config or API_ENDPOINT_KEY env var."
+                )
+
+            self.model = (
+                model_name or os.environ.get("LLM_MODEL") or api_endpoint_config.get("model")
+            )
+            self.max_retries = max_retries or int(
+                os.environ.get("LLM_MAX_RETRIES", api_endpoint_config.get("max_retries"))
+            )
+            self.retry_delay = retry_delay or float(
+                os.environ.get("LLM_RETRY_DELAY", api_endpoint_config.get("retry_delay"))
+            )
+
             # Initialize OpenAI client
             self._init_openai_client()
         else:  # Default to vLLM
             # Load vLLM configuration
             vllm_config = get_vllm_config(self.config)
-            
+
             # Set parameters, with CLI overrides taking precedence
-            self.api_base = api_base or vllm_config.get('api_base')
-            self.model = model_name or vllm_config.get('model')
-            self.max_retries = max_retries or vllm_config.get('max_retries')
-            self.retry_delay = retry_delay or vllm_config.get('retry_delay')
-            
+            self.api_base = (
+                api_base or os.environ.get("LLM_API_BASE") or vllm_config.get("api_base")
+            )
+            self.model = model_name or os.environ.get("LLM_MODEL") or vllm_config.get("model")
+            self.max_retries = max_retries or int(
+                os.environ.get("LLM_MAX_RETRIES", vllm_config.get("max_retries"))
+            )
+            self.retry_delay = retry_delay or float(
+                os.environ.get("LLM_RETRY_DELAY", vllm_config.get("retry_delay"))
+            )
+
             # No client to initialize for vLLM as we use requests directly
             # Verify server is running
             available, info = self._check_vllm_server()
             if not available:
                 raise ConnectionError(f"VLLM server not available at {self.api_base}: {info}")
-    
+
     def _init_openai_client(self):
         """Initialize OpenAI client with appropriate configuration"""
         client_kwargs = {}
-        
+
         # Add API key if provided
         if self.api_key:
-            client_kwargs['api_key'] = self.api_key
+            client_kwargs["api_key"] = self.api_key
         else:
             logger.info("No API key found!")
-        
+
         # Add base URL if provided (for OpenAI-compatible APIs)
         if self.api_base:
             logger.debug("Using API base URL: %s", self.api_base)
-            client_kwargs['base_url'] = self.api_base
-        
+            client_kwargs["base_url"] = self.api_base
+
         self.openai_client = OpenAI(**client_kwargs)
-    
+
     def _check_vllm_server(self) -> tuple:
         """Check if the VLLM server is running and accessible"""
         try:
@@ -129,47 +161,90 @@ class LLMClient:
             return False, f"Server returned status code: {response.status_code}"
         except requests.exceptions.RequestException as e:
             return False, f"Server connection error: {str(e)}"
-    
-    def chat_completion(self, 
-                      messages: List[Dict[str, str]], 
-                      temperature: float = None, 
-                      max_tokens: int = None,
-                      top_p: float = None) -> str:
+
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = None,
+        max_tokens: int = None,
+        top_p: float = None,
+        frequency_penalty: float = None,
+        presence_penalty: float = None,
+        stop: Optional[List[str]] = None,
+    ) -> str:
         """Generate a chat completion using the selected provider
-        
+
         Args:
             messages: List of message dictionaries with 'role' and 'content'
             temperature: Sampling temperature (higher = more random)
             max_tokens: Maximum tokens to generate
             top_p: Nucleus sampling parameter
-            
+
         Returns:
             String containing the generated text
         """
         # Get defaults from config if not provided
-        generation_config = self.config.get('generation', {})
-        temperature = temperature if temperature is not None else generation_config.get('temperature', 0.1)
-        max_tokens = max_tokens if max_tokens is not None else generation_config.get('max_tokens', 4096)
-        top_p = top_p if top_p is not None else generation_config.get('top_p', 0.95)
-        
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
-        
-        if self.provider == 'api-endpoint':
-            return self._openai_chat_completion(messages, temperature, max_tokens, top_p, verbose)
+        generation_config = self.config.get("generation", {})
+        temperature = (
+            temperature if temperature is not None else generation_config.get("temperature", 0.1)
+        )
+        max_tokens = (
+            max_tokens if max_tokens is not None else generation_config.get("max_tokens", 4096)
+        )
+        top_p = top_p if top_p is not None else generation_config.get("top_p", 0.95)
+        frequency_penalty = (
+            frequency_penalty
+            if frequency_penalty is not None
+            else generation_config.get("frequency_penalty", 0.0)
+        )
+        presence_penalty = (
+            presence_penalty
+            if presence_penalty is not None
+            else generation_config.get("presence_penalty", 0.0)
+        )
+        stop = stop if stop is not None else generation_config.get("stop")
+
+        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+
+        if self.provider == "api-endpoint":
+            return self._openai_chat_completion(
+                messages,
+                temperature,
+                max_tokens,
+                top_p,
+                frequency_penalty,
+                presence_penalty,
+                stop,
+                verbose,
+            )
         else:  # Default to vLLM
-            return self._vllm_chat_completion(messages, temperature, max_tokens, top_p, verbose)
-    
-    def _openai_chat_completion(self, 
-                              messages: List[Dict[str, str]],
-                              temperature: float,
-                              max_tokens: int,
-                              top_p: float,
-                              verbose: bool) -> str:
+            return self._vllm_chat_completion(
+                messages,
+                temperature,
+                max_tokens,
+                top_p,
+                frequency_penalty,
+                presence_penalty,
+                stop,
+                verbose,
+            )
+
+    def _openai_chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        frequency_penalty: float,
+        presence_penalty: float,
+        stop: Optional[List[str]],
+        verbose: bool,
+    ) -> str:
         """Generate a chat completion using the OpenAI API or compatible APIs"""
-        debug_mode = os.environ.get('SDK_DEBUG', 'false').lower() == 'true'
+        debug_mode = os.environ.get("SDK_DEBUG", "false").lower() == "true"
         if verbose:
             logger.info(f"Sending request to {self.provider} model {self.model}...")
-            
+
         for attempt in range(self.max_retries):
             try:
                 # Create the completion request
@@ -178,82 +253,110 @@ class LLMClient:
                     messages=messages,
                     temperature=temperature,
                     max_tokens=max_tokens,
-                    top_p=top_p
+                    top_p=top_p,
+                    frequency_penalty=frequency_penalty,
+                    presence_penalty=presence_penalty,
+                    stop=stop,
                 )
-                
+
                 if verbose:
                     logger.info(f"Received response from {self.provider}")
-                
+
                 # Log the full response in debug mode
                 if debug_mode:
-                    if hasattr(response, 'model_dump'):
+                    if hasattr(response, "model_dump"):
                         logger.debug(f"Full response: {response.model_dump()}")
                     else:
                         logger.debug(f"Response type: {type(response)}")
                         logger.debug(f"Response attributes: {dir(response)}")
-                
+
                 # Method 1: Try standard OpenAI API response format
                 try:
-                    if hasattr(response, 'choices') and response.choices is not None and len(response.choices) > 0:
+                    if (
+                        hasattr(response, "choices")
+                        and response.choices is not None
+                        and len(response.choices) > 0
+                    ):
                         choice = response.choices[0]
-                        if hasattr(choice, 'message') and choice.message is not None:
-                            if hasattr(choice.message, 'content') and choice.message.content is not None:
+                        if hasattr(choice, "message") and choice.message is not None:
+                            if (
+                                hasattr(choice.message, "content")
+                                and choice.message.content is not None
+                            ):
                                 return choice.message.content
                 except Exception as e:
                     if verbose:
-                        logger.info(f"Standard format extraction failed: {e}, trying alternative formats...")
-                
+                        logger.info(
+                            f"Standard format extraction failed: {e}, trying alternative formats..."
+                        )
+
                 # Method 2: Llama API format
                 try:
-                    if hasattr(response, 'completion_message') and response.completion_message is not None:
+                    if (
+                        hasattr(response, "completion_message")
+                        and response.completion_message is not None
+                    ):
                         completion = response.completion_message
                         # Handle dictionary case
-                        if isinstance(completion, dict) and 'content' in completion:
-                            content = completion['content']
+                        if isinstance(completion, dict) and "content" in completion:
+                            content = completion["content"]
                             # Different Llama API response formats
-                            if isinstance(content, dict) and 'text' in content:
-                                return content['text']
+                            if isinstance(content, dict) and "text" in content:
+                                return content["text"]
                             elif isinstance(content, str):
                                 return content
                 except Exception as e:
                     if verbose:
-                        logger.info(f"Llama API format extraction failed: {e}, trying dictionary access...")
-                
+                        logger.info(
+                            f"Llama API format extraction failed: {e}, trying dictionary access..."
+                        )
+
                 # Method 3: Try dictionary access for both formats
                 try:
                     # Convert to dictionary if possible
                     response_dict = None
-                    if hasattr(response, 'model_dump'):
+                    if hasattr(response, "model_dump"):
                         response_dict = response.model_dump()
-                    elif hasattr(response, 'dict'):
+                    elif hasattr(response, "dict"):
                         response_dict = response.dict()
-                    elif hasattr(response, '__dict__'):
+                    elif hasattr(response, "__dict__"):
                         response_dict = response.__dict__
                     elif isinstance(response, dict):
                         response_dict = response
-                    
+
                     if response_dict is not None:
                         # Try Llama API format
-                        if 'completion_message' in response_dict and response_dict['completion_message'] is not None:
-                            comp = response_dict['completion_message']
-                            if isinstance(comp, dict) and 'content' in comp:
-                                content = comp['content']
-                                if isinstance(content, dict) and 'text' in content:
-                                    return content['text']
+                        if (
+                            "completion_message" in response_dict
+                            and response_dict["completion_message"] is not None
+                        ):
+                            comp = response_dict["completion_message"]
+                            if isinstance(comp, dict) and "content" in comp:
+                                content = comp["content"]
+                                if isinstance(content, dict) and "text" in content:
+                                    return content["text"]
                                 elif isinstance(content, str):
                                     return content
-                        
+
                         # Try OpenAI format
-                        if 'choices' in response_dict and response_dict['choices'] is not None and len(response_dict['choices']) > 0:
-                            choice = response_dict['choices'][0]
-                            if isinstance(choice, dict) and 'message' in choice:
-                                message = choice['message']
-                                if isinstance(message, dict) and 'content' in message and message['content'] is not None:
-                                    return message['content']
+                        if (
+                            "choices" in response_dict
+                            and response_dict["choices"] is not None
+                            and len(response_dict["choices"]) > 0
+                        ):
+                            choice = response_dict["choices"][0]
+                            if isinstance(choice, dict) and "message" in choice:
+                                message = choice["message"]
+                                if (
+                                    isinstance(message, dict)
+                                    and "content" in message
+                                    and message["content"] is not None
+                                ):
+                                    return message["content"]
                 except Exception as e:
                     if verbose:
                         logger.info(f"Dictionary access failed: {e}")
-                
+
                 # Last resort: Try to print the full response for debugging
                 if verbose or debug_mode:
                     logger.error("Could not extract content from response using any known method")
@@ -263,110 +366,148 @@ class LLMClient:
                             logger.error(f"Key: {k}, Value type: {type(v)}, Value: {v}")
                     # Try to find any content-like fields
                     all_attrs = dir(response)
-                    content_fields = [attr for attr in all_attrs if 'content' in attr.lower() or 'text' in attr.lower() or 'message' in attr.lower()]
+                    content_fields = [
+                        attr
+                        for attr in all_attrs
+                        if "content" in attr.lower()
+                        or "text" in attr.lower()
+                        or "message" in attr.lower()
+                    ]
                     for field in content_fields:
                         try:
-                            logger.error(f"Potential content field '{field}': {getattr(response, field, 'N/A')}")
+                            logger.error(
+                                f"Potential content field '{field}': {getattr(response, field, 'N/A')}"
+                            )
                         except:
                             pass
-                
+
                 raise ValueError(f"Could not extract content from response using any known method")
-                
+
             except Exception as e:
                 if verbose:
-                    logger.error(f"{self.provider} API error (attempt {attempt+1}/{self.max_retries}): {str(e)}")
-                
+                    logger.error(
+                        f"{self.provider} API error (attempt {attempt+1}/{self.max_retries}): {str(e)}"
+                    )
+
                 if attempt == self.max_retries - 1:
-                    raise Exception(f"Failed to get {self.provider} completion after {self.max_retries} attempts: {str(e)}")
-                
+                    raise Exception(
+                        f"Failed to get {self.provider} completion after {self.max_retries} attempts: {str(e)}"
+                    )
+
                 time.sleep(self.retry_delay * (attempt + 1))  # Exponential backoff
-    
-    def _vllm_chat_completion(self, 
-                            messages: List[Dict[str, str]],
-                            temperature: float,
-                            max_tokens: int,
-                            top_p: float,
-                            verbose: bool) -> str:
+
+    def _vllm_chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        frequency_penalty: float,
+        presence_penalty: float,
+        stop: Optional[List[str]],
+        verbose: bool,
+    ) -> str:
         """Generate a chat completion using the VLLM OpenAI-compatible API"""
         data = {
             "model": self.model,
             "messages": messages,
             "temperature": temperature,
             "max_tokens": max_tokens,
-            "top_p": top_p
+            "top_p": top_p,
+            "frequency_penalty": frequency_penalty,
+            "presence_penalty": presence_penalty,
+            "stop": stop,
         }
-        
+
         for attempt in range(self.max_retries):
             try:
                 # Only print if verbose mode is enabled
                 if verbose:
                     logger.info(f"Sending request to vLLM model {self.model}...")
-                
+
                 response = requests.post(
                     f"{self.api_base}/chat/completions",
                     headers={"Content-Type": "application/json"},
                     data=json.dumps(data),
-                    timeout=180  # Increased timeout to 180 seconds
+                    timeout=180,  # Increased timeout to 180 seconds
                 )
-                
+
                 if verbose:
                     logger.info(f"Received response with status code: {response.status_code}")
-                
+
                 response.raise_for_status()
                 return response.json()["choices"][0]["message"]["content"]
-            
+
             except (requests.exceptions.RequestException, KeyError, IndexError) as e:
                 if attempt == self.max_retries - 1:
-                    raise Exception(f"Failed to get vLLM completion after {self.max_retries} attempts: {str(e)}")
+                    raise Exception(
+                        f"Failed to get vLLM completion after {self.max_retries} attempts: {str(e)}"
+                    )
                 time.sleep(self.retry_delay * (attempt + 1))  # Exponential backoff
-    
-    def batch_completion(self, 
-                       message_batches: List[List[Dict[str, str]]], 
-                       temperature: float = None, 
-                       max_tokens: int = None,
-                       top_p: float = None,
-                       batch_size: int = None) -> List[str]:
+
+    def batch_completion(
+        self,
+        message_batches: List[List[Dict[str, str]]],
+        temperature: float = None,
+        max_tokens: int = None,
+        top_p: float = None,
+        batch_size: int = None,
+    ) -> List[str]:
         """Process multiple message sets in batches
-        
+
         Instead of sending requests one at a time, this method processes
         multiple prompts in batches to maximize throughput.
         """
         # Get defaults from config if not provided
-        generation_config = self.config.get('generation', {})
-        temperature = temperature if temperature is not None else generation_config.get('temperature', 0.1)
-        max_tokens = max_tokens if max_tokens is not None else generation_config.get('max_tokens', 4096)
-        top_p = top_p if top_p is not None else generation_config.get('top_p', 0.95)
-        batch_size = batch_size if batch_size is not None else generation_config.get('batch_size', 32)
-        
-        verbose = os.environ.get('SDK_VERBOSE', 'false').lower() == 'true'
-        
-        if self.provider == 'api-endpoint':
-            return self._openai_batch_completion(message_batches, temperature, max_tokens, top_p, batch_size, verbose)
+        generation_config = self.config.get("generation", {})
+        temperature = (
+            temperature if temperature is not None else generation_config.get("temperature", 0.1)
+        )
+        max_tokens = (
+            max_tokens if max_tokens is not None else generation_config.get("max_tokens", 4096)
+        )
+        top_p = top_p if top_p is not None else generation_config.get("top_p", 0.95)
+        batch_size = (
+            batch_size if batch_size is not None else generation_config.get("batch_size", 32)
+        )
+
+        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+
+        if self.provider == "api-endpoint":
+            return self._openai_batch_completion(
+                message_batches, temperature, max_tokens, top_p, batch_size, verbose
+            )
         else:  # Default to vLLM
-            return self._vllm_batch_completion(message_batches, temperature, max_tokens, top_p, batch_size, verbose)
-    
-    async def _process_message_async(self, 
-                                    messages: List[Dict[str, str]], 
-                                    temperature: float,
-                                    max_tokens: int,
-                                    top_p: float,
-                                    verbose: bool,
-                                    debug_mode: bool):
+            return self._vllm_batch_completion(
+                message_batches, temperature, max_tokens, top_p, batch_size, verbose
+            )
+
+    async def _process_message_async(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        verbose: bool,
+        debug_mode: bool,
+    ):
         """Process a single message set asynchronously using the OpenAI API"""
         try:
             from openai import AsyncOpenAI
         except ImportError:
-            raise ImportError("The 'openai' package is required for this functionality. Please install it using 'pip install openai>=1.0.0'.")
-        
+            raise ImportError(
+                "The 'openai' package is required for this functionality. Please install it using 'pip install openai>=1.0.0'."
+            )
+
         # Initialize the async OpenAI client
         client_kwargs = {}
         if self.api_key:
-            client_kwargs['api_key'] = self.api_key
+            client_kwargs["api_key"] = self.api_key
         if self.api_base:
-            client_kwargs['base_url'] = self.api_base
-            
+            client_kwargs["base_url"] = self.api_base
+
         async_client = AsyncOpenAI(**client_kwargs)
-        
+
         for attempt in range(self.max_retries):
             try:
                 # Asynchronously call the API
@@ -375,139 +516,185 @@ class LLMClient:
                     messages=messages,
                     temperature=temperature,
                     max_tokens=max_tokens,
-                    top_p=top_p
+                    top_p=top_p,
                 )
-                
+
                 if verbose:
                     logger.info(f"Received response from {self.provider}")
-                
+
                 # Log the full response in debug mode
                 if debug_mode:
-                    if hasattr(response, 'model_dump'):
+                    if hasattr(response, "model_dump"):
                         logger.debug(f"Full response: {response.model_dump()}")
                     else:
                         logger.debug(f"Response type: {type(response)}")
                         logger.debug(f"Response attributes: {dir(response)}")
-                
+
                 content = None
-                
+
                 # Method 1: Try standard OpenAI API response format
                 try:
-                    if hasattr(response, 'choices') and response.choices is not None and len(response.choices) > 0:
+                    if (
+                        hasattr(response, "choices")
+                        and response.choices is not None
+                        and len(response.choices) > 0
+                    ):
                         choice = response.choices[0]
-                        if hasattr(choice, 'message') and choice.message is not None:
-                            if hasattr(choice.message, 'content') and choice.message.content is not None:
+                        if hasattr(choice, "message") and choice.message is not None:
+                            if (
+                                hasattr(choice.message, "content")
+                                and choice.message.content is not None
+                            ):
                                 content = choice.message.content
                 except Exception as e:
                     if verbose:
-                        logger.info(f"Standard format extraction failed: {e}, trying alternative formats...")
-                
+                        logger.info(
+                            f"Standard format extraction failed: {e}, trying alternative formats..."
+                        )
+
                 # Method 2: Llama API format
                 if content is None:
                     try:
-                        if hasattr(response, 'completion_message') and response.completion_message is not None:
+                        if (
+                            hasattr(response, "completion_message")
+                            and response.completion_message is not None
+                        ):
                             completion = response.completion_message
                             # Handle dictionary case
-                            if isinstance(completion, dict) and 'content' in completion:
-                                content_obj = completion['content']
+                            if isinstance(completion, dict) and "content" in completion:
+                                content_obj = completion["content"]
                                 # Different Llama API response formats
-                                if isinstance(content_obj, dict) and 'text' in content_obj:
-                                    content = content_obj['text']
+                                if isinstance(content_obj, dict) and "text" in content_obj:
+                                    content = content_obj["text"]
                                 elif isinstance(content_obj, str):
                                     content = content_obj
                     except Exception as e:
                         if verbose:
-                            logger.info(f"Llama API format extraction failed: {e}, trying dictionary access...")
-                
+                            logger.info(
+                                f"Llama API format extraction failed: {e}, trying dictionary access..."
+                            )
+
                 # Method 3: Try dictionary access for both formats
                 if content is None:
                     try:
                         # Convert to dictionary if possible
                         response_dict = None
-                        if hasattr(response, 'model_dump'):
+                        if hasattr(response, "model_dump"):
                             response_dict = response.model_dump()
-                        elif hasattr(response, 'dict'):
+                        elif hasattr(response, "dict"):
                             response_dict = response.dict()
-                        elif hasattr(response, '__dict__'):
+                        elif hasattr(response, "__dict__"):
                             response_dict = response.__dict__
                         elif isinstance(response, dict):
                             response_dict = response
-                        
+
                         if response_dict is not None:
                             # Try Llama API format
-                            if 'completion_message' in response_dict and response_dict['completion_message'] is not None:
-                                comp = response_dict['completion_message']
-                                if isinstance(comp, dict) and 'content' in comp:
-                                    content_obj = comp['content']
-                                    if isinstance(content_obj, dict) and 'text' in content_obj:
-                                        content = content_obj['text']
+                            if (
+                                "completion_message" in response_dict
+                                and response_dict["completion_message"] is not None
+                            ):
+                                comp = response_dict["completion_message"]
+                                if isinstance(comp, dict) and "content" in comp:
+                                    content_obj = comp["content"]
+                                    if isinstance(content_obj, dict) and "text" in content_obj:
+                                        content = content_obj["text"]
                                     elif isinstance(content_obj, str):
                                         content = content_obj
-                            
+
                             # Try OpenAI format
-                            if content is None and 'choices' in response_dict and response_dict['choices'] and len(response_dict['choices']) > 0:
-                                choice = response_dict['choices'][0]
-                                if isinstance(choice, dict) and 'message' in choice:
-                                    message = choice['message']
-                                    if isinstance(message, dict) and 'content' in message and message['content'] is not None:
-                                        content = message['content']
+                            if (
+                                content is None
+                                and "choices" in response_dict
+                                and response_dict["choices"]
+                                and len(response_dict["choices"]) > 0
+                            ):
+                                choice = response_dict["choices"][0]
+                                if isinstance(choice, dict) and "message" in choice:
+                                    message = choice["message"]
+                                    if (
+                                        isinstance(message, dict)
+                                        and "content" in message
+                                        and message["content"] is not None
+                                    ):
+                                        content = message["content"]
                     except Exception as e:
                         if verbose:
                             logger.info(f"Dictionary access failed: {e}")
-                
+
                 # If content is still None, print detailed debug info
                 if content is None:
                     if verbose or debug_mode:
-                        logger.error("Could not extract content from response using any known method")
+                        logger.error(
+                            "Could not extract content from response using any known method"
+                        )
                         logger.error(f"Response: {response}")
                         if isinstance(response, dict):
                             for k, v in response.items():
                                 logger.error(f"Key: {k}, Value type: {type(v)}, Value: {v}")
                         # Try to find any content-like fields
                         all_attrs = dir(response)
-                        content_fields = [attr for attr in all_attrs if 'content' in attr.lower() or 'text' in attr.lower() or 'message' in attr.lower()]
+                        content_fields = [
+                            attr
+                            for attr in all_attrs
+                            if "content" in attr.lower()
+                            or "text" in attr.lower()
+                            or "message" in attr.lower()
+                        ]
                         for field in content_fields:
                             try:
-                                logger.error(f"Potential content field '{field}': {getattr(response, field, 'N/A')}")
+                                logger.error(
+                                    f"Potential content field '{field}': {getattr(response, field, 'N/A')}"
+                                )
                             except:
                                 pass
-                    
-                    raise ValueError(f"Could not extract content from response using any known method")
-                
+
+                    raise ValueError(
+                        f"Could not extract content from response using any known method"
+                    )
+
                 return content
-                
+
             except Exception as e:
                 if verbose:
-                    logger.error(f"{self.provider} API error (attempt {attempt+1}/{self.max_retries}): {str(e)}")
-                
+                    logger.error(
+                        f"{self.provider} API error (attempt {attempt+1}/{self.max_retries}): {str(e)}"
+                    )
+
                 if attempt == self.max_retries - 1:
                     return f"ERROR: {str(e)}"
-                
+
                 await asyncio.sleep(self.retry_delay * (attempt + 1))  # Exponential backoff
-    
-    def _openai_batch_completion(self,
-                                message_batches: List[List[Dict[str, str]]],
-                                temperature: float,
-                                max_tokens: int,
-                                top_p: float,
-                                batch_size: int,
-                                verbose: bool) -> List[str]:
+
+    def _openai_batch_completion(
+        self,
+        message_batches: List[List[Dict[str, str]]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        batch_size: int,
+        verbose: bool,
+    ) -> List[str]:
         """Process multiple message sets using the OpenAI API or compatible APIs asynchronously"""
-        debug_mode = os.environ.get('SDK_DEBUG', 'false').lower() == 'true'
+        debug_mode = os.environ.get("SDK_DEBUG", "false").lower() == "true"
         results = []
-        
+
         # Process message batches in chunks to avoid overloading the API
         for i in range(0, len(message_batches), batch_size):
-            batch_chunk = message_batches[i:i+batch_size]
+            batch_chunk = message_batches[i : i + batch_size]
             if verbose:
-                logger.info(f"Processing batch {i//batch_size + 1}/{(len(message_batches) + batch_size - 1) // batch_size} with {len(batch_chunk)} requests")
-            
+                logger.info(
+                    f"Processing batch {i//batch_size + 1}/{(len(message_batches) + batch_size - 1) // batch_size} with {len(batch_chunk)} requests"
+                )
+
             # Import asyncio here to avoid issues if not available
             try:
                 import asyncio
             except ImportError:
-                raise ImportError("The 'asyncio' package is required for batch processing. Please ensure you're using Python 3.7+.")
-            
+                raise ImportError(
+                    "The 'asyncio' package is required for batch processing. Please ensure you're using Python 3.7+."
+                )
+
             # Define async batch processing function
             async def process_batch():
                 tasks = []
@@ -518,50 +705,56 @@ class LLMClient:
                         max_tokens=max_tokens,
                         top_p=top_p,
                         verbose=verbose,
-                        debug_mode=debug_mode
+                        debug_mode=debug_mode,
                     )
                     tasks.append(task)
-                
+
                 # Process all messages in the batch concurrently
                 return await asyncio.gather(*tasks)
-            
+
             # Run the async batch processing
             batch_results = asyncio.run(process_batch())
             results.extend(batch_results)
-            
+
             # Small delay between batches to avoid rate limits
             if i + batch_size < len(message_batches):
                 time.sleep(0.5)
-        
+
         return results
-    
-    def _vllm_batch_completion(self,
-                             message_batches: List[List[Dict[str, str]]],
-                             temperature: float,
-                             max_tokens: int,
-                             top_p: float,
-                             batch_size: int,
-                             verbose: bool) -> List[str]:
+
+    def _vllm_batch_completion(
+        self,
+        message_batches: List[List[Dict[str, str]]],
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        batch_size: int,
+        verbose: bool,
+    ) -> List[str]:
         """Process multiple message sets in batches using vLLM's API"""
         results = []
-        
+
         # Process message batches in chunks to avoid overloading the server
         for i in range(0, len(message_batches), batch_size):
-            batch_chunk = message_batches[i:i+batch_size]
+            batch_chunk = message_batches[i : i + batch_size]
             if verbose:
-                logger.info(f"Processing batch {i//batch_size + 1}/{(len(message_batches) + batch_size - 1) // batch_size} with {len(batch_chunk)} requests")
-            
+                logger.info(
+                    f"Processing batch {i//batch_size + 1}/{(len(message_batches) + batch_size - 1) // batch_size} with {len(batch_chunk)} requests"
+                )
+
             # Create batch request payload for VLLM
             batch_requests = []
             for messages in batch_chunk:
-                batch_requests.append({
-                    "model": self.model,
-                    "messages": messages,
-                    "temperature": temperature,
-                    "max_tokens": max_tokens,
-                    "top_p": top_p
-                })
-            
+                batch_requests.append(
+                    {
+                        "model": self.model,
+                        "messages": messages,
+                        "temperature": temperature,
+                        "max_tokens": max_tokens,
+                        "top_p": top_p,
+                    }
+                )
+
             try:
                 # For now, we run these in parallel with multiple requests
                 batch_results = []
@@ -569,33 +762,33 @@ class LLMClient:
                     # Only print if verbose mode is enabled
                     if verbose:
                         logger.info(f"Sending batch request to vLLM model {self.model}...")
-                    
+
                     response = requests.post(
                         f"{self.api_base}/chat/completions",
                         headers={"Content-Type": "application/json"},
                         data=json.dumps(request_data),
-                        timeout=180  # Increased timeout for batch processing
+                        timeout=180,  # Increased timeout for batch processing
                     )
-                    
+
                     if verbose:
                         logger.info(f"Received response with status code: {response.status_code}")
-                    
+
                     response.raise_for_status()
                     content = response.json()["choices"][0]["message"]["content"]
                     batch_results.append(content)
-                
+
                 results.extend(batch_results)
-                
+
             except (requests.exceptions.RequestException, KeyError, IndexError) as e:
                 raise Exception(f"Failed to process vLLM batch: {str(e)}")
-            
+
             # Small delay between batches
             if i + batch_size < len(message_batches):
                 time.sleep(0.1)
-        
+
         return results
-    
+
     @classmethod
-    def from_config(cls, config_path: Path) -> 'LLMClient':
+    def from_config(cls, config_path: Path) -> "LLMClient":
         """Create a client from configuration file"""
         return cls(config_path=config_path)


### PR DESCRIPTION
## Summary
- introduce `GenerationSettings` dataclass for typed config
- allow environment variable overrides for generation and LLM client
- expose frequency/presence penalties and stop sequences
- add `generate` command to CLI for direct dataset creation
- document new CLI usage and env vars

## Testing
- `black -q datacreek/config_models.py datacreek/utils/config.py datacreek/core/ingest.py datacreek/core/create.py datacreek/generators/qa_generator.py datacreek/generators/cot_generator.py datacreek/generators/vqa_generator.py datacreek/models/llm_client.py datacreek/cli.py datacreek/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685afc7b8c34832fadc0ce9e4043f236