### PR TITLE
Add basic Flask authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install -e . fakeredis flask flask-wtf wtforms pre-commit pytest
+      - run: pip install -e . fakeredis flask flask-wtf flask-login wtforms pre-commit pytest
       - run: pre-commit run --all-files --show-diff-on-failure
       - run: pytest -q
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ __pycache__
 *.pyc
 .env
 .DS_Store
+data/
+frontend/node_modules/
+frontend/dist/
+frontend/package-lock.json
+test_server.db

--- a/README.md
+++ b/README.md
@@ -471,9 +471,18 @@ If you encounter issues during the curation step:
 
 ## Web Interface
 
-The `datacreek.server` module provides a simple Flask UI. Start the server and
-create an account at `/register` to obtain an API key, then log in to access the
-dataset tools. All routes are protected and require authentication.
+A lightweight React application built with Vite lives in the `frontend`
+directory. It uses Tailwind CSS v4 for styling and communicates with the Flask
+API for authentication and dataset operations.
+
+```bash
+cd frontend
+npm install
+npm run dev  # start the Vite dev server
+```
+
+Point your browser to `http://localhost:5173` while the Flask API runs on
+`http://localhost:8000`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -469,6 +469,12 @@ If you encounter issues during the curation step:
   - DOCX: `pip install python-docx`
   - PPTX: `pip install python-pptx`
 
+## Web Interface
+
+The `datacreek.server` module provides a simple Flask UI. Start the server and
+create an account at `/register` to obtain an API key, then log in to access the
+dataset tools. All routes are protected and require authentication.
+
 ## License
 
 Read more about the [License](./LICENSE)

--- a/datacreek/db.py
+++ b/datacreek/db.py
@@ -1,8 +1,8 @@
 import os
 
+from flask_login import UserMixin
 from sqlalchemy import Column, ForeignKey, Integer, String, Text, create_engine
 from sqlalchemy.orm import declarative_base, relationship, sessionmaker
-from flask_login import UserMixin
 
 from datacreek.utils.config import load_config
 

--- a/datacreek/db.py
+++ b/datacreek/db.py
@@ -2,6 +2,7 @@ import os
 
 from sqlalchemy import Column, ForeignKey, Integer, String, Text, create_engine
 from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+from flask_login import UserMixin
 
 from datacreek.utils.config import load_config
 
@@ -26,11 +27,12 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
 
-class User(Base):
+class User(Base, UserMixin):
     __tablename__ = "users"
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String, unique=True, index=True, nullable=False)
     api_key = Column(String, unique=True, index=True, nullable=False)
+    password_hash = Column(String, nullable=False, default="")
 
     sources = relationship("SourceData", back_populates="owner")
     datasets = relationship("Dataset", back_populates="owner")
@@ -61,3 +63,10 @@ class Dataset(Base):
 def init_db() -> None:
     """Create database tables."""
     Base.metadata.create_all(bind=engine)
+
+
+def verify_password(user: User, password: str) -> bool:
+    """Return True if the password matches."""
+    from werkzeug.security import check_password_hash
+
+    return check_password_hash(user.password_hash, password)

--- a/datacreek/server/app.py
+++ b/datacreek/server/app.py
@@ -7,34 +7,12 @@ import os
 from pathlib import Path
 from typing import Dict
 
-from flask import (
-    Flask,
-    abort,
-    flash,
-    jsonify,
-    redirect,
-    render_template,
-    request,
-    url_for,
-)
+from flask import Flask, abort, flash, jsonify, redirect, render_template, request, url_for
+from flask_login import LoginManager, current_user, login_required, login_user, logout_user
 from flask_wtf import FlaskForm
-from flask_login import (
-    LoginManager,
-    current_user,
-    login_required,
-    login_user,
-    logout_user,
-)
-from werkzeug.security import check_password_hash, generate_password_hash
 from neo4j import GraphDatabase
-from wtforms import (
-    FileField,
-    IntegerField,
-    PasswordField,
-    SelectField,
-    StringField,
-    SubmitField,
-)
+from werkzeug.security import check_password_hash, generate_password_hash
+from wtforms import FileField, IntegerField, PasswordField, SelectField, StringField, SubmitField
 from wtforms.validators import DataRequired
 
 from datacreek.core.create import process_file
@@ -43,10 +21,10 @@ from datacreek.core.dataset import DatasetBuilder
 from datacreek.core.ingest import ingest_into_dataset
 from datacreek.core.ingest import process_file as ingest_process_file
 from datacreek.core.knowledge_graph import KnowledgeGraph
