### PR TITLE
Add unstructured HTML parsing

### DIFF
--- a/datacreek/api.py
+++ b/datacreek/api.py
@@ -133,7 +133,16 @@ async def ingest_async(
     payload: SourceCreate,
     current_user: User = Depends(get_current_user),
 ) -> dict:
-    celery_task = ingest_task.apply_async(args=[current_user.id, payload.path])
+    celery_task = ingest_task.apply_async(
+        args=[current_user.id, payload.path],
+        kwargs={
+            "high_res": payload.high_res or False,
+            "ocr": payload.ocr or False,
+            "use_unstructured": payload.use_unstructured,
+            "extract_entities": payload.extract_entities or False,
+            "extract_facts": payload.extract_facts or False,
+        },
+    )
     return {"task_id": celery_task.id}
 
 

--- a/datacreek/config.yaml
+++ b/datacreek/config.yaml
@@ -54,6 +54,8 @@ api-endpoint:
 ingest:
   default_format: "txt"  # Default output format for parsed files
   youtube_captions: "auto"  # Options: "auto", "manual" - caption preference
+  # Use unstructured as the default parser for supported formats
+  use_unstructured: true
 
 # LLM generation parameters
 generation:
@@ -64,7 +66,7 @@ generation:
   stop: null              # Optional stop sequences
   chunk_size: 4000   # Size of text chunks for processing
   overlap: 200       # Overlap between chunks to maintain context
-  chunk_method: sliding  # Options: basic|sliding|semantic
+  chunk_method: sliding  # Options: basic|sliding|semantic|contextual|summary
   similarity_drop: 0.3   # Threshold for semantic splitting
   retrieval_top_k: 3     # Number of chunks to retrieve for QA generation
   max_tokens: 4096   # Maximum tokens in LLM responses

--- a/datacreek/config_models.py
+++ b/datacreek/config_models.py
@@ -12,6 +12,7 @@ class GenerationSettings:
     top_p: float = 0.95
     chunk_size: int = 4000
     overlap: int = 200
+    # basic|sliding|semantic|contextual|summary
     chunk_method: str = "sliding"
     similarity_drop: float = 0.3
     retrieval_top_k: int = 3
@@ -46,6 +47,7 @@ class GenerationSettingsModel(BaseModel):
     top_p: float = 0.95
     chunk_size: int = 4000
     overlap: int = 200
+    # basic|sliding|semantic|contextual|summary
     chunk_method: str = "sliding"
     similarity_drop: float = 0.3
     retrieval_top_k: int = 3

--- a/datacreek/db.py
+++ b/datacreek/db.py
@@ -44,6 +44,9 @@ class SourceData(Base):
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     path = Column(String, nullable=False)
     content = Column(Text, nullable=False)
+    # optional serialized lists of entities and facts extracted during ingest
+    entities = Column(Text, nullable=True)
+    facts = Column(Text, nullable=True)
 
     owner = relationship("User", back_populates="sources")
     datasets = relationship("Dataset", back_populates="source")

--- a/datacreek/generators/qa_generator.py
+++ b/datacreek/generators/qa_generator.py
@@ -102,7 +102,7 @@ class QAGenerator:
             similarity_drop=similarity_drop,
         )
 
-        if self.kg and chunk_method in {"sliding", "semantic"}:
+        if self.kg and chunk_method in {"sliding", "semantic", "contextual"}:
             # index chunks in knowledge graph if provided
             for i, chunk in enumerate(chunks):
                 cid = f"chunk-{i}"

--- a/datacreek/parsers/__init__.py
+++ b/datacreek/parsers/__init__.py
@@ -4,9 +4,11 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 # Document parsers for different file formats
+from .audio_parser import AudioParser
 from .base import BaseParser
 from .docx_parser import DOCXParser
 from .html_parser import HTMLParser
+from .image_parser import ImageParser
 from .pdf_parser import PDFParser
 from .ppt_parser import PPTParser
 from .txt_parser import TXTParser
