### PR TITLE
Improve deep search path info

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -722,6 +722,9 @@ chunk_ids = ds.get_chunks_for_document("doc1")
 ds.graph.index.build()
 retrieved = ds.graph.search_embeddings("hello", k=1)
 retrieved_hybrid = ds.graph.search_hybrid("hello")
+deep = ds.search_with_links("hello", hops=1)
+deep_data = ds.search_with_links_data("hello", hops=1)
+# each item includes hop depth and the traversal path
 
 # Clone the dataset to try different curation strategies
 ds_copy = ds.clone(name="copy")

--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ print(ds.get_chunks_for_document("doc1"))  # ["c1"]
 ds.graph.index.build()
 print(ds.graph.search_embeddings("hello", k=1))  # ["c1"]
 print(ds.graph.search_hybrid("hello"))  # ["c1"]
+print(ds.search_with_links("hello", hops=1))  # ["c1", "c2", ...]
+print(ds.search_with_links_data("hello", hops=1)[0])  # includes depth and path
 
 Files can also be ingested directly via the REST API:
 

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -56,6 +56,26 @@ class DatasetBuilder:
 
         return self.graph.search_hybrid(query, k=k)
 
+    def search_with_links(self, query: str, k: int = 5, hops: int = 1) -> list[str]:
+        """Wrapper for :meth:`KnowledgeGraph.search_with_links`."""
+
+        return self.graph.search_with_links(query, k=k, hops=hops)
+
+    def search_with_links_data(
+        self, query: str, k: int = 5, hops: int = 1
+    ) -> List[Dict[str, Any]]:
+        """Wrapper for :meth:`KnowledgeGraph.search_with_links_data`.
+
+        Returns detailed chunk information, hop depth and traversal path.
+        """
+
+        return self.graph.search_with_links_data(query, k=k, hops=hops)
+
+    def link_similar_chunks(self, k: int = 3) -> None:
+        """Create similarity edges between chunks using embeddings."""
+
+        self.graph.link_similar_chunks(k)
+
     def get_chunks_for_document(self, doc_id: str) -> list[str]:
         return self.graph.get_chunks_for_document(doc_id)
 
@@ -63,7 +83,7 @@ class DatasetBuilder:
         """Remove a chunk node from the dataset graph."""
         if self.graph.graph.has_node(chunk_id):
             preds = list(self.graph.graph.predecessors(chunk_id))
-            self.graph.graph.remove_node(chunk_id)
+            self.graph.remove_chunk(chunk_id)
             if preds:
                 self.history.append(f"Removed chunk {chunk_id} from {preds[0]}")
 
@@ -71,9 +91,7 @@ class DatasetBuilder:
         """Remove a document and all its chunks."""
         if not self.graph.graph.has_node(doc_id):
             return
-        chunks = self.get_chunks_for_document(doc_id)
-        self.graph.graph.remove_nodes_from(chunks)
-        self.graph.graph.remove_node(doc_id)
+        self.graph.remove_document(doc_id)
         self.history.append(f"Removed document {doc_id}")
 
     def clone(self, name: Optional[str] = None) -> "DatasetBuilder":

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -61,9 +61,7 @@ class DatasetBuilder:
 
         return self.graph.search_with_links(query, k=k, hops=hops)
 
