### PR TITLE
Implement hybrid search wrappers

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -721,6 +721,7 @@ chunk_ids = ds.get_chunks_for_document("doc1")
 # Embedding-based retrieval
 ds.graph.index.build()
 retrieved = ds.graph.search_embeddings("hello", k=1)
+retrieved_hybrid = ds.graph.search_hybrid("hello")
 
 # Clone the dataset to try different curation strategies
 ds_copy = ds.clone(name="copy")

--- a/README.md
+++ b/README.md
@@ -360,6 +360,9 @@ ds.add_chunk("doc1", "c1", "hello world")
 print(ds.search("hello"))  # ["c1"]
 print(ds.search_documents("paper"))  # ["doc1"]
 print(ds.get_chunks_for_document("doc1"))  # ["c1"]
+ds.graph.index.build()
+print(ds.graph.search_embeddings("hello", k=1))  # ["c1"]
+print(ds.graph.search_hybrid("hello"))  # ["c1"]
 
 Files can also be ingested directly via the REST API:
 

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -46,6 +46,16 @@ class DatasetBuilder:
     def search_documents(self, query: str) -> list[str]:
         return self.graph.search_documents(query)
 
+    def search_embeddings(self, query: str, k: int = 3, fetch_neighbors: bool = True) -> list[str]:
+        """Wrapper for :meth:`KnowledgeGraph.search_embeddings`."""
+
+        return self.graph.search_embeddings(query, k=k, fetch_neighbors=fetch_neighbors)
+
+    def search_hybrid(self, query: str, k: int = 5) -> list[str]:
+        """Wrapper for :meth:`KnowledgeGraph.search_hybrid`."""
+
+        return self.graph.search_hybrid(query, k=k)
+
     def get_chunks_for_document(self, doc_id: str) -> list[str]:
         return self.graph.get_chunks_for_document(doc_id)
 

--- a/datacreek/core/knowledge_graph.py
+++ b/datacreek/core/knowledge_graph.py
@@ -94,6 +94,28 @@ class KnowledgeGraph:
                 result.append(c)
         return result
 
+    def search_hybrid(self, query: str, k: int = 5) -> list[str]:
+        """Return chunk IDs by combining lexical and embedding search.
+
+        Results from plain text search are returned first followed by
+        semantic matches from the embedding index. Duplicate IDs are
+        removed while preserving order. Only the top ``k`` items are
+        returned.
+        """
+
+        lexical_matches = self.search_chunks(query)
+        embedding_ids = [self.index.get_id(i) for i in self.index.search(query, k)]
+
+        seen = set()
+        results: List[str] = []
+        for cid in lexical_matches + embedding_ids:
+            if cid not in seen:
+                seen.add(cid)
+                results.append(cid)
+            if len(results) >= k:
+                break
+        return results
+
     def get_chunks_for_document(self, doc_id: str) -> list[str]:
         """Return all chunk IDs that belong to the given document."""
 

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -22,6 +22,9 @@ def test_dataset_search_wrappers():
     assert ds.search_chunks("text") == ["c"]
     assert ds.search_documents("d") == ["d"]
     assert ds.get_chunks_for_document("d") == ["c"]
+    ds.graph.index.build()
+    assert ds.search_embeddings("text", k=1) == ["c"]
+    assert ds.search_hybrid("text", k=1) == ["c"]
 
 
 def test_dataset_clone():

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -59,3 +59,16 @@ def test_duplicate_checks():
     kg.add_chunk("d", "c1", "text")
     with pytest.raises(ValueError):
         kg.add_chunk("d", "c1", "text")
+
+
+def test_hybrid_search():
+    kg = KnowledgeGraph()
+    kg.add_document("doc", source="s")
+    kg.add_chunk("doc", "c1", "hello world")
+    kg.add_chunk("doc", "c2", "bonjour le monde")
+    kg.add_chunk("doc", "c3", "greetings planet")
+    kg.index.build()
+
+    results = kg.search_hybrid("hello", k=2)
+    assert results[0] == "c1"
+    assert len(results) == 2


### PR DESCRIPTION
## Summary
- add hybrid and embedding search wrappers to DatasetBuilder
- document hybrid retrieval in README and DOCS
- test new wrappers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c96d3945c832f8b78fa84c774d7b3