### PR TITLE
Switch parsers to unstructured

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ This toolkit simplifies the journey of:
 - Using a LLM (vLLM or any local/external API endpoint) to generate examples
 - Converting your existing files to fine-tuning friendly formats
 - Parsing additional formats like images (via [unstructured](https://github.com/Unstructured-IO/unstructured)) and audio files (transcribed with SpeechRecognition + pocketsphinx). Extracted text from these sources is inserted in the knowledge graph while preserving the original file path
-- `unstructured` is now the default parser for PDF, DOCX, PPTX, HTML and image files, with a fallback to the previous libraries when unavailable
+- `unstructured` is used to parse PDF, DOCX, PPTX, HTML and image files, ensuring consistent handling across formats
+- Files are partitioned with `unstructured` so text and images become individual elements linked in the graph
+- Text is cleaned with `unstructured` before being inserted into the knowledge graph
 - Optionally extracting named entities and standalone facts during ingestion
 - Advanced chunking options including semantic, contextual and summarized splitting
 - Creating synthetic datasets
@@ -365,9 +367,11 @@ from datacreek import DatasetBuilder, DatasetType, KnowledgeGraph
 ds = DatasetBuilder(DatasetType.QA, name="example")
 ds.add_document("doc1", source="paper.pdf")
 ds.add_chunk("doc1", "c1", "hello world")
+ds.add_image("doc1", "img0", "pages/img0.png", page=1)
 print(ds.search("hello"))  # ["c1"]
 print(ds.search_documents("paper"))  # ["doc1"]
 print(ds.get_chunks_for_document("doc1"))  # ["c1"]
+print(ds.get_images_for_document("doc1"))  # ["img0"]
 print(ds.get_document_for_chunk("c1"))  # "doc1"
 ds.graph.index.build()
 print(ds.graph.search_embeddings("hello", k=1))  # ["c1"]
@@ -570,11 +574,8 @@ If you encounter issues during the curation step:
 ### Parser Errors
 
 - Ensure required dependencies are installed for specific parsers:
-  - PDF: `pip install pdfminer.six`
-  - HTML: `pip install beautifulsoup4`
   - YouTube: `pip install pytubefix youtube-transcript-api`
-  - DOCX: `pip install python-docx`
-  - PPTX: `pip install python-pptx`
+  - Office/PDF/HTML: `pip install "unstructured[all-docs]"`
 
 ## Web Interface
 

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -73,6 +73,18 @@ class DatasetBuilder:
 
         self.graph.add_chunk(doc_id, chunk_id, text, source, section_id=section_id, page=page)
 
+    def add_image(
+        self,
+        doc_id: str,
+        image_id: str,
+        path: str,
+        *,
+        page: int | None = None,
+    ) -> None:
+        """Insert an image node in the dataset graph."""
+
+        self.graph.add_image(doc_id, image_id, path, page=page)
+
     def add_entity(self, entity_id: str, text: str, source: Optional[str] = None) -> None:
         """Insert an entity node."""
 
@@ -421,6 +433,9 @@ class DatasetBuilder:
 
     def get_chunks_for_document(self, doc_id: str) -> list[str]:
         return self.graph.get_chunks_for_document(doc_id)
+
+    def get_images_for_document(self, doc_id: str) -> list[str]:
+        return self.graph.get_images_for_document(doc_id)
 
     def get_sections_for_document(self, doc_id: str) -> list[str]:
         return self.graph.get_sections_for_document(doc_id)

--- a/datacreek/parsers/docx_parser.py
+++ b/datacreek/parsers/docx_parser.py
@@ -13,8 +13,10 @@ from .base import BaseParser
 class DOCXParser(BaseParser):
     """Parser for Microsoft Word documents"""
 
-    def parse(self, file_path: str, *, use_unstructured: bool = True) -> str:
-        """Parse a DOCX file into plain text
+    def parse(
+        self, file_path: str, *, use_unstructured: bool = True, return_elements: bool = False
+    ) -> str | list[Any]:
+        """Parse a DOCX file into plain text using ``unstructured``
 
         Args:
             file_path: Path to the DOCX file
@@ -22,35 +24,16 @@ class DOCXParser(BaseParser):
         Returns:
             Extracted text from the document
         """
-        if use_unstructured:
-            try:
-                from unstructured.partition.docx import partition_docx
-
-                elements = partition_docx(filename=file_path)
-                texts = [
-                    getattr(el, "text", str(el)) for el in elements if getattr(el, "text", None)
-                ]
-                return "\n".join(texts)
-            except Exception:
-                pass
-
         try:
-            import docx
-        except ImportError:
-            raise ImportError(
-                "python-docx is required for DOCX parsing. Install it with: pip install python-docx"
-            )
+            from unstructured.partition.docx import partition_docx
 
-        doc = docx.Document(file_path)
-
-        paragraphs = [p.text for p in doc.paragraphs]
-
-        for table in doc.tables:
-            for row in table.rows:
-                for cell in row.cells:
-                    paragraphs.append(cell.text)
-
-        return "\n\n".join(p for p in paragraphs if p)
+            elements = partition_docx(filename=file_path)
+            if return_elements:
+                return elements
+            texts = [getattr(el, "text", str(el)) for el in elements if getattr(el, "text", None)]
+            return "\n".join(texts)
+        except Exception as exc:  # pragma: no cover - unexpected failures
+            raise RuntimeError("Failed to parse DOCX with unstructured") from exc
 
     def save(self, content: str, output_path: str) -> None:
         """Save the extracted text to a file

--- a/datacreek/server/app.py
+++ b/datacreek/server/app.py
@@ -1567,7 +1567,11 @@ def ingest():
 
             # Process the file or URL
             output_path = ingest_process_file(
-                file_path=input_path, output_dir=output_dir, output_name=output_name, config=config
+                file_path=input_path,
+                output_dir=output_dir,
+                output_name=output_name,
+                save=True,
+                config=config,
             )
 
             # Clean up temporary file if it was an upload

--- a/datacreek/utils/__init__.py
+++ b/datacreek/utils/__init__.py
@@ -13,7 +13,7 @@ from .config import (
 from .entity_extraction import extract_entities
 from .fact_extraction import extract_facts
 from .llm_processing import convert_to_conversation_format, parse_qa_pairs, parse_ratings
-from .text import extract_json_from_text, split_into_chunks
+from .text import clean_text, extract_json_from_text, split_into_chunks
 
 __all__ = [
     "load_config",
@@ -26,6 +26,7 @@ __all__ = [
     "merge_configs",
     "split_into_chunks",
     "extract_json_from_text",
+    "clean_text",
     "parse_qa_pairs",
     "parse_ratings",
     "convert_to_conversation_format",

--- a/datacreek/utils/text.py
+++ b/datacreek/utils/text.py
@@ -8,6 +8,8 @@ import json
 import re
 from typing import Any, Dict, List, Optional
 
+from unstructured.cleaners.core import clean as _clean
+
 from .chunking import (
     contextual_chunk_split,
     semantic_chunk_split,
@@ -84,3 +86,9 @@ def extract_json_from_text(text: str) -> Dict[str, Any]:
             pass
 
     raise ValueError("Could not extract valid JSON from the response")
+
+
+def clean_text(text: str) -> str:
+    """Return ``text`` normalized using ``unstructured`` cleaners."""
+
+    return _clean(text, extra_whitespace=True, dashes=True, bullets=True)

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -10,8 +10,9 @@ from datacreek.parsers.pdf_parser import PDFParser
 def test_pdf_parser_basic(monkeypatch, tmp_path):
     pdf = tmp_path / "sample.pdf"
     pdf.write_bytes(b"%PDF-1.4 test")
-    dummy = types.SimpleNamespace(extract_text=lambda p: "hello")
-    monkeypatch.setitem(sys.modules, "pdfminer.high_level", dummy)
+    module = types.ModuleType("unstructured.partition.pdf")
+    module.partition_pdf = lambda filename: [types.SimpleNamespace(text="hello")]
+    monkeypatch.setitem(sys.modules, "unstructured.partition.pdf", module)
     parser = PDFParser()
     assert parser.parse(str(pdf)) == "hello"
 
@@ -35,8 +36,9 @@ def test_pdf_parser_high_res_missing(monkeypatch, tmp_path):
 def test_pdf_parser_ocr(monkeypatch, tmp_path):
     pdf = tmp_path / "sample.pdf"
     pdf.write_bytes(b"%PDF-1.4 test")
-    dummy_pdfminer = types.SimpleNamespace(extract_text=lambda p: "")
-    monkeypatch.setitem(sys.modules, "pdfminer.high_level", dummy_pdfminer)
+    module = types.ModuleType("unstructured.partition.pdf")
+    module.partition_pdf = lambda filename: [types.SimpleNamespace(text="base")]
+    monkeypatch.setitem(sys.modules, "unstructured.partition.pdf", module)
     mod_pdf2image = types.ModuleType("pdf2image")
     mod_pytesseract = types.ModuleType("pytesseract")
     mod_pdf2image.convert_from_path = lambda p: ["img"]

--- a/tests/test_unstructured_parsers.py
+++ b/tests/test_unstructured_parsers.py
@@ -22,9 +22,6 @@ def test_pdf_parser_unstructured(monkeypatch, tmp_path):
     module = types.ModuleType("unstructured.partition.pdf")
     module.partition_pdf = lambda filename: [types.SimpleNamespace(text="hi")]
     monkeypatch.setitem(sys.modules, "unstructured.partition.pdf", module)
-    dummy_pdfminer = types.ModuleType("pdfminer.high_level")
-    dummy_pdfminer.extract_text = lambda p: "fallback"
-    monkeypatch.setitem(sys.modules, "pdfminer.high_level", dummy_pdfminer)
     parser = PDFParser()
     assert parser.parse(str(f), use_unstructured=True) == "hi"
 


### PR DESCRIPTION
## Summary
- rely exclusively on `unstructured` for HTML, DOCX, PPTX and PDF parsing
- clean text with `unstructured` before splitting and inserting into the knowledge graph
- expose new `clean_text` helper
- update docs for new default behaviour
- adjust parser tests accordingly
- add partition-based ingestion with image handling
- fix element processing when adding images
- document `add_image` and `get_images_for_document`
- ingest directly into the graph without saving parsed text files

## Testing
- `pre-commit run --files datacreek/core/ingest.py datacreek/server/app.py DOCS.md tests/test_ingest.py README.md datacreek/config.yaml datacreek/core/dataset.py datacreek/core/knowledge_graph.py datacreek/parsers/docx_parser.py datacreek/parsers/html_parser.py datacreek/parsers/pdf_parser.py datacreek/parsers/ppt_parser.py datacreek/utils/__init__.py datacreek/utils/text.py tests/test_pdf_parser.py tests/test_unstructured_parsers.py` *(failed: command not found)*
- `pytest -q` *(failed to run due to missing dependencies such as `fastapi`, `pydantic`, and `requests`)*

------
https://chatgpt.com/codex/tasks/task_e_685f290a8a98832f9ce2ff02f32f2149