-    def search_with_links_data(
-        self, query: str, k: int = 5, hops: int = 1
-    ) -> List[Dict[str, Any]]:
+    def search_with_links_data(self, query: str, k: int = 5, hops: int = 1) -> List[Dict[str, Any]]:
         """Wrapper for :meth:`KnowledgeGraph.search_with_links_data`.
 
         Returns detailed chunk information, hop depth and traversal path.

--- a/datacreek/core/knowledge_graph.py
+++ b/datacreek/core/knowledge_graph.py
@@ -73,7 +73,11 @@ class KnowledgeGraph:
         """Delete ``chunk_id`` from the graph and index."""
         if not self.graph.has_node(chunk_id):
             return
-        preds = [p for p in self.graph.predecessors(chunk_id) if self.graph.edges[p, chunk_id].get("relation") == "has_chunk"]
+        preds = [
+            p
+            for p in self.graph.predecessors(chunk_id)
+            if self.graph.edges[p, chunk_id].get("relation") == "has_chunk"
+        ]
         doc_id = preds[0] if preds else None
         self.graph.remove_node(chunk_id)
         self.index.remove(chunk_id)
@@ -199,7 +203,9 @@ class KnowledgeGraph:
             # traverse both successors and predecessors so that similar chunks
             # are discovered regardless of edge direction
             for neighbor in list(self.graph.successors(node)) + list(self.graph.predecessors(node)):
-                rel = self.graph.edges.get((node, neighbor)) or self.graph.edges.get((neighbor, node))
+                rel = self.graph.edges.get((node, neighbor)) or self.graph.edges.get(
+                    (neighbor, node)
+                )
                 if not rel:
                     continue
                 if rel.get("relation") not in {"next_chunk", "similar_to"}:
@@ -212,9 +218,7 @@ class KnowledgeGraph:
 
         return results
 
-    def search_with_links_data(
-        self, query: str, k: int = 5, hops: int = 1
-    ) -> List[Dict[str, Any]]:
+    def search_with_links_data(self, query: str, k: int = 5, hops: int = 1) -> List[Dict[str, Any]]:
         """Return enriched search results expanding through graph links.
 
         Each item contains the chunk ``id``, its ``text``, owning ``document``
@@ -224,18 +228,14 @@ class KnowledgeGraph:
 
         seeds = self.search_hybrid(query, k)
         seen = set(seeds)
-        queue: List[tuple[str, int, List[str]]] = [
-            (cid, 0, [cid]) for cid in seeds
-        ]
+        queue: List[tuple[str, int, List[str]]] = [(cid, 0, [cid]) for cid in seeds]
         results: List[tuple[str, int, List[str]]] = queue.copy()
 
         while queue:
             node, depth, path = queue.pop(0)
             if depth >= hops:
                 continue
-            for nb in list(self.graph.successors(node)) + list(
-                self.graph.predecessors(node)
-            ):
+            for nb in list(self.graph.successors(node)) + list(self.graph.predecessors(node)):
                 rel = self.graph.edges.get((node, nb)) or self.graph.edges.get((nb, node))
                 if not rel or rel.get("relation") not in {"next_chunk", "similar_to"}:
                     continue

--- a/datacreek/core/knowledge_graph.py
+++ b/datacreek/core/knowledge_graph.py
@@ -30,9 +30,66 @@ class KnowledgeGraph:
             source = self.graph.nodes[doc_id].get("source")
         if self.graph.has_node(chunk_id):
             raise ValueError(f"Chunk already exists: {chunk_id}")
+
+        # Determine the sequence index based on existing chunks
+        existing_chunks = self.get_chunks_for_document(doc_id)
+        sequence = len(existing_chunks)
+
+        # Add the chunk node and relation to the document
         self.graph.add_node(chunk_id, type="chunk", text=text, source=source)
-        self.graph.add_edge(doc_id, chunk_id, relation="has_chunk")
+        self.graph.add_edge(
+            doc_id,
+            chunk_id,
+            relation="has_chunk",
+            sequence=sequence,
+        )
+
+        # Connect to the previous chunk to keep the original order
+        if existing_chunks:
+            prev_chunk = existing_chunks[-1]
+            self.graph.add_edge(prev_chunk, chunk_id, relation="next_chunk")
+
         self.index.add(chunk_id, text)
