### PR TITLE
Support multiple generation versions

### DIFF
--- a/datacreek/server/app.py
+++ b/datacreek/server/app.py
@@ -4,9 +4,9 @@ Flask application for the Datacreek web interface.
 
 import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict
-from datetime import datetime, timezone
 
 from flask import Flask, abort, flash, jsonify, redirect, render_template, request, url_for
 from flask_login import LoginManager, current_user, login_required, login_user, logout_user

--- a/datacreek/server/app.py
+++ b/datacreek/server/app.py
@@ -6,6 +6,7 @@ import json
 import os
 from pathlib import Path
 from typing import Dict
+from datetime import datetime, timezone
 
 from flask import Flask, abort, flash, jsonify, redirect, render_template, request, url_for
 from flask_login import LoginManager, current_user, login_required, login_user, logout_user
@@ -73,6 +74,8 @@ def get_neo4j_driver():
 
 # In-memory store of datasets being built
 DATASETS: Dict[str, DatasetBuilder] = {}
+# Store knowledge graphs independently from datasets
+GRAPHS: Dict[str, DatasetBuilder] = {}
 
 
 # Forms
@@ -202,6 +205,209 @@ def api_session():
     return jsonify({"username": None})
 
 
+@app.get("/api/datasets")
+@login_required
+def api_datasets():
+    """Return list of dataset names."""
+    return jsonify(list(DATASETS.keys()))
+
+
+@app.post("/api/datasets")
+@login_required
+def api_create_dataset():
+    data = request.get_json() or {}
+    name = data.get("name")
+    dtype = data.get("dataset_type")
+    graph_name = data.get("graph")
+    if not name or not dtype:
+        abort(400)
+    if name in DATASETS:
+        abort(400, description="Dataset already exists")
+    try:
+        ds = DatasetBuilder(DatasetType(dtype), name=name)
+    except ValueError:
+        abort(400)
+    if graph_name:
+        g = GRAPHS.get(graph_name)
+        if not g:
+            abort(404)
+        ds.graph = KnowledgeGraph.from_dict(g.graph.to_dict())
+        ds.stage = max(ds.stage, 1)
+        ds.history.append(f"Initialized from graph {graph_name}")
+    ds.history.append("Dataset created")
+    DATASETS[name] = ds
+    return jsonify({"message": "Dataset created"})
+
+
+@app.get("/api/datasets/<name>")
+@login_required
+def api_dataset_detail(name: str):
+    """Return dataset details as JSON."""
+    ds = DATASETS.get(name)
+    if not ds:
+        abort(404)
+    nodes = ds.graph.graph
+    num_docs = sum(1 for _, d in nodes.nodes(data=True) if d.get("type") == "document")
+    num_chunks = sum(1 for _, d in nodes.nodes(data=True) if d.get("type") == "chunk")
+    quality = min(100, num_chunks * 5)
+    tips = []
+    if num_docs == 0:
+        tips.append("Add documents to your dataset")
+    if num_chunks == 0:
+        tips.append("Ingest text chunks to improve quality")
+    info = {
+        "name": ds.name,
+        "type": ds.dataset_type.value,
+        "created_at": ds.created_at.isoformat(),
+        "num_nodes": len(nodes.nodes),
+        "num_edges": len(nodes.edges),
+        "num_documents": num_docs,
+        "num_chunks": num_chunks,
+        "quality": quality,
+        "tips": tips,
+        "history": ds.history,
+        "versions": ds.versions,
+        "stage": ds.stage,
+    }
+    return jsonify(info)
+
+
+@app.get("/api/datasets/<name>/content")
+@login_required
+def api_dataset_content(name: str):
+    """Return dataset documents with their chunks."""
+    ds = DATASETS.get(name)
+    if not ds:
+        abort(404)
+    docs = []
+    for node, data in ds.graph.graph.nodes(data=True):
+        if data.get("type") == "document":
+            doc = {
+                "id": node,
+                "source": data.get("source"),
+                "chunks": [],
+            }
+            for cid in ds.graph.get_chunks_for_document(node):
+                cdata = ds.graph.graph.nodes[cid]
+                doc["chunks"].append({"id": cid, "text": cdata.get("text", "")})
+            docs.append(doc)
+    return jsonify(docs)
+
+
+@app.post("/api/datasets/<name>/ingest")
+@login_required
+def api_dataset_ingest(name: str):
+    """Ingest a document into the dataset."""
+    ds = DATASETS.get(name)
+    if not ds:
+        abort(404)
+    data = request.get_json() or {}
+    path = data.get("path")
+    doc_id = data.get("doc_id")
+    if not path:
+        abort(400)
+    ingest_into_dataset(path, ds, doc_id=doc_id, config=config)
+    ds.history.append(f"Ingested {os.path.basename(path)}")
+    ds.stage = max(ds.stage, 1)
+    return jsonify({"message": "ingested"})
+
+
+@app.post("/api/datasets/<name>/generate")
+@login_required
+def api_dataset_generate(name: str):
+    """Record a generation run with optional parameters."""
+    ds = DATASETS.get(name)
+    if not ds:
+        abort(404)
+    data = request.get_json() or {}
+    params = data.get("params", {})
+    ds.versions.append(
+        {
+            "params": params,
+            "time": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    ds.stage = max(ds.stage, 2)
+    ds.history.append(f"Dataset generated (v{len(ds.versions)})")
+    return jsonify({"message": "generated", "version": len(ds.versions)})
+
+
+@app.delete("/api/datasets/<name>/chunks/<cid>")
+@login_required
+def api_delete_chunk(name: str, cid: str):
+    ds = DATASETS.get(name)
+    if not ds:
+        abort(404)
+    ds.remove_chunk(cid)
+    return jsonify({"message": "deleted"})
+
+
+@app.get("/api/datasets/<name>/export")
+@login_required
+def api_export_dataset(name: str):
+    """Return the dataset as JSON and mark it exported."""
+    ds = DATASETS.get(name)
+    if not ds:
+        abort(404)
+    ds.stage = max(ds.stage, 4)
+    ds.history.append("Dataset exported")
+    return jsonify(ds.to_dict())
+
+
+# ---------------------------------------------------------------------------
+# Knowledge Graph API
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/graphs")
+@login_required
+def api_graphs():
+    """Return list of knowledge graph names."""
+    return jsonify(list(GRAPHS.keys()))
+
+
+@app.post("/api/graphs")
+@login_required
+def api_create_graph():
+    data = request.get_json() or {}
+    name = data.get("name")
+    docs = data.get("documents", [])
+    if not name:
+        abort(400)
+    if name in GRAPHS:
+        abort(400, description="Graph already exists")
+    kg_ds = DatasetBuilder(DatasetType.DOCUMENT, name=name)
+    for path in docs:
+        ingest_into_dataset(path, kg_ds, config=config)
+    kg_ds.history.append("Graph created")
+    GRAPHS[name] = kg_ds
+    return jsonify({"message": "graph created"})
+
+
+@app.get("/api/graphs/<name>")
+@login_required
+def api_graph_detail(name: str):
+    ds = GRAPHS.get(name)
+    if not ds:
+        abort(404)
+    graph = ds.graph.graph
+    info = {
+        "name": name,
+        "num_nodes": len(graph.nodes),
+        "num_edges": len(graph.edges),
+    }
+    return jsonify(info)
+
+
+@app.get("/api/graphs/<name>/data")
+@login_required
+def api_graph_data(name: str):
+    ds = GRAPHS.get(name)
+    if not ds:
+        abort(404)
+    return jsonify(ds.graph.to_dict())
+
+
 @app.route("/")
 def index():
     """Serve the front-end application."""
@@ -220,6 +426,7 @@ def datasets():
         name = form.name.data
         ds_type = DatasetType(form.dataset_type.data)
         DATASETS[name] = DatasetBuilder(ds_type, name=name)
+        DATASETS[name].history.append("Dataset created")
         flash("Dataset created", "success")
         return redirect(url_for("dataset_detail", name=name))
     return render_template("datasets.html", datasets=DATASETS, form=form)
@@ -275,6 +482,8 @@ def dataset_ingest(name: str):
 
     try:
         ingest_into_dataset(input_path, ds, doc_id=doc_id, config=config)
+        ds.history.append(f"Ingested {os.path.basename(input_path)}")
+        ds.stage = max(ds.stage, 1)
         flash("Document ingested", "success")
     except Exception as e:  # pragma: no cover - flash message only
         flash(f"Error ingesting document: {e}", "danger")
@@ -294,6 +503,7 @@ def save_dataset_neo4j(name: str):
         abort(500, description="Neo4j not configured")
     ds.graph.to_neo4j(driver)
     driver.close()
+    ds.history.append("Saved to Neo4j")
     flash("Graph saved to Neo4j", "success")
     return redirect(url_for("dataset_detail", name=name))
 
@@ -310,6 +520,7 @@ def load_dataset_neo4j(name: str):
         abort(500, description="Neo4j not configured")
     ds.graph = KnowledgeGraph.from_neo4j(driver)
     driver.close()
+    ds.history.append("Loaded from Neo4j")
     flash("Graph loaded from Neo4j", "success")
     return redirect(url_for("dataset_detail", name=name))
 
@@ -334,6 +545,7 @@ def copy_dataset(name: str):
         counter += 1
         new_name = f"{name}_copy{counter}"
     DATASETS[new_name] = ds.clone(name=new_name)
+    DATASETS[new_name].history.append(f"Copied from {name}")
     flash("Dataset copied", "success")
     return redirect(url_for("dataset_detail", name=new_name))
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,16 +9,27 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@headlessui/react": "^1.7.18",
+    "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-dropdown-menu": "^2.1.15",
+    "@radix-ui/react-icons": "^1.3.2",
+    "@radix-ui/react-navigation-menu": "^1.2.13",
+    "@radix-ui/react-checkbox": "^1.0.4",
+    "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.12",
+    "@radix-ui/themes": "^3.2.1",
+    "react-force-graph-3d": "^1.27.0",
+    "three": "^0.177.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@headlessui/react": "^1.7.18"
+    "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^5.0.0",
-    "tailwindcss": "^4.0.0",
     "@tailwindcss/postcss": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.16",
     "postcss": "^8.4.32",
-    "autoprefixer": "^10.4.16"
+    "tailwindcss": "^4.0.0",
+    "vite": "^5.0.0"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,69 +1,53 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom'
+import Sidebar from './components/Sidebar'
+import Dashboard from './components/Dashboard'
+import DatasetDetail from './components/DatasetDetail'
+import DatasetWizard from './components/DatasetWizard'
+import GraphWizard from './components/GraphWizard'
+import Login from './components/Login'
 
-function App() {
-  const [mode, setMode] = useState('login')
-  const [username, setUsername] = useState('')
-  const [password, setPassword] = useState('')
-  const [message, setMessage] = useState('')
-  const [apiKey, setApiKey] = useState('')
+function AppRoutes() {
+  const [user, setUser] = useState(null)
+  const [menuOpen, setMenuOpen] = useState(true)
+  const navigate = useNavigate()
 
-  useEffect(() => {
+  const fetchSession = () => {
     fetch('/api/session').then(res => res.json()).then(data => {
+      setUser(data.username)
       if (data.username) {
-        setMessage(`Logged in as ${data.username}`)
+        navigate('/')
       }
     })
+  }
+
+  useEffect(() => {
+    fetchSession()
   }, [])
 
-  async function submit(e) {
-    e.preventDefault()
-    const endpoint = mode === 'login' ? '/api/login' : '/api/register'
-    const res = await fetch(endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password })
-    })
-    const data = await res.json()
-    if (res.ok) {
-      setMessage(data.message)
-      if (data.api_key) setApiKey(data.api_key)
-    } else {
-      setMessage(data.error)
-    }
+  if (!user) {
+    return <Login onLoggedIn={fetchSession} />
   }
 
   return (
-    <div className="max-w-sm mx-auto mt-10">
-      <h1 className="text-2xl font-bold mb-4 text-center">Datacreek</h1>
-      <form onSubmit={submit} className="space-y-4 bg-white p-4 rounded shadow">
-        <input
-          className="w-full border p-2 rounded"
-          placeholder="Username"
-          value={username}
-          onChange={e => setUsername(e.target.value)}
-        />
-        <input
-          type="password"
-          className="w-full border p-2 rounded"
-          placeholder="Password"
-          value={password}
-          onChange={e => setPassword(e.target.value)}
-        />
-        <button className="w-full bg-blue-600 text-white py-2 rounded" type="submit">
-          {mode === 'login' ? 'Login' : 'Register'}
-        </button>
-      </form>
-      <p className="text-center mt-2">
-        <button className="text-blue-600" onClick={() => setMode(mode === 'login' ? 'register' : 'login')}>
-          {mode === 'login' ? 'Create account' : 'Have an account? Login'}
-        </button>
-      </p>
-      {apiKey && (
-        <p className="mt-4 text-center text-sm">API key: <code>{apiKey}</code></p>
-      )}
-      {message && <p className="mt-4 text-center">{message}</p>}
+    <div className="flex min-h-screen">
+      <Sidebar open={menuOpen} setOpen={setMenuOpen} user={{ username: user }} />
+      <div className="flex-1 p-4 transition-all">
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/datasets/new" element={<DatasetWizard />} />
+          <Route path="/datasets/:name" element={<DatasetDetail />} />
+          <Route path="/graphs/new" element={<GraphWizard />} />
+        </Routes>
+      </div>
     </div>
   )
 }
 
-export default App
+export default function App() {
+  return (
+    <BrowserRouter>
+      <AppRoutes />
+    </BrowserRouter>
+  )
+}

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ArrowRightIcon } from '@radix-ui/react-icons'
+import { Card, CardHeader, CardContent, Progress, Button } from './ui'
+
+export default function Dashboard() {
+  const [datasets, setDatasets] = useState([])
+
+  useEffect(() => {
+    fetch('/api/datasets')
+      .then(r => r.json())
+      .then(names => Promise.all(names.map(n => fetch(`/api/datasets/${n}`).then(r => r.json()))))
+      .then(setDatasets)
+  }, [])
+
+  const activities = datasets.flatMap(ds =>
+    ds.history.slice(-3).map(msg => ({ name: ds.name, msg }))
+  ).slice(-5).reverse()
+
+  return (
+    <div className="grid md:grid-cols-2 gap-4">
+      <Card>
+        <CardHeader className="flex items-center justify-between">
+          <span>Datasets</span>
+          <Button asChild className="h-8 px-3 py-1 text-sm">
+            <Link to="/datasets/new">New dataset</Link>
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {datasets.length ? (
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              {datasets.map(ds => (
+                <Link
+                  key={ds.name}
+                  to={`/datasets/${ds.name}`}
+                  className="group border rounded-md p-3 flex flex-col gap-2 hover:bg-gray-50 transition-colors"
+                >
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <div className="font-medium">{ds.name}</div>
+                      <div className="text-xs text-gray-500 capitalize">{ds.type}</div>
+                    </div>
+                    <ArrowRightIcon className="w-4 h-4 opacity-0 group-hover:opacity-100 transition-opacity" />
+                  </div>
+                  <Progress value={ds.quality} />
+                  <div className="text-xs text-gray-500 mt-auto">
+                    {new Date(ds.created_at).toLocaleString()}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted">No datasets</p>
+          )}
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>Activity</CardHeader>
+        <CardContent>
+          {activities.length ? (
+            <ul className="space-y-1 text-sm">
+              {activities.map((a, i) => (
+                <li key={i} className="border-b last:border-none pb-1">
+                  <span className="font-medium">{a.name}</span>: {a.msg}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted">No recent activity</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/components/DatasetDetail.jsx
+++ b/frontend/src/components/DatasetDetail.jsx
@@ -1,0 +1,267 @@
+import { useEffect, useState, useRef, useMemo } from "react";
+import { useParams } from "react-router-dom";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@radix-ui/react-tabs";
+import * as Checkbox from "@radix-ui/react-checkbox";
+import { CheckIcon } from "@radix-ui/react-icons";
+import ForceGraph3D from "react-force-graph-3d";
+import { Card, CardHeader, CardContent, Progress, Button } from "./ui";
+
+export default function DatasetDetail() {
+  const { name } = useParams();
+  const [info, setInfo] = useState(null);
+  const [graph, setGraph] = useState(null);
+  const [content, setContent] = useState([]);
+  const [filters, setFilters] = useState({ document: true, chunk: true });
+  const [curQuery, setCurQuery] = useState("");
+  const graphRef = useRef();
+
+  useEffect(() => {
+    fetch(`/api/datasets/${name}`)
+      .then((r) => r.json())
+      .then(setInfo);
+    fetch(`/datasets/${name}/graph`)
+      .then((r) => r.json())
+      .then(setGraph);
+    fetch(`/api/datasets/${name}/content`)
+      .then((r) => r.json())
+      .then(setContent);
+  }, [name]);
+
+  const filteredGraph = useMemo(() => {
+    if (!graph) return null;
+    const nodeSet = new Set(
+      graph.nodes.filter((n) => filters[n.type]).map((n) => n.id),
+    );
+    return {
+      nodes: graph.nodes.filter((n) => nodeSet.has(n.id)),
+      edges: graph.edges.filter(
+        (e) => nodeSet.has(e.source) && nodeSet.has(e.target),
+      ),
+    };
+  }, [graph, filters]);
+
+  const curChunks = useMemo(() => {
+    const all = content.flatMap((d) => d.chunks);
+    if (!curQuery) return all;
+    const q = curQuery.toLowerCase();
+    return all.filter((c) => c.text.toLowerCase().includes(q));
+  }, [content, curQuery]);
+
+  async function deleteChunk(id) {
+    await fetch(`/api/datasets/${name}/chunks/${id}`, { method: "DELETE" });
+    setContent((docs) =>
+      docs.map((doc) => ({
+        ...doc,
+        chunks: doc.chunks.filter((c) => c.id !== id),
+      })),
+    );
+    fetch(`/api/datasets/${name}`)
+      .then((r) => r.json())
+      .then(setInfo);
+  }
+
+  async function exportDataset() {
+    const res = await fetch(`/api/datasets/${name}/export`);
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${name}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    fetch(`/api/datasets/${name}`)
+      .then((r) => r.json())
+      .then(setInfo);
+  }
+
+  if (!info) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">{name}</h2>
+      <Tabs defaultValue="content">
+        <TabsList className="flex gap-2 mb-4">
+          <TabsTrigger value="content">Content</TabsTrigger>
+          {info.stage >= 1 && (
+            <TabsTrigger value="graph">Knowledge Graph</TabsTrigger>
+          )}
+          {info.stage >= 2 && (
+            <TabsTrigger value="curation">Curation</TabsTrigger>
+          )}
+        </TabsList>
+        <TabsContent value="content">
+          <Card className="mb-4">
+            <CardHeader>Info</CardHeader>
+            <CardContent>
+              <dl className="grid grid-cols-2 gap-y-2 text-sm">
+                <dt className="font-medium">Type</dt>
+                <dd>{info.type}</dd>
+                <dt className="font-medium">Created</dt>
+                <dd>{new Date(info.created_at).toLocaleString()}</dd>
+                <dt className="font-medium">Documents</dt>
+                <dd>{info.num_documents}</dd>
+                <dt className="font-medium">Chunks</dt>
+                <dd>{info.num_chunks}</dd>
+              </dl>
+            </CardContent>
+          </Card>
+          <Card className="mb-4">
+            <CardHeader>Content</CardHeader>
+            <CardContent>
+              {content.length ? (
+                <ul className="space-y-2 text-sm">
+                  {content.map((doc) => (
+                    <li key={doc.id} className="border rounded p-2">
+                      <div className="font-medium mb-1">{doc.id}</div>
+                      <ul className="list-disc list-inside space-y-1">
+                        {doc.chunks.map((c) => (
+                          <li key={c.id}>{c.text.slice(0, 80)}</li>
+                        ))}
+                      </ul>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-muted">No content</p>
+              )}
+            </CardContent>
+          </Card>
+          <Card className="mb-4">
+            <CardHeader>Quality</CardHeader>
+            <CardContent>
+              <div className="flex items-center gap-2 mb-2">
+                <Progress value={info.quality} className="flex-1" />
+                <span className="text-sm">{info.quality}</span>
+              </div>
+              {info.tips.length > 0 && (
+                <ul className="list-disc list-inside text-sm text-gray-600 space-y-1">
+                  {info.tips.map((tip, i) => (
+                    <li key={i}>{tip}</li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+          {info.versions.length > 0 && (
+            <Card className="mb-4">
+              <CardHeader>Generations</CardHeader>
+              <CardContent>
+                <ul className="text-sm space-y-1">
+                  {info.versions.map((v, i) => (
+                    <li key={i} className="border-b last:border-none pb-1">
+                      <div className="font-medium">v{i + 1}</div>
+                      <div className="text-xs text-gray-500">
+                        {new Date(v.time).toLocaleString()}
+                      </div>
+                      {Object.keys(v.params || {}).length > 0 && (
+                        <pre className="text-xs bg-gray-50 p-1 rounded mt-1 whitespace-pre-wrap">
+                          {JSON.stringify(v.params, null, 2)}
+                        </pre>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          )}
+          <Card>
+            <CardHeader>History</CardHeader>
+            <CardContent>
+              {info.history.length ? (
+                <ul className="text-sm space-y-1">
+                  {info.history.map((h, i) => (
+                    <li key={i}>{h}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-muted">No history</p>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="graph">
+          {info.stage < 1 ? (
+            <p className="text-sm text-muted">
+              Ingest documents to view the graph.
+            </p>
+          ) : (
+            filteredGraph && (
+              <div className="space-y-2">
+                <div className="flex gap-4 items-center text-sm">
+                  {["document", "chunk"].map((t) => (
+                    <label key={t} className="flex items-center gap-1">
+                      <Checkbox.Root
+                        className="h-4 w-4 border rounded"
+                        checked={filters[t]}
+                        onCheckedChange={(v) =>
+                          setFilters((f) => ({ ...f, [t]: v }))
+                        }
+                      >
+                        <Checkbox.Indicator className="flex items-center justify-center text-white bg-indigo-600">
+                          <CheckIcon className="w-3 h-3" />
+                        </Checkbox.Indicator>
+                      </Checkbox.Root>
+                      {t}
+                    </label>
+                  ))}
+                </div>
+                <div className="h-96">
+                  <ForceGraph3D
+                    ref={graphRef}
+                    graphData={filteredGraph}
+                    nodeLabel={(n) => `${n.id} (${n.type})`}
+                    nodeAutoColorBy="type"
+                  />
+                </div>
+              </div>
+            )
+          )}
+        </TabsContent>
+        <TabsContent value="curation">
+          {info.stage < 2 ? (
+            <p className="text-sm text-muted">
+              Generate dataset before curating.
+            </p>
+          ) : (
+            <Card>
+              <CardHeader>Curation</CardHeader>
+              <CardContent className="space-y-4">
+                <input
+                  className="border rounded p-2 w-full text-sm"
+                  placeholder="Filter chunks"
+                  value={curQuery}
+                  onChange={(e) => setCurQuery(e.target.value)}
+                />
+                <ul className="space-y-2 max-h-64 overflow-auto text-sm">
+                  {curChunks.map((c) => (
+                    <li
+                      key={c.id}
+                      className="border rounded p-2 flex justify-between gap-2"
+                    >
+                      <span className="flex-1">{c.text.slice(0, 80)}</span>
+                      <button
+                        className="text-red-600 text-xs"
+                        onClick={() => deleteChunk(c.id)}
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                  {curChunks.length === 0 && (
+                    <li className="text-gray-500">No chunks</li>
+                  )}
+                </ul>
+              </CardContent>
+            </Card>
+          )}
+        </TabsContent>
+      </Tabs>
+      {info.stage >= 3 && (
+        <div className="mt-4">
+          <Button onClick={exportDataset}>Export Dataset</Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/DatasetWizard.jsx
+++ b/frontend/src/components/DatasetWizard.jsx
@@ -1,0 +1,171 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Card, CardHeader, CardContent, Button } from './ui'
+
+function StepIndicator({ step }) {
+  const steps = ['Dataset', 'Knowledge Graph', 'Generation']
+  return (
+    <ol className="flex justify-center gap-4 mb-4 text-sm">
+      {steps.map((label, i) => (
+        <li key={label} className="flex items-center gap-1">
+          <span
+            className={`w-5 h-5 rounded-full text-white text-xs flex items-center justify-center ${
+              step === i ? 'bg-indigo-600' : 'bg-gray-300'
+            }`}
+          >
+            {i + 1}
+          </span>
+          <span className={step === i ? 'font-medium' : 'text-gray-500'}>{label}</span>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+export default function DatasetWizard() {
+  const [step, setStep] = useState(0)
+  const [name, setName] = useState('')
+  const [type, setType] = useState('qa')
+  const [docs, setDocs] = useState([''])
+  const [graphs, setGraphs] = useState([])
+  const [graphName, setGraphName] = useState('')
+  const [params, setParams] = useState('')
+  const navigate = useNavigate()
+
+  async function submit() {
+    const res = await fetch('/api/datasets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, dataset_type: type, graph: graphName || null })
+    })
+    if (!res.ok) return
+    if (!graphName) {
+      for (const path of docs.filter(Boolean)) {
+        await fetch(`/api/datasets/${name}/ingest`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ path })
+        })
+      }
+    }
+    let genParams = {}
+    try {
+      genParams = params ? JSON.parse(params) : {}
+    } catch {
+      // ignore parse errors
+    }
+    await fetch(`/api/datasets/${name}/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ params: genParams })
+    })
+    navigate(`/datasets/${name}`)
+  }
+
+  function addDocField() {
+    setDocs(d => [...d, ''])
+  }
+
+  function updateDoc(i, value) {
+    setDocs(d => d.map((v, idx) => (idx === i ? value : v)))
+  }
+
+  useEffect(() => {
+    fetch('/api/graphs').then(r => r.json()).then(setGraphs)
+  }, [])
+
+  return (
+    <div className="max-w-xl mx-auto">
+      <Card>
+        <CardHeader>New Dataset</CardHeader>
+        <CardContent>
+          <StepIndicator step={step} />
+          {step === 0 && (
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm mb-1">Name</label>
+                <input
+                  className="w-full border rounded p-2"
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm mb-1">Type</label>
+                <select
+                  className="w-full border rounded p-2"
+                  value={type}
+                  onChange={e => setType(e.target.value)}
+                >
+                  <option value="qa">qa</option>
+                  <option value="tool">tool</option>
+                  <option value="document">document</option>
+                </select>
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button type="button" disabled={!name} onClick={() => setStep(1)}>
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+          {step === 1 && (
+            <div className="space-y-4">
+              {graphs.length > 0 && (
+                <div>
+                  <label className="block text-sm mb-1">Use existing graph</label>
+                  <select
+                    className="w-full border rounded p-2"
+                    value={graphName}
+                    onChange={e => setGraphName(e.target.value)}
+                  >
+                    <option value="">None</option>
+                    {graphs.map(g => (
+                      <option key={g} value={g}>{g}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+              {!graphName && (
+                <div className="space-y-2">
+                  {docs.map((d, i) => (
+                    <input
+                      key={i}
+                      className="w-full border rounded p-2"
+                      placeholder="Document path or URL"
+                      value={d}
+                      onChange={e => updateDoc(i, e.target.value)}
+                    />
+                  ))}
+                  <Button type="button" onClick={addDocField}>Add document</Button>
+                </div>
+              )}
+              <div className="flex justify-between gap-2">
+                <Button type="button" onClick={() => setStep(0)}>Back</Button>
+                <Button type="button" onClick={() => setStep(2)}>Next</Button>
+              </div>
+            </div>
+          )}
+          {step === 2 && (
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm mb-1">Generation parameters</label>
+                <textarea
+                  className="w-full border rounded p-2"
+                  rows="3"
+                  value={params}
+                  onChange={e => setParams(e.target.value)}
+                />
+              </div>
+              <div className="flex justify-between gap-2">
+                <Button type="button" onClick={() => setStep(1)}>Back</Button>
+                <Button type="button" onClick={submit}>Create Dataset</Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/components/GraphWizard.jsx
+++ b/frontend/src/components/GraphWizard.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Card, CardHeader, CardContent, Button } from './ui'
+
+export default function GraphWizard() {
+  const [name, setName] = useState('')
+  const [docs, setDocs] = useState([''])
+  const navigate = useNavigate()
+
+  function addDocField() {
+    setDocs(d => [...d, ''])
+  }
+  function updateDoc(i, value) {
+    setDocs(d => d.map((v, idx) => (idx === i ? value : v)))
+  }
+
+  async function submit() {
+    const res = await fetch('/api/graphs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, documents: docs.filter(Boolean) })
+    })
+    if (res.ok) {
+      navigate('/')
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto">
+      <Card>
+        <CardHeader>Create Knowledge Graph</CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <label className="block text-sm mb-1">Name</label>
+            <input
+              className="w-full border rounded p-2"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            {docs.map((d, i) => (
+              <input
+                key={i}
+                className="w-full border rounded p-2"
+                placeholder="Document path or URL"
+                value={d}
+                onChange={e => updateDoc(i, e.target.value)}
+              />
+            ))}
+            <Button type="button" onClick={addDocField}>Add document</Button>
+          </div>
+          <div className="flex justify-end">
+            <Button type="button" onClick={submit} disabled={!name}>Create</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,0 +1,60 @@
+import { useState } from 'react'
+
+export default function Login({ onLoggedIn }) {
+  const [mode, setMode] = useState('login')
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [message, setMessage] = useState('')
+  const [apiKey, setApiKey] = useState('')
+
+  async function submit(e) {
+    e.preventDefault()
+    const endpoint = mode === 'login' ? '/api/login' : '/api/register'
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+    const data = await res.json()
+    if (res.ok) {
+      setMessage(data.message)
+      if (data.api_key) setApiKey(data.api_key)
+      onLoggedIn()
+    } else {
+      setMessage(data.error)
+    }
+  }
+
+  return (
+    <div className="max-w-sm mx-auto mt-10">
+      <h1 className="text-2xl font-bold mb-4 text-center">Datacreek</h1>
+      <form onSubmit={submit} className="space-y-4 bg-white p-4 rounded shadow">
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Username"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          className="w-full border p-2 rounded"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button className="w-full bg-blue-600 text-white py-2 rounded" type="submit">
+          {mode === 'login' ? 'Login' : 'Register'}
+        </button>
+      </form>
+      <p className="text-center mt-2">
+        <button className="text-blue-600" onClick={() => setMode(mode === 'login' ? 'register' : 'login')}>
+          {mode === 'login' ? 'Create account' : 'Have an account? Login'}
+        </button>
+      </p>
+      {apiKey && (
+        <p className="mt-4 text-center text-sm">API key: <code>{apiKey}</code></p>
+      )}
+      {message && <p className="mt-4 text-center">{message}</p>}
+    </div>
+  )
+}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+import { NavigationMenu, NavigationMenuList, NavigationMenuItem, NavigationMenuTrigger, NavigationMenuContent } from '@radix-ui/react-navigation-menu'
+import { Link } from 'react-router-dom'
+
+export default function Navbar() {
+  const [user, setUser] = useState(null)
+
+  useEffect(() => {
+    fetch('/api/session').then(r => r.json()).then(d => setUser(d.username))
+  }, [])
+
+  const logout = () => {
+    fetch('/api/logout', { method: 'POST' }).then(() => window.location.reload())
+  }
+
+  return (
+    <NavigationMenu className="bg-white shadow px-4 py-2 mb-6">
+      <NavigationMenuList className="flex gap-4">
+        <NavigationMenuItem>
+          <NavigationMenuTrigger className="font-bold">Datacreek</NavigationMenuTrigger>
+          <NavigationMenuContent className="p-2 bg-white rounded-md shadow">
+            <Link className="block px-2 py-1 hover:bg-gray-100 rounded" to="/">Dashboard</Link>
+            <Link className="block px-2 py-1 hover:bg-gray-100 rounded" to="/datasets">Datasets</Link>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        {user && (
+          <NavigationMenuItem className="ml-auto">
+            <NavigationMenuTrigger>{user}</NavigationMenuTrigger>
+            <NavigationMenuContent className="p-2 bg-white rounded-md shadow">
+              <button className="px-2 py-1 hover:bg-gray-100 rounded w-full text-left" onClick={logout}>Logout</button>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        )}
+      </NavigationMenuList>
+    </NavigationMenu>
+  )
+}

--- a/frontend/src/components/NewDataset.jsx
+++ b/frontend/src/components/NewDataset.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Card, CardHeader, CardContent, Button } from './ui'
+
+export default function NewDataset() {
+  const [name, setName] = useState('')
+  const [type, setType] = useState('qa')
+  const [error, setError] = useState('')
+  const navigate = useNavigate()
+
+  async function submit(e) {
+    e.preventDefault()
+    setError('')
+    const res = await fetch('/api/datasets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, dataset_type: type })
+    })
+    if (res.ok) {
+      navigate(`/datasets/${name}`)
+    } else {
+      const data = await res.json().catch(() => ({}))
+      setError(data.error || 'Error creating dataset')
+    }
+  }
+
+  return (
+    <div className="max-w-sm mx-auto">
+      <Card>
+        <CardHeader>New Dataset</CardHeader>
+        <CardContent>
+          <form onSubmit={submit} className="space-y-4">
+            <div>
+              <label className="block text-sm mb-1">Name</label>
+              <input
+                className="w-full border rounded p-2"
+                value={name}
+                onChange={e => setName(e.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm mb-1">Type</label>
+              <select
+                className="w-full border rounded p-2"
+                value={type}
+                onChange={e => setType(e.target.value)}
+              >
+                <option value="qa">qa</option>
+                <option value="tool">tool</option>
+                <option value="document">document</option>
+              </select>
+            </div>
+            {error && <p className="text-red-600 text-sm">{error}</p>}
+            <Button type="submit" className="w-full">Create</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,49 @@
+import { Link } from 'react-router-dom'
+import { HamburgerMenuIcon, AvatarIcon } from '@radix-ui/react-icons'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+
+export default function Sidebar({ open, setOpen, user }) {
+  const email = user?.email || `${user?.username || ''}@example.com`
+  const logout = () => {
+    fetch('/api/logout', { method: 'POST' }).then(() => window.location.reload())
+  }
+  return (
+    <div className={`flex flex-col justify-between bg-white border-r h-screen transition-all duration-300 ${open ? 'w-60' : 'w-16'}`}>
+      <div>
+        <div className="flex items-center justify-between p-4">
+          <Link to="/" className="font-bold text-lg">{open ? 'Datacreek' : 'DC'}</Link>
+          <button onClick={() => setOpen(!open)} aria-label="toggle menu">
+            <HamburgerMenuIcon />
+          </button>
+        </div>
+        <nav className="px-4 space-y-2 text-sm">
+          <Link to="/datasets/new" className="block py-1">Nouveau dataset</Link>
+          <Link to="/graphs/new" className="block py-1">Nouveau graph</Link>
+          <Link to="/marketplace" className="block py-1">Marketplace</Link>
+          <div className="h-px bg-gray-200 my-2" />
+          <Link to="/" className="block py-1">Mes datasets</Link>
+          <Link to="/documents" className="block py-1">Mes documents</Link>
+        </nav>
+      </div>
+      <div className="p-4">
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger asChild>
+            <button className="flex items-center gap-2 w-full" aria-label="Account">
+              <AvatarIcon className="w-6 h-6" />
+              {open && <span className="font-medium">{user?.username}</span>}
+            </button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content side="top" align="start" className="bg-white rounded shadow p-2">
+            <div className="px-2 py-1">
+              <div className="font-medium">{user?.username}</div>
+              <div className="text-xs text-gray-500">{email}</div>
+            </div>
+            <div className="h-px bg-gray-200 my-1" />
+            <DropdownMenu.Item className="px-2 py-1 cursor-pointer">Setting</DropdownMenu.Item>
+            <DropdownMenu.Item className="px-2 py-1 cursor-pointer" onSelect={logout}>Deconnexion</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Root>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui.jsx
+++ b/frontend/src/components/ui.jsx
@@ -1,0 +1,29 @@
+import { Slot } from '@radix-ui/react-slot'
+
+export function Card({ children, className }) {
+  return <div className={`bg-white rounded shadow ${className || ''}`}>{children}</div>
+}
+export function CardHeader({ children, className }) {
+  return <div className={`border-b px-4 py-2 font-semibold ${className || ''}`}>{children}</div>
+}
+export function CardContent({ children, className }) {
+  return <div className={`p-4 ${className || ''}`}>{children}</div>
+}
+
+export function Progress({ value, className }) {
+  return (
+    <div className={`w-full bg-gray-200 rounded h-2 ${className || ''}`}>
+      <div className="bg-green-500 h-2 rounded" style={{ width: `${value}%` }} />
+    </div>
+  )
+}
+
+export function Button({ className, asChild = false, ...props }) {
+  const Comp = asChild ? Slot : 'button'
+  return (
+    <Comp
+      className={`inline-flex items-center justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 disabled:opacity-50 ${className || ''}`}
+      {...props}
+    />
+  )
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,9 +2,13 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
+import '@radix-ui/themes/styles.css'
+import { Theme } from '@radix-ui/themes'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <Theme accentColor="indigo" grayColor="mauve">
+      <App />
+    </Theme>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- store generation versions on DatasetBuilder
- record parameters for each generation via `/api/datasets/<name>/generate`
- expose version list in dataset detail API
- display versions on the dataset detail page
- allow passing JSON params in dataset wizard

## Testing
- `pytest -q`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b8e0672f4832fb0e02022a286e40f