@@ -20,6 +22,14 @@ _PARSER_REGISTRY = {
     ".docx": DOCXParser,
     ".pptx": PPTParser,
     ".txt": TXTParser,
+    ".png": ImageParser,
+    ".jpg": ImageParser,
+    ".jpeg": ImageParser,
+    ".gif": ImageParser,
+    ".bmp": ImageParser,
+    ".wav": AudioParser,
+    ".mp3": AudioParser,
+    ".ogg": AudioParser,
 }
 
 
@@ -41,6 +51,8 @@ __all__ = [
     "DOCXParser",
     "PPTParser",
     "TXTParser",
+    "ImageParser",
+    "AudioParser",
     "register_parser",
     "get_parser_for_extension",
 ]

--- a/datacreek/parsers/audio_parser.py
+++ b/datacreek/parsers/audio_parser.py
@@ -1,0 +1,29 @@
+import os
+
+from .base import BaseParser
+
+
+class AudioParser(BaseParser):
+    """Parser for audio files using SpeechRecognition."""
+
+    def parse(self, file_path: str) -> str:
+        try:
+            import speech_recognition as sr
+        except Exception as exc:  # pragma: no cover - dependency missing
+            raise ImportError(
+                "SpeechRecognition and pocketsphinx are required for audio parsing."
+            ) from exc
+        recognizer = sr.Recognizer()
+        with sr.AudioFile(file_path) as source:
+            audio = recognizer.record(source)
+        try:
+            return recognizer.recognize_sphinx(audio)
+        except sr.UnknownValueError:
+            return ""
+        except sr.RequestError as exc:  # pragma: no cover - unlikely
+            raise RuntimeError("Sphinx request error") from exc
+
+    def save(self, content: str, output_path: str) -> None:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(content)

--- a/datacreek/parsers/html_parser.py
+++ b/datacreek/parsers/html_parser.py
@@ -17,7 +17,7 @@ from .base import BaseParser
 class HTMLParser(BaseParser):
     """Parser for HTML files and web pages"""
 
-    def parse(self, file_path: str) -> str:
+    def parse(self, file_path: str, *, use_unstructured: bool = True) -> str:
         """Parse an HTML file or URL into plain text
 
         Args:
@@ -26,6 +26,22 @@ class HTMLParser(BaseParser):
         Returns:
             Extracted text from the HTML
         """
+        if use_unstructured:
+            try:
+                from unstructured.partition.html import partition_html
+
+                elements = partition_html(
+                    url=file_path if file_path.startswith(("http://", "https://")) else None,
+                    filename=None if file_path.startswith(("http://", "https://")) else file_path,
+                )
+                texts = [
+                    getattr(el, "text", str(el)) for el in elements if getattr(el, "text", None)
+                ]
+                if texts:
+                    return "\n".join(texts)
+            except Exception:
+                pass
+
         try:
             from bs4 import BeautifulSoup
         except ImportError:

--- a/datacreek/parsers/image_parser.py
+++ b/datacreek/parsers/image_parser.py
@@ -1,0 +1,27 @@
+import os
+
+from .base import BaseParser
+
+
+class ImageParser(BaseParser):
+    """Parser for image files using unstructured."""
+
+    def parse(self, file_path: str) -> str:
+        try:
+            from unstructured.partition.image import partition_image
+        except Exception as exc:  # pragma: no cover - dependency missing
+            raise ImportError(
+                "unstructured with image support is required for image parsing."
+            ) from exc
+        elements = partition_image(filename=file_path)
+        texts = []
+        for el in elements:
+            t = getattr(el, "text", str(el))
+            if t:
+                texts.append(t)
+        return "\n".join(texts)
+
+    def save(self, content: str, output_path: str) -> None:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(content)