-from datacreek.pipelines import DatasetType
-from datacreek.utils.config import get_llm_provider, get_neo4j_config, load_config
 from datacreek.db import SessionLocal, User, init_db
+from datacreek.pipelines import DatasetType
 from datacreek.services import generate_api_key, hash_key
+from datacreek.utils.config import get_llm_provider, get_neo4j_config, load_config
 
 STATIC_DIR = Path(__file__).parents[2] / "frontend" / "dist"
 
@@ -60,6 +38,7 @@ login_manager.login_view = None
 @login_manager.unauthorized_handler
 def unauthorized():
     return jsonify({"error": "login required"}), 401
+
 
 # Set default paths
 DEFAULT_DATA_DIR = Path(__file__).parents[2] / "data"
@@ -171,6 +150,7 @@ class DatasetForm(FlaskForm):
 
 
 # API Routes
+
 
 @app.post("/api/login")
 def api_login():

--- a/datacreek/server/templates/base.html
+++ b/datacreek/server/templates/base.html
@@ -102,16 +102,6 @@
                     <li class="nav-item">
                         <span class="navbar-text me-2">{{ current_user.username }}</span>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
-                    </li>
-                    {% else %}
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('login') }}">Login</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('register') }}">Register</a>
-                    </li>
                     {% endif %}
                 </ul>
             </div>

--- a/datacreek/server/templates/base.html
+++ b/datacreek/server/templates/base.html
@@ -76,6 +76,7 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('index') }}">Home</a>
                     </li>
+                    {% if current_user.is_authenticated %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('ingest') }}">Ingest Document</a>
                     </li>
@@ -94,6 +95,24 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('upload') }}">Upload File</a>
                     </li>
+                    {% endif %}
+                </ul>
+                <ul class="navbar-nav ms-auto">
+                    {% if current_user.is_authenticated %}
+                    <li class="nav-item">
+                        <span class="navbar-text me-2">{{ current_user.username }}</span>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+                    </li>
+                    {% else %}
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('login') }}">Login</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('register') }}">Register</a>
+                    </li>
+                    {% endif %}
                 </ul>
             </div>
         </div>

--- a/datacreek/server/templates/login.html
+++ b/datacreek/server/templates/login.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">{{ form.username.label }} {{ form.username(class='form-control') }}</div>
+  <div class="mb-3">{{ form.password.label }} {{ form.password(class='form-control') }}</div>
+  {{ form.submit(class='btn btn-primary') }}
+</form>
+{% endblock %}

--- a/datacreek/server/templates/register.html
+++ b/datacreek/server/templates/register.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block title %}Register{% endblock %}
+{% block content %}
+<h2>Register</h2>
+{% if api_key %}
+  <div class="alert alert-success">
+    Your account has been created. Save this API key:
+    <code>{{ api_key }}</code>
+  </div>
+  <a href="{{ url_for('login') }}" class="btn btn-primary">Login</a>
+{% else %}
+  <form method="post">
+    {{ form.hidden_tag() }}
+    <div class="mb-3">
+      {{ form.username.label }} {{ form.username(class='form-control') }}
+    </div>
+    <div class="mb-3">
+      {{ form.password.label }} {{ form.password(class='form-control') }}
+    </div>
+    {{ form.submit(class='btn btn-primary') }}
+  </form>
+{% endif %}
+{% endblock %}

--- a/datacreek/services.py
+++ b/datacreek/services.py
@@ -2,9 +2,9 @@ import secrets
 from hashlib import sha256
 
 from sqlalchemy.orm import Session
+from werkzeug.security import generate_password_hash
 
 from datacreek.db import Dataset, SourceData, User
-from werkzeug.security import generate_password_hash
 
 
 def hash_key(api_key: str) -> str:
@@ -21,9 +21,7 @@ def get_user_by_key(db: Session, api_key: str) -> User | None:
     return db.query(User).filter_by(api_key=hashed).first()
 
 
-def create_user(
-    db: Session, username: str, api_key: str, password: str | None = None
-) -> User:
+def create_user(db: Session, username: str, api_key: str, password: str | None = None) -> User:
     user = User(
         username=username,
         api_key=hash_key(api_key),

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Datacreek</title>
   </head>
-  <body>
-    <div id="root"></div>
+  <body class="min-h-screen bg-gray-50">
+    <div id="root" class="p-4"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,10 +9,14 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "@headlessui/react": "^1.7.18"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "tailwindcss": "^4.0.0",
+    "postcss": "^8.4.32",
+    "autoprefixer": "^10.4.16"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "datacreek-frontend",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -16,6 +17,7 @@
     "@vitejs/plugin-react": "^4.0.0",
     "vite": "^5.0.0",
     "tailwindcss": "^4.0.0",
+    "@tailwindcss/postcss": "^4.0.0",
     "postcss": "^8.4.32",
     "autoprefixer": "^10.4.16"
   }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
