### PR TITLE
Improve generation configuration and profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,40 @@ Most options can also be overridden with environment variables. For example set
 | `GEN_TOP_P` | Default top-p value |
 | `GEN_CHUNK_SIZE` | Override chunk size |
 | `GEN_OVERLAP` | Override overlap between chunks |
+| `GEN_CHUNK_METHOD` | Chunking method (`basic`, `sliding`, `semantic`) |
+| `GEN_SIMILARITY_DROP` | Similarity threshold for semantic splits |
+| `GEN_RETRIEVAL_TOP_K` | Top-k chunks retrieved |
+| `GEN_NUM_PAIRS` | Default number of QA pairs |
+| `GEN_NUM_COT_EXAMPLES` | Default number of CoT examples |
+| `GEN_NUM_COT_ENHANCE_EXAMPLES` | Max conversations to enhance |
 | `GEN_BATCH_SIZE` | Batch size for generation |
 | `GEN_MAX_TOKENS` | Maximum tokens in completions |
 | `GEN_FREQUENCY_PENALTY` | Sampling frequency penalty |
 | `GEN_PRESENCE_PENALTY` | Sampling presence penalty |
-| `GEN_RETRIEVAL_TOP_K` | Top-k chunks retrieved |
 | `GEN_SUMMARY_TEMPERATURE` | Temperature for summaries |
 | `GEN_SUMMARY_MAX_TOKENS` | Max tokens for summaries |
+| `SDK_VERBOSE` | Enable detailed logs |
+| `SDK_DEBUG` | Log full model responses |
+
+### Model Profiles
+
+Define multiple model profiles in your configuration to easily switch between
+providers or models:
+
+```yaml
+models:
+  local-llama:
+    provider: vllm
+    api_base: "http://localhost:8000/v1"
+    model: "meta-llama/Llama-3.3-70B-Instruct"
+  llama-api:
+    provider: api-endpoint
+    api_base: "https://api.llama.com/v1"
+    model: "Llama-4-Maverick-17B-128E-Instruct-FP8"
+```
+
+Select a profile by passing `profile` when calling the API or constructing an
+``LLMClient``.
 
 You can override prompt templates per request by sending a `prompts` object to
 `/tasks/generate`:

--- a/datacreek/api.py
+++ b/datacreek/api.py
@@ -147,10 +147,13 @@ async def generate_async(
         args=[current_user.id, params.src_id, params.content_type, params.num_pairs],
         kwargs={
             "provider": params.provider,
+            "profile": params.profile,
             "model": params.model,
             "api_base": params.api_base,
             "config_path": x_config_path,
-            "generation": params.generation,
+            "generation": params.generation.model_dump(exclude_none=True)
+            if params.generation
+            else None,
             "prompts": params.prompts,
         },
     )

--- a/datacreek/config.yaml
+++ b/datacreek/config.yaml
@@ -30,6 +30,17 @@ vllm:
   model: "meta-llama/Llama-3.3-70B-Instruct" # Default model to use
   max_retries: 3                       # Number of retries for API calls
   retry_delay: 1.0                     # Initial delay between retries (seconds)
+
+# Optional model profiles for quick switching
+models:
+  local-llama:
+    provider: "vllm"
+    api_base: "http://localhost:8000/v1"
+    model: "meta-llama/Llama-3.3-70B-Instruct"
+  llama-api:
+    provider: "api-endpoint"
+    api_base: "https://api.llama.com/v1"
+    model: "Llama-4-Maverick-17B-128E-Instruct-FP8"
   
 # API endpoint configuration
 api-endpoint:

--- a/datacreek/config_models.py
+++ b/datacreek/config_models.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from pydantic import BaseModel
+
 
 @dataclass
 class GenerationSettings:
@@ -35,3 +37,29 @@ class GenerationSettings:
         for key, value in overrides.items():
             if hasattr(self, key) and value is not None:
                 setattr(self, key, value)