+
+    def _renumber_chunks(self, doc_id: str) -> None:
+        """Update sequence numbers and next_chunk links for ``doc_id``."""
+        chunks = self.get_chunks_for_document(doc_id)
+        # Update sequence numbers
+        for i, cid in enumerate(chunks):
+            if (doc_id, cid) in self.graph.edges:
+                self.graph.edges[doc_id, cid]["sequence"] = i
+
+        # Remove existing next_chunk edges for this document
+        for cid in chunks:
+            for succ in list(self.graph.successors(cid)):
+                if self.graph.edges[cid, succ].get("relation") == "next_chunk":
+                    self.graph.remove_edge(cid, succ)
+
+        # Recreate next_chunk edges
+        for a, b in zip(chunks, chunks[1:]):
+            self.graph.add_edge(a, b, relation="next_chunk")
+
+    def remove_chunk(self, chunk_id: str) -> None:
+        """Delete ``chunk_id`` from the graph and index."""
+        if not self.graph.has_node(chunk_id):
+            return
+        preds = [p for p in self.graph.predecessors(chunk_id) if self.graph.edges[p, chunk_id].get("relation") == "has_chunk"]
+        doc_id = preds[0] if preds else None
+        self.graph.remove_node(chunk_id)
+        self.index.remove(chunk_id)
+        if doc_id:
+            self._renumber_chunks(doc_id)
+
+    def remove_document(self, doc_id: str) -> None:
+        """Remove a document and all its chunks."""
+        if not self.graph.has_node(doc_id):
+            return
+        chunks = self.get_chunks_for_document(doc_id)
+        for cid in chunks:
+            self.index.remove(cid)
+        self.graph.remove_nodes_from(chunks)
+        if self.graph.has_node(doc_id):
+            self.graph.remove_node(doc_id)
 
     def search(self, query: str, node_type: str = "chunk") -> list[str]:
         """Return node IDs of the given type matching the query.
@@ -116,14 +173,124 @@ class KnowledgeGraph:
                 break
         return results
 
+    def search_with_links(self, query: str, k: int = 5, hops: int = 1) -> list[str]:
+        """Return chunk IDs related to a query and expand via graph links.
+
+        Parameters
+        ----------
+        query:
+            Text to search for.
+        k:
+            Number of initial matches to retrieve via :meth:`search_hybrid`.
+        hops:
+            How many hops to traverse through ``next_chunk`` or ``similar_to``
+            relations starting from the initial results.
+        """
+
+        seeds = self.search_hybrid(query, k)
+        seen = set(seeds)
+        results = list(seeds)
+        queue = [(cid, 0) for cid in seeds]
+
+        while queue:
+            node, depth = queue.pop(0)
+            if depth >= hops:
+                continue
+            # traverse both successors and predecessors so that similar chunks
+            # are discovered regardless of edge direction
+            for neighbor in list(self.graph.successors(node)) + list(self.graph.predecessors(node)):
+                rel = self.graph.edges.get((node, neighbor)) or self.graph.edges.get((neighbor, node))
+                if not rel:
+                    continue
+                if rel.get("relation") not in {"next_chunk", "similar_to"}:
+                    continue
+                if neighbor in seen:
+                    continue
+                seen.add(neighbor)
+                results.append(neighbor)
+                queue.append((neighbor, depth + 1))
+
+        return results
+
+    def search_with_links_data(
+        self, query: str, k: int = 5, hops: int = 1
+    ) -> List[Dict[str, Any]]:
+        """Return enriched search results expanding through graph links.
+
+        Each item contains the chunk ``id``, its ``text``, owning ``document``
+        and ``source`` plus the hop ``depth`` and the ``path`` from the initial
+        result used to reach it.
+        """
+
+        seeds = self.search_hybrid(query, k)
+        seen = set(seeds)
+        queue: List[tuple[str, int, List[str]]] = [
+            (cid, 0, [cid]) for cid in seeds
+        ]
+        results: List[tuple[str, int, List[str]]] = queue.copy()
+
+        while queue:
+            node, depth, path = queue.pop(0)
+            if depth >= hops:
+                continue
+            for nb in list(self.graph.successors(node)) + list(
+                self.graph.predecessors(node)
+            ):
+                rel = self.graph.edges.get((node, nb)) or self.graph.edges.get((nb, node))
+                if not rel or rel.get("relation") not in {"next_chunk", "similar_to"}:
+                    continue
+                if nb in seen:
+                    continue
+                seen.add(nb)
+                new_path = path + [nb]
+                results.append((nb, depth + 1, new_path))
+                queue.append((nb, depth + 1, new_path))
+
+        out: List[Dict[str, Any]] = []
+        for cid, depth, path in results:
+            node = self.graph.nodes[cid]
+            doc_id = None
+            for pred in self.graph.predecessors(cid):
+                if self.graph.edges[pred, cid].get("relation") == "has_chunk":
+                    doc_id = pred
+                    break
+            out.append(
+                {
+                    "id": cid,
+                    "text": node.get("text"),
+                    "document": doc_id,
+                    "source": node.get("source"),
+                    "depth": depth,
+                    "path": path,
+                }
+            )
+        return out
+
+    def link_similar_chunks(self, k: int = 3) -> None:
+        """Add ``similar_to`` edges between semantically close chunks."""
+
+        neighbors = self.index.nearest_neighbors(k, return_distances=True)
+        for src, nb_list in neighbors.items():
+            for tgt, score in nb_list:
+                if src == tgt:
+                    continue
+                if (
+                    self.graph.has_edge(src, tgt)
+                    and self.graph.edges[src, tgt].get("relation") == "similar_to"
+                ):
+                    continue
+                self.graph.add_edge(src, tgt, relation="similar_to", similarity=score)
+
     def get_chunks_for_document(self, doc_id: str) -> list[str]:
         """Return all chunk IDs that belong to the given document."""
 
-        return [
-            tgt
-            for src, tgt, data in self.graph.edges(doc_id, data=True)
+        edges = [
+            (data.get("sequence", i), tgt)
+            for i, (src, tgt, data) in enumerate(self.graph.edges(doc_id, data=True))
             if data.get("relation") == "has_chunk"
         ]
+        edges.sort(key=lambda x: x[0])
+        return [t for _, t in edges]
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize the graph to a dictionary."""
@@ -214,9 +381,17 @@ class KnowledgeGraph:
                 kg.graph.add_node(node_id, type=node_type, **props)
                 if node_type == "chunk" and "text" in props:
                     kg.index.add(node_id, props["text"])