--- a/datacreek/parsers/ppt_parser.py
+++ b/datacreek/parsers/ppt_parser.py
@@ -14,7 +14,7 @@ from .base import BaseParser
 class PPTParser(BaseParser):
     """Parser for PowerPoint presentations"""
 
-    def parse(self, file_path: str) -> str:
+    def parse(self, file_path: str, *, use_unstructured: bool = True) -> str:
         """Parse a PPTX file into plain text
 
         Args:
@@ -23,6 +23,18 @@ class PPTParser(BaseParser):
         Returns:
             Extracted text from the presentation
         """
+        if use_unstructured:
+            try:
+                from unstructured.partition.pptx import partition_pptx
+
+                elements = partition_pptx(filename=file_path)
+                texts = [
+                    getattr(el, "text", str(el)) for el in elements if getattr(el, "text", None)
+                ]
+                return "\n".join(texts)
+            except Exception:
+                pass
+
         try:
             from pptx import Presentation
         except ImportError:

--- a/datacreek/schemas.py
+++ b/datacreek/schemas.py
@@ -18,6 +18,11 @@ class UserOut(BaseModel):
 class SourceCreate(BaseModel):
     path: str
     name: str | None = None
+    high_res: bool | None = False
+    ocr: bool | None = False
+    use_unstructured: bool | None = None
+    extract_entities: bool | None = False
+    extract_facts: bool | None = False
 
 
 class SourceOut(BaseModel):

--- a/datacreek/services.py
+++ b/datacreek/services.py
@@ -1,3 +1,4 @@
+import json
 import secrets
 from hashlib import sha256
 