+
+
+class GenerationSettingsModel(BaseModel):
+    """Pydantic model for validating generation settings."""
+
+    temperature: float = 0.7
+    top_p: float = 0.95
+    chunk_size: int = 4000
+    overlap: int = 200
+    chunk_method: str = "sliding"
+    similarity_drop: float = 0.3
+    retrieval_top_k: int = 3
+    max_tokens: int = 4096
+    num_pairs: int = 25
+    num_cot_examples: int = 5
+    num_cot_enhance_examples: Optional[int] = None
+    batch_size: int = 32
+    frequency_penalty: float = 0.0
+    presence_penalty: float = 0.0
+    stop: Optional[List[str]] = None
+    summary_temperature: float = 0.1
+    summary_max_tokens: int = 1024
+
+    def to_settings(self) -> GenerationSettings:
+        """Convert to :class:`GenerationSettings`."""
+        return GenerationSettings.from_dict(self.model_dump())

--- a/datacreek/core/create.py
+++ b/datacreek/core/create.py
@@ -32,6 +32,7 @@ def process_file(
     num_pairs: Optional[int] = None,
     verbose: bool = False,
     provider: Optional[str] = None,
+    profile: Optional[str] = None,
     document_text: Optional[str] = None,
     config_overrides: Optional[Dict[str, Any]] = None,
 ) -> str:
@@ -56,7 +57,11 @@ def process_file(
 
     # Initialize LLM client
     client = LLMClient(
-        config_path=config_path, provider=provider, api_base=api_base, model_name=model
+        config_path=config_path,
+        provider=provider,
+        api_base=api_base,
+        model_name=model,
+        profile=profile,
     )
 
     # Debug: Print which provider is being used

--- a/datacreek/schemas.py
+++ b/datacreek/schemas.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel
 
+from datacreek.config_models import GenerationSettingsModel
+
 
 class UserCreate(BaseModel):
     username: str
@@ -30,9 +32,10 @@ class GenerateParams(BaseModel):
     content_type: str = "qa"
     num_pairs: int | None = None
     provider: str | None = None
+    profile: str | None = None
     model: str | None = None
     api_base: str | None = None
-    generation: dict | None = None
+    generation: GenerationSettingsModel | None = None
     prompts: dict | None = None
 
 

--- a/datacreek/tasks.py
+++ b/datacreek/tasks.py
@@ -42,6 +42,7 @@ def generate_task(
     num_pairs: int | None,
     *,
     provider: str | None = None,
+    profile: str | None = None,
     model: str | None = None,
     api_base: str | None = None,
     config_path: str | None = None,
@@ -69,6 +70,7 @@ def generate_task(
             num_pairs,
             False,
             provider=provider,
+            profile=profile,
             document_text=src.content,
             config_overrides=overrides if overrides else None,
         )

--- a/datacreek/utils/config.py
+++ b/datacreek/utils/config.py
@@ -181,6 +181,14 @@ def merge_configs(base_config: Dict[str, Any], override_config: Dict[str, Any]) 
     return result
 
 
+def get_model_profile(config: Dict[str, Any], name: str) -> Dict[str, Any]:
+    """Retrieve a model profile by name."""
+    profiles = config.get("models", {})
+    if name not in profiles:
+        raise KeyError(f"Model profile '{name}' not found")
+    return profiles[name]
+
+
 def get_redis_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return config.get("databases", {}).get("redis", {"host": "localhost", "port": 6379})
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+
+from datacreek.utils.config import load_config, get_generation_config
+from datacreek.config_models import GenerationSettingsModel, GenerationSettings
+
+
+def test_env_override(monkeypatch):
+    cfg = load_config()
+    monkeypatch.setenv("GEN_TEMPERATURE", "0.5")
+    gen_cfg = get_generation_config(cfg)
+    assert gen_cfg.temperature == 0.5
+
+
+def test_generation_settings_model_validation():
+    model = GenerationSettingsModel(temperature=0.4)
+    settings = model.to_settings()
+    assert isinstance(settings, GenerationSettings)
+    assert settings.temperature == 0.4
+    with pytest.raises(Exception):
+        GenerationSettingsModel(temperature="hot")


### PR DESCRIPTION
## Summary
- add `GenerationSettingsModel` for validated generation params
- expose all generation fields in API and Celery tasks
- support model profiles in configuration and LLMClient
- document environment variables and model profiles
- add tests for configuration helpers

## Testing
- `pytest tests/test_config.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_685b60cf8fa4832f9d328e0d6712d2d3