### PR TITLE
Automate container-based deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ NEO4J_PASSWORD=neo4j
 SECRET_KEY=change-me
 API_KEY=change-me
 
+# Container image names for deployment
+IMAGE_NAME=ghcr.io/yourorg/datacreek
+FRONTEND_IMAGE_NAME=ghcr.io/yourorg/datacreek-frontend
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/setup-buildx-action@v3
       - name: Set image name
-        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+          echo "FRONTEND_IMAGE_NAME=${GITHUB_REPOSITORY,,}-frontend" >> $GITHUB_ENV
       - uses: docker/build-push-action@v5
         with:
           push: true
           tags: ghcr.io/${{ env.IMAGE_NAME }}:latest
+      - uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: true
+          tags: ghcr.io/${{ env.FRONTEND_IMAGE_NAME }}:latest
 
   deploy:
     needs: docker-build

--- a/README.md
+++ b/README.md
@@ -133,10 +133,13 @@ docker compose build
 
 ### Deployment
 
-Use the `scripts/deploy.sh` helper to update a remote host after pushing a new
-image. Export `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_KEY` and `DEPLOY_PATH`
-before executing the script. Docker Compose automatically loads variables from
-an optional `.env` file located next to `docker-compose.yml`:
+Use the `scripts/deploy.sh` helper to update a remote host. The CI pipeline
+builds container images for the API, worker and front-end and pushes them to
+GitHub Container Registry. On deployment the remote host pulls the latest
+images defined in `.env` and restarts the stack. Export `DEPLOY_HOST`,
+`DEPLOY_USER`, `DEPLOY_KEY` and `DEPLOY_PATH` before executing the script.
+Docker Compose automatically loads variables from an optional `.env` file
+located next to `docker-compose.yml`:
 
 ```bash
 export DEPLOY_HOST=example.com
@@ -151,7 +154,8 @@ Environment variables can be configured via a `.env` file. See
 
 At a minimum, set `NEO4J_URI`, `NEO4J_USER` and `NEO4J_PASSWORD` so the
 API can reach the Neo4j instance. `DATABASE_URL` defaults to storing the
-SQLite file inside the mounted `./data` directory.
+SQLite file inside the mounted `./data` directory. `IMAGE_NAME` and
+`FRONTEND_IMAGE_NAME` define the container images pulled during deployment.
 
 You can override any value by providing a custom YAML file to the server.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
 
   api:
     build: .
+    image: ${IMAGE_NAME:-datacreek}
     command: uvicorn datacreek.api:app --host 0.0.0.0 --port 8000
     env_file: .env
     volumes:
@@ -29,6 +30,7 @@ services:
 
   worker:
     build: .
+    image: ${IMAGE_NAME:-datacreek}
     command: celery -A datacreek.tasks worker --loglevel=info
     env_file: .env
     volumes:
@@ -39,6 +41,7 @@ services:
   frontend:
     build:
       context: ./frontend
+    image: ${FRONTEND_IMAGE_NAME:-datacreek-frontend}
     ports:
       - "3000:80"
     depends_on:


### PR DESCRIPTION
## Summary
- update docker-compose to pull tagged images
- extend `.env.example` with image variables
- build & push frontend image in CI
- document auto-deploy setup

## Testing
- `pre-commit run --files docker-compose.yml .env.example .github/workflows/ci.yml README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4257dd50832fa04e5dd806cfbe8a