+import tailwindcss from '@tailwindcss/postcss';
+import autoprefixer from 'autoprefixer';
+
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [tailwindcss(), autoprefixer()],
 };

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,19 +1,67 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 function App() {
-  const [msg, setMsg] = useState('')
+  const [mode, setMode] = useState('login')
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [message, setMessage] = useState('')
+  const [apiKey, setApiKey] = useState('')
 
-  async function createUser() {
-    const res = await fetch('http://localhost:8000/users?username=test&api_key=key', { method: 'POST' })
+  useEffect(() => {
+    fetch('/api/session').then(res => res.json()).then(data => {
+      if (data.username) {
+        setMessage(`Logged in as ${data.username}`)
+      }
+    })
+  }, [])
+
+  async function submit(e) {
+    e.preventDefault()
+    const endpoint = mode === 'login' ? '/api/login' : '/api/register'
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
     const data = await res.json()
-    setMsg(`Created user with ID ${data.id}`)
+    if (res.ok) {
+      setMessage(data.message)
+      if (data.api_key) setApiKey(data.api_key)
+    } else {
+      setMessage(data.error)
+    }
   }
 
   return (
-    <div>
-      <h1>Datacreek</h1>
-      <button onClick={createUser}>Create Test User</button>
-      <p>{msg}</p>
+    <div className="max-w-sm mx-auto mt-10">
+      <h1 className="text-2xl font-bold mb-4 text-center">Datacreek</h1>
+      <form onSubmit={submit} className="space-y-4 bg-white p-4 rounded shadow">
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Username"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          className="w-full border p-2 rounded"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button className="w-full bg-blue-600 text-white py-2 rounded" type="submit">
+          {mode === 'login' ? 'Login' : 'Register'}
+        </button>
+      </form>
+      <p className="text-center mt-2">
+        <button className="text-blue-600" onClick={() => setMode(mode === 'login' ? 'register' : 'login')}>
+          {mode === 'login' ? 'Create account' : 'Have an account? Login'}
+        </button>
+      </p>
+      {apiKey && (
+        <p className="mt-4 text-center text-sm">API key: <code>{apiKey}</code></p>
+      )}
+      {message && <p className="mt-4 text-center">{message}</p>}
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
+import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,jsx,ts,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ dependencies = [
     "scikit-learn>=1.7.0",
     "redis>=5.0.0",
     "neo4j>=5.17.0",
+    "flask>=3.1.0",
+    "flask-login>=0.6.3",
+    "flask-wtf>=1.2.0",
+    "wtforms>=3.0",
 ]
 
 # These fields appear in pip show

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -18,3 +18,5 @@ def test_init_db_creates_tables(tmp_path, monkeypatch):
     insp = inspect(db.engine)
     tables = set(insp.get_table_names())
     assert {"users", "sources", "datasets"}.issubset(tables)
+    cols = [c["name"] for c in insp.get_columns("users")]
+    assert "password_hash" in cols

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+
 from werkzeug.security import generate_password_hash
 
 os.environ["DATABASE_URL"] = "sqlite:///test_server.db"
@@ -9,6 +10,7 @@ if os.path.exists("test_server.db"):
 if "datacreek.db" in sys.modules:
     importlib.reload(sys.modules["datacreek.db"])
 import datacreek.db as db
+
 db.init_db()
 with db.SessionLocal() as session:
     user = db.User(
@@ -22,9 +24,9 @@ with db.SessionLocal() as session:
 import datacreek.server.app as app_module
 from datacreek.core.dataset import DatasetBuilder
 from datacreek.core.knowledge_graph import KnowledgeGraph
+from datacreek.db import verify_password
 from datacreek.pipelines import DatasetType
 from datacreek.server.app import DATASETS, app
-from datacreek.db import verify_password
 
 app.config["WTF_CSRF_ENABLED"] = False
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,8 +1,64 @@
+import importlib
+import os
+import sys
+from werkzeug.security import generate_password_hash
+
+os.environ["DATABASE_URL"] = "sqlite:///test_server.db"
+if os.path.exists("test_server.db"):
+    os.remove("test_server.db")
+if "datacreek.db" in sys.modules:
+    importlib.reload(sys.modules["datacreek.db"])
+import datacreek.db as db
+db.init_db()
+with db.SessionLocal() as session:
+    user = db.User(
+        username="alice",
+        api_key="key",
+        password_hash=generate_password_hash("pw"),
+    )
+    session.add(user)
+    session.commit()
+
 import datacreek.server.app as app_module
 from datacreek.core.dataset import DatasetBuilder
 from datacreek.core.knowledge_graph import KnowledgeGraph
 from datacreek.pipelines import DatasetType
 from datacreek.server.app import DATASETS, app
+from datacreek.db import verify_password
+
+app.config["WTF_CSRF_ENABLED"] = False
+
+
+def _login(client):
+    return client.post(
+        "/login",
+        data={"username": "alice", "password": "pw"},
+        follow_redirects=True,
+    )
+
+
+def test_register_and_login():
+    with app.test_client() as client:
+        res = client.post(
+            "/register",
+            data={"username": "bob", "password": "pw"},
+            follow_redirects=True,
+        )
+        assert b"API key" in res.data
+        # Now login with new user
+        res = client.post(
+            "/login",
+            data={"username": "bob", "password": "pw"},
+            follow_redirects=True,
+        )
+        assert b"Logged in" in res.data
+
+
+def test_login_required_redirect():
+    with app.test_client() as client:
+        res = client.get("/datasets")
+        assert res.status_code == 302
+        assert "/login" in res.headers["Location"]
 
 
 def test_dataset_graph_route():
@@ -12,6 +68,7 @@ def test_dataset_graph_route():
     DATASETS["demo"] = ds
 
     with app.test_client() as client:
+        _login(client)
         res = client.get("/datasets/demo/graph")
         assert res.status_code == 200
         data = res.get_json()
@@ -27,6 +84,7 @@ def test_dataset_search_route():
     DATASETS["demo"] = ds
 
     with app.test_client() as client:
+        _login(client)
         res = client.get("/datasets/demo/search", query_string={"q": "hello"})
         assert res.status_code == 200
         data = res.get_json()
@@ -42,6 +100,7 @@ def test_dataset_ingest_route(tmp_path):
     f.write_text("hello world")
 
     with app.test_client() as client:
+        _login(client)
         res = client.post(
             "/datasets/demo/ingest",
             data={"input_path": str(f), "doc_id": "doc1"},
@@ -71,6 +130,7 @@ def test_save_dataset_neo4j(monkeypatch):
     monkeypatch.setattr(app_module, "get_neo4j_driver", lambda: DummyDriver())
 
     with app.test_client() as client:
+        _login(client)
         res = client.post("/datasets/demo/save_neo4j")
         assert res.status_code == 302
     assert called.get("called")
@@ -93,6 +153,7 @@ def test_load_dataset_neo4j(monkeypatch):
     monkeypatch.setattr(app_module, "get_neo4j_driver", lambda: DummyDriver())
 
     with app.test_client() as client:
+        _login(client)
         res = client.post("/datasets/demo/load_neo4j")
         assert res.status_code == 302
     assert ds.graph is new_graph

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -31,34 +31,31 @@ app.config["WTF_CSRF_ENABLED"] = False
 
 def _login(client):
     return client.post(
-        "/login",
-        data={"username": "alice", "password": "pw"},
-        follow_redirects=True,
+        "/api/login",
+        json={"username": "alice", "password": "pw"},
     )
 
 
 def test_register_and_login():
     with app.test_client() as client:
         res = client.post(
-            "/register",
-            data={"username": "bob", "password": "pw"},
-            follow_redirects=True,
+            "/api/register",
+            json={"username": "bob", "password": "pw"},
         )
-        assert b"API key" in res.data
+        data = res.get_json()
+        assert "api_key" in data
         # Now login with new user
         res = client.post(
-            "/login",
-            data={"username": "bob", "password": "pw"},
-            follow_redirects=True,
+            "/api/login",
+            json={"username": "bob", "password": "pw"},
         )
-        assert b"Logged in" in res.data
+        assert res.status_code == 200
 
 
 def test_login_required_redirect():
     with app.test_client() as client:
         res = client.get("/datasets")
-        assert res.status_code == 302
-        assert "/login" in res.headers["Location"]
+        assert res.status_code == 401
 
 
 def test_dataset_graph_route():


### PR DESCRIPTION
## Summary
- extend `User` model with a hashed password and login mixin
- implement Flask-Login with registration and login pages
- secure server routes with `@login_required`
- show login/logout links in base template
- add tests covering authentication workflow
- show API key after registering and call `init_db()` on server startup

## Testing
- `pip install -e .`
- `pip install flask flask-login werkzeug fakeredis flask-wtf`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b762d1168832fada91a79ad441a62