### PR TITLE
Improve graph fact retrieval methods

### DIFF
--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -31,12 +31,25 @@ class DatasetBuilder:
         """Insert a document node in the dataset graph."""
         self.graph.add_document(doc_id, source)
 
+    def add_section(
+        self, doc_id: str, section_id: str, title: str | None = None, source: Optional[str] = None
+    ) -> None:
+        """Insert a section node for ``doc_id``."""
+
+        self.graph.add_section(doc_id, section_id, title=title, source=source)
+
     def add_chunk(
-        self, doc_id: str, chunk_id: str, text: str, source: Optional[str] = None
+        self,
+        doc_id: str,
+        chunk_id: str,
+        text: str,
+        source: Optional[str] = None,
+        *,
+        section_id: str | None = None,
     ) -> None:
         """Insert a chunk node in the dataset graph."""
 
-        self.graph.add_chunk(doc_id, chunk_id, text, source)
+        self.graph.add_chunk(doc_id, chunk_id, text, source, section_id=section_id)
 
     def add_entity(self, entity_id: str, text: str, source: Optional[str] = None) -> None:
         """Insert an entity node."""
@@ -64,15 +77,42 @@ class DatasetBuilder:
     def search_documents(self, query: str) -> list[str]:
         return self.graph.search_documents(query)
 
-    def search_embeddings(self, query: str, k: int = 3, fetch_neighbors: bool = True) -> list[str]:
+    def search_entities(self, query: str) -> list[str]:
+        """Return entity IDs matching ``query``."""
+
+        return self.graph.search(query, node_type="entity")
+
+    def search_sections(self, query: str) -> list[str]:
+        """Return section IDs whose title or ID matches ``query``."""
+
+        return self.graph.search(query, node_type="section")
+
+    def search_facts(self, query: str) -> list[str]:
+        """Return fact IDs whose subject, predicate or object matches the query."""
+
+        return self.graph.search(query, node_type="fact")
+
+    def search_embeddings(
+        self,
+        query: str,
+        k: int = 3,
+        fetch_neighbors: bool = True,
+        *,
+        node_type: str = "chunk",
+    ) -> list[str]:
         """Wrapper for :meth:`KnowledgeGraph.search_embeddings`."""
 
-        return self.graph.search_embeddings(query, k=k, fetch_neighbors=fetch_neighbors)
+        return self.graph.search_embeddings(
+            query,
+            k=k,
+            fetch_neighbors=fetch_neighbors,
+            node_type=node_type,
+        )
 
-    def search_hybrid(self, query: str, k: int = 5) -> list[str]:
+    def search_hybrid(self, query: str, k: int = 5, *, node_type: str = "chunk") -> list[str]:
         """Wrapper for :meth:`KnowledgeGraph.search_hybrid`."""
 
-        return self.graph.search_hybrid(query, k=k)
+        return self.graph.search_hybrid(query, k=k, node_type=node_type)
 
     def search_with_links(self, query: str, k: int = 5, hops: int = 1) -> list[str]:
         """Wrapper for :meth:`KnowledgeGraph.search_with_links`."""
@@ -206,6 +246,91 @@ class DatasetBuilder:
 
     def get_chunks_for_document(self, doc_id: str) -> list[str]:
         return self.graph.get_chunks_for_document(doc_id)
