### PR TITLE
Add fact conflict tools in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This toolkit simplifies the journey of:
 - Using a LLM (vLLM or any local/external API endpoint) to generate examples
 - Converting your existing files to fine-tuning friendly formats
 - Creating synthetic datasets
+- Extracting standalone facts into a knowledge graph
 - Supporting various formats of post-training fine-tuning
 
 # How does Datacreek offer it?
@@ -367,6 +368,8 @@ print(ds.search_with_links("hello", hops=1))  # ["c1", "c2", ...]
 print(ds.search_with_links_data("hello", hops=1)[0])  # includes depth and path
 ds.link_similar_chunks()         # connect semantically close chunks
 ds.update_embeddings()           # materialize embeddings on graph nodes
+ds.extract_facts()               # populate fact nodes using an LLM or regex
+print(ds.find_conflicting_facts())  # check for conflicting information
 
 # After ingestion you can further enrich the graph:
 ds.consolidate_schema()        # normalize labels
@@ -392,6 +395,8 @@ You can then enrich and query the graph via the API:
 curl -X POST localhost:8000/api/datasets/example/similarity -H "X-API-Key: <key>"
 curl -X GET  localhost:8000/api/datasets/example/search_hybrid?q=hello -H "X-API-Key: <key>"
 curl -X GET  localhost:8000/api/datasets/example/search_links?q=hello\&hops=1 -H "X-API-Key: <key>"