@@ -42,8 +43,22 @@ def create_user_with_generated_key(
     return user, api_key
 
 
-def create_source(db: Session, owner_id: int | None, path: str, content: str) -> SourceData:
-    src = SourceData(owner_id=owner_id, path=path, content=content)
+def create_source(
+    db: Session,
+    owner_id: int | None,
+    path: str,
+    content: str,
+    *,
+    entities: list[str] | None = None,
+    facts: list[dict[str, str]] | None = None,
+) -> SourceData:
+    src = SourceData(
+        owner_id=owner_id,
+        path=path,
+        content=content,
+        entities=json.dumps(entities) if entities else None,
+        facts=json.dumps(facts) if facts else None,
+    )
     db.add(src)
     db.commit()
     db.refresh(src)

--- a/datacreek/utils/chunking.py
+++ b/datacreek/utils/chunking.py
@@ -54,3 +54,30 @@ def semantic_chunk_split(text: str, max_tokens: int, similarity_drop: float = 0.
     if current:
         chunks.append(current.strip())
     return chunks
+
+
+def contextual_chunk_split(text: str, max_tokens: int, context_size: int = 20) -> List[str]:
+    """Split ``text`` and prepend minimal context to each chunk."""
+
+    words = text.split()
+    chunks = []
+    for i in range(0, len(words), max_tokens):
+        chunk_tokens = words[i : i + max_tokens]
+        prefix_tokens = words[max(0, i - context_size) : i]
+        prefix = " ".join(prefix_tokens)
+        chunk = (prefix + " " if prefix else "") + " ".join(chunk_tokens)
+        chunks.append(chunk.strip())
+    return chunks
+
+
+def summarized_chunk_split(text: str, max_tokens: int, summary_len: int = 20) -> List[str]:
+    """Split text and prefix each chunk with a short summary of the previous one."""
+
+    base_chunks = semantic_chunk_split(text, max_tokens=max_tokens)
+    out: List[str] = []
+    prev = ""
+    for chunk in base_chunks:
+        summary = " ".join(prev.split()[-summary_len:])
+        out.append((summary + " " if summary else "") + chunk)
+        prev = chunk
+    return out

--- a/datacreek/utils/text.py
+++ b/datacreek/utils/text.py
@@ -8,7 +8,12 @@ import json
 import re
 from typing import Any, Dict, List, Optional
 
-from .chunking import semantic_chunk_split, sliding_window_chunks
+from .chunking import (
+    contextual_chunk_split,
+    semantic_chunk_split,
+    sliding_window_chunks,
+    summarized_chunk_split,
+)
 
 
 def split_into_chunks(
@@ -23,6 +28,10 @@ def split_into_chunks(
         return sliding_window_chunks(text, chunk_size, overlap)
     if method == "semantic":
         return semantic_chunk_split(text, max_tokens=chunk_size, similarity_drop=similarity_drop)
+    if method == "contextual":
+        return contextual_chunk_split(text, max_tokens=chunk_size)
+    if method == "summary":
+        return summarized_chunk_split(text, max_tokens=chunk_size)
 
     paragraphs = text.split("\n\n")
     chunks = []

--- a/frontend/src/components/DatasetWizard.jsx
+++ b/frontend/src/components/DatasetWizard.jsx
@@ -29,6 +29,9 @@ export default function DatasetWizard() {
   const [docs, setDocs] = useState([''])
   const [highRes, setHighRes] = useState(false)
   const [ocr, setOcr] = useState(false)
+  const [extractEntities, setExtractEntities] = useState(false)
+  const [extractFacts, setExtractFacts] = useState(false)
+  const [useUnstructured, setUseUnstructured] = useState(true)
   const [graphs, setGraphs] = useState([])
   const [graphName, setGraphName] = useState('')
   const [params, setParams] = useState('')
@@ -46,7 +49,14 @@ export default function DatasetWizard() {
         const resp = await fetch(`/api/datasets/${name}/ingest`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ path, high_res: highRes, ocr })
+            body: JSON.stringify({
+              path,
+              high_res: highRes,
+              ocr,
+              use_unstructured: useUnstructured,
+              extract_entities: extractEntities,
+              extract_facts: extractFacts
+            })
         })
         if (!resp.ok) {
           // eslint-disable-next-line no-alert
@@ -174,6 +184,30 @@ export default function DatasetWizard() {
                         onChange={e => setOcr(e.target.checked)}
                       />
                       OCR
+                    </label>
+                    <label className="flex items-center gap-1 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={extractEntities}
+                        onChange={e => setExtractEntities(e.target.checked)}
+                      />
+                      Entities
+                    </label>
+                    <label className="flex items-center gap-1 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={extractFacts}
+                        onChange={e => setExtractFacts(e.target.checked)}
+                      />
+                      Facts
+                    </label>
+                    <label className="flex items-center gap-1 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={useUnstructured}
+                        onChange={e => setUseUnstructured(e.target.checked)}
+                      />
+                      Unstructured
                     </label>
                   </div>
                 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
     "flask-login>=0.6.3",
     "flask-wtf>=1.2.0",
     "wtforms>=3.0",
+    "unstructured>=0.18.1",
+    "SpeechRecognition>=3.14.0",
+    "pocketsphinx>=5.0",
 ]
 
 # These fields appear in pip show

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,4 +1,9 @@
-from datacreek.utils.chunking import semantic_chunk_split, sliding_window_chunks
+from datacreek.utils.chunking import (
+    contextual_chunk_split,
+    semantic_chunk_split,
+    sliding_window_chunks,
+    summarized_chunk_split,
+)
 
 
 def test_sliding_window_chunks():
@@ -12,3 +17,21 @@ def test_semantic_chunk_split():
     text = "Sentence one. Sentence two related. Different topic."
     chunks = semantic_chunk_split(text, max_tokens=50, similarity_drop=0.5)
     assert len(chunks) >= 2
+
+
+def test_contextual_chunk_split():
+    text = (
+        "Berlin est la capitale de l'Allemagne. La ville est un centre culturel majeur."
+        " Encore une phrase."
+    )
+    chunks = contextual_chunk_split(text, max_tokens=6, context_size=3)
+    assert len(chunks) > 1
+    # second chunk should reuse tokens from the first chunk
+    assert chunks[1].startswith("capitale de l'Allemagne")
+
+
+def test_summarized_chunk_split():
+    text = "Sentence one. Sentence two about Berlin. Another."
+    chunks = summarized_chunk_split(text, max_tokens=20, summary_len=3)
+    assert len(chunks) >= 2
+    assert "Sentence one" in chunks[1]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -20,3 +20,6 @@ def test_init_db_creates_tables(tmp_path, monkeypatch):
     assert {"users", "sources", "datasets"}.issubset(tables)
     cols = [c["name"] for c in insp.get_columns("users")]
     assert "password_hash" in cols
+    src_cols = [c["name"] for c in insp.get_columns("sources")]
+    assert "entities" in src_cols
+    assert "facts" in src_cols

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,7 +1,10 @@
 import pytest
 
+import datacreek.parsers
 from datacreek import DatasetBuilder, DatasetType, ingest_file, to_kg
-from datacreek.core.ingest import ingest_into_dataset
+from datacreek.core.ingest import ingest_into_dataset, process_file
+from datacreek.parsers import AudioParser, ImageParser
+from datacreek.parsers.pdf_parser import PDFParser
 
 
 def test_ingest_to_kg(tmp_path):
@@ -65,3 +68,102 @@ def test_ingest_into_dataset_with_facts(tmp_path):
     ingest_into_dataset(str(text_file), ds, extract_facts=True)
     facts = ds.search_facts("Paris")
     assert facts
+
+
+def test_ingest_into_dataset_with_entities(tmp_path):
+    text_file = tmp_path / "doc.txt"
+    text_file.write_text("Albert Einstein was born in Ulm.")
+    ds = DatasetBuilder(DatasetType.TEXT)
+    ingest_into_dataset(str(text_file), ds, extract_entities=True)
+    ents = ds.search_entities("Einstein")
+    assert ents
+
+
+def test_ingest_into_dataset_records_source(tmp_path):
+    f = tmp_path / "sample.txt"
+    f.write_text("hello")
+
+    ds = DatasetBuilder(DatasetType.TEXT)
+    ingest_into_dataset(str(f), ds)
+
+    assert ds.graph.graph.nodes["sample"]["source"] == str(f)
+
+
+def test_ingest_image_and_audio(monkeypatch, tmp_path):
+    img = tmp_path / "img.png"
+    img.write_bytes(b"x")
+    aud = tmp_path / "clip.wav"
+    aud.write_bytes(b"y")
+
+    monkeypatch.setattr(ImageParser, "parse", lambda self, p: "img text")
+    monkeypatch.setattr(ImageParser, "save", lambda self, c, o: None)
+    monkeypatch.setattr(AudioParser, "parse", lambda self, p: "audio text")
+    monkeypatch.setattr(AudioParser, "save", lambda self, c, o: None)
+
+    ds = DatasetBuilder(DatasetType.TEXT)
+    ingest_into_dataset(str(img), ds)
+    ingest_into_dataset(str(aud), ds)
+
+    assert ds.search_chunks("img text")
+    assert ds.search_chunks("audio text")
+
+
+def test_determine_parser_remote_image(monkeypatch):
+    called = {}
+
+    class DummyParser:
+        def parse(self, file_path):
+            called["path"] = file_path
+            return "ok"
+
+        def save(self, content, output_path):
+            pass
+
+    monkeypatch.setitem(datacreek.parsers._PARSER_REGISTRY, ".png", DummyParser)
+
+    text = ingest_file("https://example.com/test.png")
+    assert text == "ok"
+    assert called["path"] == "https://example.com/test.png"
+
+
+def test_determine_parser_remote_audio(monkeypatch):
+    called = {}
+
+    class DummyParser:
+        def parse(self, file_path):
+            called["path"] = file_path
+            return "ok"
+
+        def save(self, content, output_path):
+            pass
+
+    monkeypatch.setitem(datacreek.parsers._PARSER_REGISTRY, ".mp3", DummyParser)
+
+    text = ingest_file("https://example.com/test.mp3")
+    assert text == "ok"
+    assert called["path"] == "https://example.com/test.mp3"
+
+
+def test_process_file_unstructured(monkeypatch, tmp_path):
+    pdf = tmp_path / "doc.pdf"
+    pdf.write_bytes(b"x")
+
+    class Dummy(PDFParser):
+        def parse(
+            self,
+            file_path,
+            *,
+            high_res=False,
+            ocr=False,
+            return_pages=False,
+            use_unstructured=False,
+        ):
+            assert use_unstructured is True
+            return "ok"
+
+        def save(self, content, output_path):
+            pass
+
+    monkeypatch.setattr(datacreek.core.ingest, "determine_parser", lambda f, c: Dummy())
+    text = process_file(str(pdf), use_unstructured=True)
+    assert text == "ok"

--- a/tests/test_new_parsers.py
+++ b/tests/test_new_parsers.py
@@ -1,0 +1,11 @@
+from datacreek.parsers import AudioParser, ImageParser, get_parser_for_extension
+
+
+def test_image_parser_registry():
+    parser = get_parser_for_extension(".png")
+    assert isinstance(parser, ImageParser)
+
+
+def test_audio_parser_registry():
+    parser = get_parser_for_extension(".wav")
+    assert isinstance(parser, AudioParser)

--- a/tests/test_unstructured_parsers.py
+++ b/tests/test_unstructured_parsers.py
@@ -1,0 +1,39 @@
+import sys
+import types
+
+from datacreek.parsers.docx_parser import DOCXParser
+from datacreek.parsers.html_parser import HTMLParser
+from datacreek.parsers.pdf_parser import PDFParser
+
+
+def test_docx_parser_unstructured(monkeypatch, tmp_path):
+    f = tmp_path / "sample.docx"
+    f.write_bytes(b"doc")
+    module = types.ModuleType("unstructured.partition.docx")
+    module.partition_docx = lambda filename: [types.SimpleNamespace(text="hello")]
+    monkeypatch.setitem(sys.modules, "unstructured.partition.docx", module)
+    parser = DOCXParser()
+    assert parser.parse(str(f), use_unstructured=True) == "hello"
+
+
+def test_pdf_parser_unstructured(monkeypatch, tmp_path):
+    f = tmp_path / "sample.pdf"
+    f.write_bytes(b"pdf")
+    module = types.ModuleType("unstructured.partition.pdf")
+    module.partition_pdf = lambda filename: [types.SimpleNamespace(text="hi")]
+    monkeypatch.setitem(sys.modules, "unstructured.partition.pdf", module)
+    dummy_pdfminer = types.ModuleType("pdfminer.high_level")
+    dummy_pdfminer.extract_text = lambda p: "fallback"
+    monkeypatch.setitem(sys.modules, "pdfminer.high_level", dummy_pdfminer)
+    parser = PDFParser()
+    assert parser.parse(str(f), use_unstructured=True) == "hi"
+
+
+def test_html_parser_unstructured(monkeypatch, tmp_path):
+    f = tmp_path / "page.html"
+    f.write_text("<html><body><p>Hello</p></body></html>")
+    module = types.ModuleType("unstructured.partition.html")
+    module.partition_html = lambda url=None, filename=None: [types.SimpleNamespace(text="hi html")]
+    monkeypatch.setitem(sys.modules, "unstructured.partition.html", module)
+    parser = HTMLParser()
+    assert parser.parse(str(f), use_unstructured=True) == "hi html"


### PR DESCRIPTION
## Summary
- support unstructured-powered HTML parsing with fallback to BeautifulSoup
- document HTML support in README
- test HTML parser integration with unstructured

## Testing
- `pre-commit run --files datacreek/parsers/html_parser.py tests/test_unstructured_parsers.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e0350ac80832f9c02734044afac5c