### PR TITLE
Improve generation configuration handling

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -59,6 +59,8 @@ generation:
   num_cot_examples: 5  # Default number of Chain of Thought examples to generate
   num_cot_enhance_examples: null  # Maximum number of conversations to enhance (null = enhance all)
   batch_size: 32     # Number of requests to batch together (for create)
+  summary_temperature: 0.1  # Temperature used when generating summaries
+  summary_max_tokens: 1024   # Max tokens for summary responses
 
 # Content curation parameters
 curate:

--- a/datacreek/api.py
+++ b/datacreek/api.py
@@ -151,6 +151,7 @@ async def generate_async(
             "api_base": params.api_base,
             "config_path": x_config_path,
             "generation": params.generation,
+            "prompts": params.prompts,
         },
     )
     return {"task_id": celery_task.id}

--- a/datacreek/cli.py
+++ b/datacreek/cli.py
@@ -1,49 +1,6 @@
-from pathlib import Path
-from typing import Any, Dict, Optional
-
 import typer
-import uvicorn
 
-from datacreek.core.create import process_file
-
-app_cli = typer.Typer(help="Command line utilities for managing the datacreek application")
-
-
-@app_cli.command()
-def serve(host: str = "127.0.0.1", port: int = 8000):
-    """Run the REST API server."""
-    uvicorn.run("datacreek.api:app", host=host, port=port, reload=True)
-
-
-@app_cli.command()
-def generate(
-    file: Path = typer.Argument(..., exists=True, help="Input file"),
-    output_dir: Path = typer.Option("output", help="Directory for results"),
-    content_type: str = typer.Option("qa", help="Type: qa|summary|cot|cot-enhance"),
-    model: Optional[str] = typer.Option(None, help="Model name"),
-    provider: Optional[str] = typer.Option(None, help="LLM provider"),
-    api_base: Optional[str] = typer.Option(None, help="Custom API base"),
-    temperature: Optional[float] = typer.Option(None, help="Generation temperature"),
-    prompt_file: Optional[Path] = typer.Option(None, help="Override prompt file"),
-    num_pairs: Optional[int] = typer.Option(None, help="Number of pairs/examples"),
-):
-    """Run content generation from the command line."""
-    overrides: Dict[str, Any] = {}
-    if temperature is not None:
-        overrides.setdefault("generation", {})["temperature"] = temperature
-    if prompt_file:
-        overrides.setdefault("prompts", {})[f"{content_type}_generation"] = prompt_file.read_text()
-
-    process_file(
-        file_path=str(file),
-        output_dir=str(output_dir),
-        api_base=api_base,
-        model=model,
-        provider=provider,
-        content_type=content_type,
-        num_pairs=num_pairs,
-        config_overrides=overrides if overrides else None,
-    )
+app_cli = typer.Typer(help="Maintenance utilities for datacreek (database init, tests, upgrades)")
 
 
 @app_cli.command()

--- a/datacreek/config_models.py
+++ b/datacreek/config_models.py
@@ -21,6 +21,8 @@ class GenerationSettings:
     frequency_penalty: float = 0.0
     presence_penalty: float = 0.0
     stop: Optional[List[str]] = field(default=None)
+    summary_temperature: float = 0.1
+    summary_max_tokens: int = 1024
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "GenerationSettings":