+curl -X POST localhost:8000/api/datasets/example/extract_facts -H "X-API-Key: <key>"
+curl -X GET  localhost:8000/api/datasets/example/conflicts -H "X-API-Key: <key>"
 ```
 
 The `path` is resolved using the configured input directories so relative

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -181,3 +181,10 @@ prompts:
     
     Original conversations:
     {conversations}
+
+  # Fact extraction prompt
+  fact_extraction: |
+    Extract standalone facts from the text in JSON format. Each fact must have
+    "subject", "predicate" and "object" fields. Only return the JSON array.
+    Text:
+    {text}

--- a/datacreek/__init__.py
+++ b/datacreek/__init__.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 """Datacreek: tools for preparing synthetic data for LLM fine-tuning."""
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 from .config_models import GenerationSettings
 from .core.dataset import DatasetBuilder
@@ -23,6 +23,7 @@ from .pipelines import (
     get_pipelines_for_training,
     get_trainings_for_dataset,
 )
+from .utils.fact_extraction import extract_facts
 
 __all__ = [
     "GenerationPipeline",
@@ -38,5 +39,6 @@ __all__ = [
     "ingest_file",
     "to_kg",
     "ingest_into_dataset",
+    "extract_facts",
     "GenerationSettings",
 ]

--- a/datacreek/config.yaml
+++ b/datacreek/config.yaml
@@ -193,6 +193,13 @@ prompts:
     Original conversations:
     {conversations}
 
+  # Fact extraction prompt
+  fact_extraction: |
+    Extract standalone facts from the text in JSON format. Each fact must have
+    "subject", "predicate" and "object" fields. Only return the JSON array.
+    Text:
+    {text}
+
 # Database configuration
 databases:
   redis:

--- a/datacreek/core/knowledge_graph.py
+++ b/datacreek/core/knowledge_graph.py
@@ -34,6 +34,40 @@ class KnowledgeGraph:
         if text:
             self.index.add(entity_id, text)
 
+    def add_fact(
+        self,
+        subject: str,
+        predicate: str,
+        obj: str,
+        fact_id: Optional[str] = None,
+        *,
+        source: Optional[str] = None,
+    ) -> str:
+        """Insert a standalone fact and link corresponding entities."""
+
+        fact_id = fact_id or f"fact_{len(self.graph.nodes)}"
+        if self.graph.has_node(fact_id):
+            raise ValueError(f"Fact already exists: {fact_id}")
+
+        # ensure entity nodes exist
+        if not self.graph.has_node(subject):
+            self.add_entity(subject, subject, source)
+        if not self.graph.has_node(obj):
+            self.add_entity(obj, obj, source)
+
+        self.graph.add_node(
+            fact_id,
+            type="fact",
+            subject=subject,
+            predicate=predicate,
+            object=obj,
+            source=source,
+        )
+        self.graph.add_edge(fact_id, subject, relation="subject", provenance=source)
+        self.graph.add_edge(fact_id, obj, relation="object", provenance=source)
+        self.graph.add_edge(subject, obj, relation=predicate, provenance=source)
+        return fact_id
+
     def link_entity(
         self,
         node_id: str,

--- a/datacreek/utils/__init__.py
+++ b/datacreek/utils/__init__.py
@@ -10,6 +10,7 @@ from .config import (
     load_config,
     merge_configs,
 )
+from .fact_extraction import extract_facts
 from .llm_processing import convert_to_conversation_format, parse_qa_pairs, parse_ratings
 from .text import extract_json_from_text, split_into_chunks
 
@@ -27,4 +28,5 @@ __all__ = [
     "parse_qa_pairs",
     "parse_ratings",
     "convert_to_conversation_format",
+    "extract_facts",
 ]

--- a/datacreek/utils/fact_extraction.py
+++ b/datacreek/utils/fact_extraction.py
@@ -1,0 +1,57 @@
+import json
+import re
+from typing import Dict, List, Optional
+
+from datacreek.models.llm_client import LLMClient
+from datacreek.utils.config import get_prompt, load_config
+
+
+def extract_facts(
+    text: str,
+    client: Optional[LLMClient] = None,
+    *,
+    config: Optional[dict] = None,
+) -> List[Dict[str, str]]:
+    """Extract atomic facts from ``text`` using an LLM if provided.
+
+    The returned items follow the schema ``{"subject", "predicate", "object"}``.
+    When ``client`` is ``None`` a naive regex extractor is used for testing.
+    """
+    if client is None:
+        pattern = r"([A-Za-z ]+) is (?:the )?([A-Za-z ]+)\."
+        pattern2 = r"([A-Za-z ]+) was born in ([A-Za-z ]+)\."
+        facts = []
+        for m in re.finditer(pattern, text):
+            subj = m.group(1).strip()
+            obj = m.group(2).strip()
+            facts.append({"subject": subj, "predicate": "is", "object": obj})
+        for m in re.finditer(pattern2, text):
+            subj = m.group(1).strip()
+            obj = m.group(2).strip()
+            facts.append({"subject": subj, "predicate": "born_in", "object": obj})
+        return facts
+
+    cfg = config or load_config()
+    prompt = get_prompt(cfg, "fact_extraction")
+    messages = [
+        {"role": "system", "content": prompt},
+        {"role": "user", "content": text},
+    ]
+    response = client.chat_completion(messages, temperature=0)
+    try:
+        data = json.loads(response)
+    except Exception:
+        return []
+    out = []
+    if isinstance(data, list):
+        for item in data:
+            if not all(k in item for k in ("subject", "predicate", "object")):
+                continue
+            out.append(
+                {
+                    "subject": item["subject"],
+                    "predicate": item["predicate"],
+                    "object": item["object"],
+                }
+            )
+    return out

--- a/tests/test_fact_extraction.py
+++ b/tests/test_fact_extraction.py
@@ -1,0 +1,22 @@
+def test_extract_facts_regex():
+    from datacreek.utils.fact_extraction import extract_facts
+
+    text = "Berlin is the capital of Germany. Beethoven was born in Bonn."
+    facts = extract_facts(text)
+    objs = {f["object"] for f in facts}
+    assert "Bonn" in objs
+    assert any("Germany" in o for o in objs)
+
+
+def test_dataset_extract_facts():
+    from datacreek import DatasetBuilder, DatasetType
+
+    ds = DatasetBuilder(DatasetType.TEXT)
+    ds.add_document("d", source="src")
+    ds.add_chunk("d", "c1", "Paris is the capital of France.")
+    ds.extract_facts()
+    fact_nodes = [n for n, d in ds.graph.graph.nodes(data=True) if d.get("type") == "fact"]
+    assert len(fact_nodes) == 1
+    edges = ds.graph.graph.edges(fact_nodes[0])
+    assert any(ds.graph.graph.edges[e]["relation"] == "subject" for e in edges)
+


### PR DESCRIPTION
## Summary
- fix conflicting facts detection logic
- report fact counts from the API
- add fact extraction and conflict buttons in the frontend
- document new dataset endpoints
- bump package version
- mention fact extraction in README overview

## Testing
- `black frontend datacreek`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf573c520832fb3944a556bb5e4d7