+
+    def get_sections_for_document(self, doc_id: str) -> list[str]:
+        return self.graph.get_sections_for_document(doc_id)
+
+    def get_chunks_for_section(self, section_id: str) -> list[str]:
+        return self.graph.get_chunks_for_section(section_id)
+
+    def get_section_for_chunk(self, chunk_id: str) -> str | None:
+        return self.graph.get_section_for_chunk(chunk_id)
+
+    def get_next_chunk(self, chunk_id: str) -> str | None:
+        """Return the chunk following ``chunk_id`` if any."""
+
+        return self.graph.get_next_chunk(chunk_id)
+
+    def get_previous_chunk(self, chunk_id: str) -> str | None:
+        """Return the chunk preceding ``chunk_id`` if any."""
+
+        return self.graph.get_previous_chunk(chunk_id)
+
+    def get_next_section(self, section_id: str) -> str | None:
+        """Return the section following ``section_id`` if any."""
+
+        return self.graph.get_next_section(section_id)
+
+    def get_previous_section(self, section_id: str) -> str | None:
+        """Return the section preceding ``section_id`` if any."""
+
+        return self.graph.get_previous_section(section_id)
+
+    def get_facts_for_chunk(self, chunk_id: str) -> list[str]:
+        """Return fact IDs attached to ``chunk_id``."""
+
+        return self.graph.get_facts_for_chunk(chunk_id)
+
+    def get_facts_for_document(self, doc_id: str) -> list[str]:
+        """Return fact IDs related to any chunk of ``doc_id``."""
+
+        return self.graph.get_facts_for_document(doc_id)
+
+    def get_chunks_for_fact(self, fact_id: str) -> list[str]:
+        """Return chunk IDs referencing ``fact_id``."""
+
+        return self.graph.get_chunks_for_fact(fact_id)
+
+    def get_entities_for_fact(self, fact_id: str) -> list[str]:
+        """Return entity IDs linked as subject or object of ``fact_id``."""
+
+        return self.graph.get_entities_for_fact(fact_id)
+
+    def get_facts_for_entity(self, entity_id: str) -> list[str]:
+        """Return fact IDs connected to ``entity_id``."""
+
+        return self.graph.get_facts_for_entity(entity_id)
+
+    def get_chunks_for_entity(self, entity_id: str) -> list[str]:
+        """Return chunk IDs mentioning ``entity_id``."""
+
+        return self.graph.get_chunks_for_entity(entity_id)
+
+    def get_entities_for_chunk(self, chunk_id: str) -> list[str]:
+        """Return entity IDs mentioned in ``chunk_id``."""
+
+        return self.graph.get_entities_for_chunk(chunk_id)
+
+    def get_entities_for_document(self, doc_id: str) -> list[str]:
+        """Return entity IDs mentioned anywhere in ``doc_id``."""
+
+        return self.graph.get_entities_for_document(doc_id)
+
+    def find_facts(
+        self,
+        *,
+        subject: str | None = None,
+        predicate: str | None = None,
+        object: str | None = None,
+    ) -> list[str]:
+        """Wrapper for :meth:`KnowledgeGraph.find_facts`."""
+
+        return self.graph.find_facts(subject=subject, predicate=predicate, object=object)
+
+    def get_documents_for_entity(self, entity_id: str) -> list[str]:
+        """Return document IDs where ``entity_id`` is mentioned."""
+
+        return self.graph.get_documents_for_entity(entity_id)
 
     def remove_chunk(self, chunk_id: str) -> None:
         """Remove a chunk node from the dataset graph."""

--- a/datacreek/parsers/pdf_parser.py
+++ b/datacreek/parsers/pdf_parser.py
@@ -11,25 +11,57 @@ from .base import BaseParser
 
 
 class PDFParser(BaseParser):
-    """Parser for PDF documents"""
+    """Parser for PDF documents."""
 
-    def parse(self, file_path: str) -> str:
-        """Parse a PDF file into plain text
+    def parse(self, file_path: str, *, high_res: bool = False, ocr: bool = False) -> str:
+        """Parse ``file_path`` and return extracted text.
 
