### PR TITLE
Improve graph embedding utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ print(ds.graph.search_hybrid("hello"))  # ["c1"]
 print(ds.search_with_links("hello", hops=1))  # ["c1", "c2", ...]
 print(ds.search_with_links_data("hello", hops=1)[0])  # includes depth and path
 ds.link_similar_chunks()         # connect semantically close chunks
+ds.update_embeddings()           # materialize embeddings on graph nodes
 
 # After ingestion you can further enrich the graph:
 ds.consolidate_schema()        # normalize labels

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -116,6 +116,11 @@ class DatasetBuilder:
     def score_trust(self) -> None:
         self.graph.score_trust()
 
+    def update_embeddings(self, node_type: str = "chunk") -> None:
+        """Materialize embeddings for nodes of ``node_type``."""
+
+        self.graph.update_embeddings(node_type=node_type)
+
     def get_chunks_for_document(self, doc_id: str) -> list[str]:
         return self.graph.get_chunks_for_document(doc_id)
 

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -155,3 +155,14 @@ def test_link_entity_source_and_trust():
     edge = ds.graph.graph.edges["c1", "e1"]
     assert edge["provenance"] == "src"
     assert "trust" in edge
+
+
+def test_update_embeddings_wrapper():
+    ds = DatasetBuilder(DatasetType.TEXT)
+    ds.add_document("d", source="s")
+    ds.add_chunk("d", "c1", "hello world")
+    ds.graph.index.build()
+    ds.update_embeddings()
+    emb = ds.graph.graph.nodes["c1"].get("embedding")
+    assert isinstance(emb, list)
+    assert len(emb) > 0

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -208,3 +208,14 @@ def test_edge_provenance_and_trust():
     assert "trust" in kg.graph.edges["d", "c1"]
     assert kg.graph.edges["c1", "e"]["provenance"] == "src"
     assert "trust" in kg.graph.edges["c1", "e"]
+
+
+def test_update_embeddings():
+    kg = KnowledgeGraph()
+    kg.add_document("d", source="s")
+    kg.add_chunk("d", "c1", "hello world")
+    kg.index.build()
+    kg.update_embeddings()
+    emb = kg.graph.nodes["c1"].get("embedding")
+    assert isinstance(emb, list)
+    assert len(emb) > 0


### PR DESCRIPTION
## Summary
- add ability to materialize embeddings for nodes
- persist embeddings when `_node_embedding` is called
- test embedding persistence via `update_embeddings`
- expose `update_embeddings` on `DatasetBuilder`
- test dataset wrapper for embedding updates
- document embedding materialization in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cec18f79c832f82d626c21dcf946a