-            edges = tx.run("MATCH (a)-[r]->(b) RETURN a.id AS src, type(r) AS rel, b.id AS tgt")
+            edges = tx.run(
+                "MATCH (a)-[r]->(b) RETURN a.id AS src, type(r) AS rel, b.id AS tgt, r as rel_props"
+            )
             for record in edges:
-                kg.graph.add_edge(record["src"], record["tgt"], relation=record["rel"].lower())
+                props = dict(record["rel_props"])
+                kg.graph.add_edge(
+                    record["src"],
+                    record["tgt"],
+                    relation=record["rel"].lower(),
+                    **props,
+                )
 
         with driver.session() as session:
             session.execute_read(_read)

--- a/datacreek/utils/retrieval.py
+++ b/datacreek/utils/retrieval.py
@@ -23,6 +23,17 @@ class EmbeddingIndex:
         self.ids.append(chunk_id)
         self.texts.append(text)
 
+    def remove(self, chunk_id: str) -> None:
+        """Remove a chunk from the index."""
+        if chunk_id not in self.ids:
+            return
+        idx = self.ids.index(chunk_id)
+        del self.ids[idx]
+        del self.texts[idx]
+        self._vectorizer = None
+        self._matrix = None
+        self._nn = None
+
     def build(self) -> None:
         if not self.texts:
             return
@@ -30,6 +41,47 @@ class EmbeddingIndex:
         self._matrix = self._vectorizer.transform(self.texts)
         self._nn = NearestNeighbors(metric="cosine")
         self._nn.fit(self._matrix)
+
+    def _ensure_index(self) -> None:
+        """Build the index if it has not been constructed yet."""
+        if self._vectorizer is None or self._matrix is None or self._nn is None:
+            self.build()
+
+    def nearest_neighbors(
+        self, k: int = 3, return_distances: bool = False
+    ) -> Dict[str, List[tuple[str, float]] | List[str]]:
+        """Return the ``k`` nearest neighbors for each text ID.
+
+        Parameters
+        ----------
+        k:
+            Number of neighbors to return.
+        return_distances:
+            If ``True``, return a list of ``(id, similarity)`` tuples for each
+            chunk. Similarity is ``1 - cosine_distance``.
+        """
+
+        self._ensure_index()
+        if not self.texts or self._matrix is None:
+            return {}
+
+        distances, indices = self._nn.kneighbors(
+            self._matrix, n_neighbors=min(k + 1, len(self.ids))
+        )
+        neighbors: Dict[str, List[tuple[str, float]] | List[str]] = {}
+        for idx, (dist_row, neigh_row) in enumerate(zip(distances, indices)):
+            items: List[tuple[str, float]] | List[str] = []
+            for dist, i in zip(dist_row, neigh_row):
+                if i == idx:
+                    continue
+                if len(items) >= k:
+                    break
+                if return_distances:
+                    items.append((self.ids[i], 1 - float(dist)))
+                else:
+                    items.append(self.ids[i])
+            neighbors[self.ids[idx]] = items
+        return neighbors
 
     def search(self, query: str, k: int = 5) -> List[int]:
         if not self.texts:

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -141,4 +141,3 @@ def test_search_with_links_data_wrapper():
         if r["id"] == "c2":
             assert r["depth"] == 1
             assert r["path"] == ["c1", "c2"]