-        Args:
-            file_path: Path to the PDF file
-
-        Returns:
-            Extracted text from the PDF
+        Parameters
+        ----------
+        file_path:
+            Path to the PDF file.
+        high_res:
+            If ``True`` and :mod:`llamaparse` is available, use it for
+            high resolution parsing of complex layouts.
+        ocr:
+            When ``True`` additionally run OCR on each page using
+            :mod:`pytesseract`.
         """
-        try:
-            from pdfminer.high_level import extract_text
+        text = ""
+        if high_res:
+            try:
+                from llamaparse import LlamaParse
 
-            return extract_text(file_path)
-        except ImportError:
-            raise ImportError(
-                "pdfminer.six is required for PDF parsing. Install it with: pip install pdfminer.six"
-            )
+                parser = LlamaParse()
+                text = parser.parse(file_path)
+            except ImportError as exc:
+                raise ImportError(
+                    "llamaparse is required for high resolution parsing. Install it with: pip install llamaparse"
+                ) from exc
+        else:
+            try:
+                from pdfminer.high_level import extract_text
+
+                text = extract_text(file_path)
+            except ImportError as exc:
+                raise ImportError(
+                    "pdfminer.six is required for PDF parsing. Install it with: pip install pdfminer.six"
+                ) from exc
+
+        if ocr:
+            try:
+                import pytesseract
+                from pdf2image import convert_from_path
+
+                images = convert_from_path(file_path)
+                ocr_text = "\n".join(pytesseract.image_to_string(img) for img in images)
+                text += "\n" + ocr_text
+            except ImportError as exc:
+                raise ImportError(
+                    "pdf2image and pytesseract are required for OCR mode. Install them with: pip install pdf2image pytesseract"
+                ) from exc
+
+        return text
 
     def save(self, content: str, output_path: str) -> None:
         """Save the extracted text to a file

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -1,0 +1,47 @@
+import builtins
+import sys
+import types
+
+import pytest
+
+from datacreek.parsers.pdf_parser import PDFParser
+
+
+def test_pdf_parser_basic(monkeypatch, tmp_path):
+    pdf = tmp_path / "sample.pdf"
+    pdf.write_bytes(b"%PDF-1.4 test")
+    dummy = types.SimpleNamespace(extract_text=lambda p: "hello")
+    monkeypatch.setitem(sys.modules, "pdfminer.high_level", dummy)
+    parser = PDFParser()
+    assert parser.parse(str(pdf)) == "hello"
+
+
+def test_pdf_parser_high_res_missing(monkeypatch, tmp_path):
+    pdf = tmp_path / "sample.pdf"
+    pdf.write_bytes(b"%PDF-1.4 test")
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "llamaparse":
+            raise ImportError("not installed")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    parser = PDFParser()
+    with pytest.raises(ImportError):
+        parser.parse(str(pdf), high_res=True)
+
+
+def test_pdf_parser_ocr(monkeypatch, tmp_path):
+    pdf = tmp_path / "sample.pdf"
+    pdf.write_bytes(b"%PDF-1.4 test")
+    dummy_pdfminer = types.SimpleNamespace(extract_text=lambda p: "")
+    monkeypatch.setitem(sys.modules, "pdfminer.high_level", dummy_pdfminer)
+    mod_pdf2image = types.ModuleType("pdf2image")
+    mod_pytesseract = types.ModuleType("pytesseract")
+    mod_pdf2image.convert_from_path = lambda p: ["img"]
+    mod_pytesseract.image_to_string = lambda img: "ocr"
+    monkeypatch.setitem(sys.modules, "pdf2image", mod_pdf2image)
+    monkeypatch.setitem(sys.modules, "pytesseract", mod_pytesseract)
+    parser = PDFParser()
+    assert "ocr" in parser.parse(str(pdf), ocr=True)


### PR DESCRIPTION
## Summary
- add section nodes with ordering and next_section relations
- allow chunks to be associated with sections
- expose section helpers via DatasetBuilder
- test new section structure and fix search_with_links_data test
- support searching facts with embeddings and hybrid search
- restrict embedding and hybrid search by node type
- ensure similarity edges only connect chunk nodes
- expose new helpers to retrieve entities for chunks, documents, and reverse lookups
- test entity lookup helpers
- add navigation helpers for getting next/previous chunk
- expose entity and section search methods
- add section navigation helpers
- add high-resolution and OCR options to PDF parser
- test PDF parser options
- add fact lookup utilities
- **add helpers to lookup chunks and entities for a given fact**

## Testing
- `pre-commit run --files datacreek/core/knowledge_graph.py datacreek/core/dataset.py tests/test_dataset_builder.py tests/test_knowledge_graph.py` *(fails: `pre-commit` not installed)*
- `pytest tests/test_dataset_builder.py tests/test_knowledge_graph.py -q` *(fails: missing dependencies such as fakeredis, requests)*


------
https://chatgpt.com/codex/tasks/task_e_685d25e11330832fa7144ab276db127b