--- a/datacreek/core/create.py
+++ b/datacreek/core/create.py
@@ -88,16 +88,7 @@ def process_file(
         output_path = os.path.join(output_dir, f"{base_name}_qa_pairs.json")
         print(f"Saving result to {output_path}")
 
-        # First, let's save a basic test file to confirm the directory is writable
-        test_path = os.path.join(output_dir, "test_write.json")
-        try:
-            with open(test_path, "w", encoding="utf-8") as f:
-                f.write('{"test": "data"}')
-            print(f"Successfully wrote test file to {test_path}")
-        except Exception as e:
-            print(f"Error writing test file: {e}")
-
-        # Now save the actual result
+        # Save the actual result
         try:
             with open(output_path, "w", encoding="utf-8") as f:
                 json.dump(result, f, indent=2)

--- a/datacreek/models/llm_client.py
+++ b/datacreek/models/llm_client.py
@@ -453,6 +453,9 @@ class LLMClient:
         max_tokens: int = None,
         top_p: float = None,
         batch_size: int = None,
+        frequency_penalty: float = None,
+        presence_penalty: float = None,
+        stop: Optional[List[str]] = None,
     ) -> List[str]:
         """Process multiple message sets in batches
 
@@ -471,16 +474,43 @@ class LLMClient:
         batch_size = (
             batch_size if batch_size is not None else generation_config.get("batch_size", 32)
         )
+        frequency_penalty = (
+            frequency_penalty
+            if frequency_penalty is not None
+            else generation_config.get("frequency_penalty", 0.0)
+        )
+        presence_penalty = (
+            presence_penalty
+            if presence_penalty is not None
+            else generation_config.get("presence_penalty", 0.0)
+        )
+        stop = stop if stop is not None else generation_config.get("stop")
 
         verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
 
         if self.provider == "api-endpoint":
             return self._openai_batch_completion(
-                message_batches, temperature, max_tokens, top_p, batch_size, verbose
+                message_batches,
+                temperature,
+                max_tokens,
+                top_p,
+                batch_size,
+                frequency_penalty,
+                presence_penalty,
+                stop,
+                verbose,
             )
         else:  # Default to vLLM
             return self._vllm_batch_completion(
-                message_batches, temperature, max_tokens, top_p, batch_size, verbose
+                message_batches,
+                temperature,
+                max_tokens,
+                top_p,
+                batch_size,
+                frequency_penalty,
+                presence_penalty,
+                stop,
+                verbose,
             )
 
     async def _process_message_async(
@@ -489,6 +519,9 @@ class LLMClient:
         temperature: float,
         max_tokens: int,
         top_p: float,
+        frequency_penalty: float,
+        presence_penalty: float,
+        stop: Optional[List[str]],
         verbose: bool,
         debug_mode: bool,
     ):
@@ -518,6 +551,9 @@ class LLMClient:
                     temperature=temperature,
                     max_tokens=max_tokens,
                     top_p=top_p,
+                    frequency_penalty=frequency_penalty,
+                    presence_penalty=presence_penalty,
+                    stop=stop,
                 )
 
                 if verbose:
@@ -674,6 +710,9 @@ class LLMClient:
         max_tokens: int,
         top_p: float,
         batch_size: int,
+        frequency_penalty: float,
+        presence_penalty: float,
+        stop: Optional[List[str]],
         verbose: bool,
     ) -> List[str]:
         """Process multiple message sets using the OpenAI API or compatible APIs asynchronously"""
@@ -705,6 +744,9 @@ class LLMClient:
                         temperature=temperature,
                         max_tokens=max_tokens,
                         top_p=top_p,
+                        frequency_penalty=frequency_penalty,
+                        presence_penalty=presence_penalty,
+                        stop=stop,
                         verbose=verbose,
                         debug_mode=debug_mode,
                     )
@@ -730,6 +772,9 @@ class LLMClient:
         max_tokens: int,
         top_p: float,
         batch_size: int,
+        frequency_penalty: float,
+        presence_penalty: float,
+        stop: Optional[List[str]],
         verbose: bool,
     ) -> List[str]:
         """Process multiple message sets in batches using vLLM's API"""
@@ -753,6 +798,9 @@ class LLMClient:
                         "temperature": temperature,
                         "max_tokens": max_tokens,
                         "top_p": top_p,
+                        "frequency_penalty": frequency_penalty,
+                        "presence_penalty": presence_penalty,
+                        "stop": stop,
                     }
                 )
 

--- a/datacreek/schemas.py
+++ b/datacreek/schemas.py
@@ -33,6 +33,7 @@ class GenerateParams(BaseModel):
     model: str | None = None
     api_base: str | None = None
     generation: dict | None = None
+    prompts: dict | None = None
 
 
 class DatasetOut(BaseModel):

--- a/datacreek/tasks.py
+++ b/datacreek/tasks.py
@@ -46,6 +46,7 @@ def generate_task(
     api_base: str | None = None,
     config_path: str | None = None,
     generation: dict | None = None,
+    prompts: dict | None = None,
 ) -> dict:
     with SessionLocal() as db:
         src = db.get(SourceData, src_id)
@@ -53,6 +54,11 @@ def generate_task(
             raise RuntimeError("Source not found")
         output_dir = Path("data/generated")
         output_dir.mkdir(parents=True, exist_ok=True)
+        overrides = {}
+        if generation is not None:
+            overrides["generation"] = generation
+        if prompts is not None:
+            overrides["prompts"] = prompts
         out = generate_data(
             None,
             str(output_dir),
@@ -64,7 +70,7 @@ def generate_task(
             False,
             provider=provider,
             document_text=src.content,
-            config_overrides={"generation": generation} if generation else None,
+            config_overrides=overrides if overrides else None,
         )
         ds = create_dataset(db, user_id, src_id, out)
         return {"id": ds.id}


### PR DESCRIPTION
## Summary
- restrict CLI to init-db and test commands only
- add `prompts` override support in API/task pipeline
- list additional environment variables in README
- document CLI's maintenance purpose and show custom prompt example

## Testing
- `black datacreek configs --line-length 100`
- `isort datacreek/cli.py datacreek/api.py datacreek/tasks.py datacreek/schemas.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4d4eac9c832f98c7f908f55d8644