-

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -157,4 +157,3 @@ def test_search_with_links_data():
     second = next(r for r in results if r["id"] == "c2")
     assert second["depth"] == 1
     assert second["path"] == ["c1", "c2"]
-

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -72,3 +72,89 @@ def test_hybrid_search():
     results = kg.search_hybrid("hello", k=2)
     assert results[0] == "c1"
     assert len(results) == 2
+
+
+def test_chunk_order_and_next_relations():
+    kg = KnowledgeGraph()
+    kg.add_document("doc", source="s")
+    kg.add_chunk("doc", "c1", "t1")
+    kg.add_chunk("doc", "c2", "t2")
+    kg.add_chunk("doc", "c3", "t3")
+
+    # edges should have sequence numbers
+    assert kg.graph.edges["doc", "c1"]["sequence"] == 0
+    assert kg.graph.edges["doc", "c2"]["sequence"] == 1
+    assert kg.graph.edges["doc", "c3"]["sequence"] == 2
+
+    # next_chunk relations preserve order
+    assert ("c1", "c2") in kg.graph.edges
+    assert kg.graph.edges["c1", "c2"]["relation"] == "next_chunk"
+    assert kg.get_chunks_for_document("doc") == ["c1", "c2", "c3"]
+
+
+def test_serialization_preserves_order():
+    kg = KnowledgeGraph()
+    kg.add_document("d", source="s")
+    kg.add_chunk("d", "c1", "first")
+    kg.add_chunk("d", "c2", "second")
+
+    data = kg.to_dict()
+    loaded = KnowledgeGraph.from_dict(data)
+    assert loaded.get_chunks_for_document("d") == ["c1", "c2"]
+
+
+def test_link_similar_chunks():
+    kg = KnowledgeGraph()
+    kg.add_document("doc", source="s")
+    kg.add_chunk("doc", "c1", "hello world")
+    kg.add_chunk("doc", "c2", "hello planet")
+    kg.add_chunk("doc", "c3", "unrelated text")
+
+    kg.index.build()
+    kg.link_similar_chunks(k=1)
+
+    assert ("c1", "c2") in kg.graph.edges
+    edge = kg.graph.edges["c1", "c2"]
+    assert edge["relation"] == "similar_to"
+    assert 0 < edge["similarity"] <= 1
+
+
+def test_search_with_links():
+    kg = KnowledgeGraph()
+    kg.add_document("doc", source="s")
+    kg.add_chunk("doc", "c1", "hello world")
+    kg.add_chunk("doc", "c2", "hello planet")
+    kg.add_chunk("doc", "c3", "different text")
+
+    kg.index.build()
+    kg.link_similar_chunks(k=1)
+
+    # search should return c1 and also c2 via the similarity edge
+    results = kg.search_with_links("hello", k=1, hops=1)
+    assert "c1" in results
+    assert "c2" in results
+
+
+def test_search_with_links_data():
+    kg = KnowledgeGraph()
+    kg.add_document("doc", source="s")
+    kg.add_chunk("doc", "c1", "hello world")
+    kg.add_chunk("doc", "c2", "hello planet")
+    kg.add_chunk("doc", "c3", "different text")
+
+    kg.index.build()
+    kg.link_similar_chunks(k=1)
+
+    results = kg.search_with_links_data("hello", k=1, hops=1)
+    ids = [r["id"] for r in results]
+    assert "c1" in ids
+    assert "c2" in ids
+    first = next(r for r in results if r["id"] == "c1")
+    assert first["text"] == "hello world"
+    assert first["document"] == "doc"
+    assert first["depth"] == 0
+    assert first["path"] == ["c1"]
+    second = next(r for r in results if r["id"] == "c2")
+    assert second["depth"] == 1
+    assert second["path"] == ["c1", "c2"]
+


### PR DESCRIPTION
## Summary
- expose traversal path in `search_with_links_data`
- update DatasetBuilder wrapper and docs for new field
- verify returned paths in tests

## Testing
- `pip install -e .`
- `pip install fakeredis`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c9e9b9b6c832f9fd2ea7803b3cc75