### PR TITLE
Add backend service and optional local build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ DATABASE_URL=sqlite:////app/data/datacreek.db
 NEO4J_URI=bolt://neo4j:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=neo4j
+# Port the Flask backend listens on
+PORT=5000
 # Example secrets (override in production)
 SECRET_KEY=change-me
 API_KEY=change-me

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,15 @@ jobs:
       - run: pip install -e . fakeredis flask flask-wtf flask-login wtforms pre-commit pytest
       - run: pre-commit run --all-files --show-diff-on-failure
       - run: pytest -q
+      - name: Build container images
+        run: docker compose build
+      - name: Run tests inside image
+        run: |
+          docker build -t datacreek:test .
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace datacreek:test \
+            sh -c "pip install fakeredis flask flask-wtf flask-login wtforms pytest && pytest -q"
 
   docker-build:
     runs-on: ubuntu-latest

--- a/DOCS.md
+++ b/DOCS.md
@@ -1675,16 +1675,17 @@ Start all services with Docker Compose for development:
 ./scripts/start_services.sh
 ```
 
-The compose file launches five containers:
+The compose file launches six containers:
 
 - `api` – FastAPI application
 - `worker` – Celery task runner
 - `redis` – broker and result backend
 - `neo4j` – graph database
+- `backend` – Flask interface
 - `frontend` – Vite/React interface
 
-The API is available on `http://localhost:8000` while the UI runs on
-`http://localhost:3000`.
+The API is available on `http://localhost:8000`, the Flask backend on
+`http://localhost:5000` and the UI runs on `http://localhost:3000`.
 
 ### Production deployment
 

--- a/README.md
+++ b/README.md
@@ -206,13 +206,14 @@ This will watch for file changes and serve the interface on
 Use the provided `docker-compose.yml` to launch the API, Celery worker,
 Redis, Neo4j and the front-end:
 
-The stack consists of five main services:
+The stack consists of six main services:
 
 - **api** – FastAPI server exposing ingestion, generation, curation and export
   endpoints.
 - **worker** – Celery background worker executing long-running tasks.
 - **redis** – message broker and task result backend.
 - **neo4j** – knowledge graph database.
+- **backend** – Flask web interface.
 - **frontend** – React web application built with Vite.
 
 ```bash
@@ -224,9 +225,9 @@ need to adjust values for production. The default configuration stores
 the SQLite database and generated datasets in `./data` which is mounted
 inside the containers.
 
-The API will be available on `http://localhost:8000` while the front-end is
-served on `http://localhost:3000`. Redis listens on `6379` and Neo4j exposes
-`7474` and `7687`.
+The API will be available on `http://localhost:8000` and the Flask backend on
+`http://localhost:5000` while the front-end is served on `http://localhost:3000`.
+Redis listens on `6379` and Neo4j exposes `7474` and `7687`.
 
 To rebuild the images after modifying the code simply run:
 

--- a/datacreek/server/app.py
+++ b/datacreek/server/app.py
@@ -1746,4 +1746,7 @@ def run_server(host="127.0.0.1", port=5000, debug=False):
 
 
 if __name__ == "__main__":
-    run_server(debug=True)
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", "5000"))
+    debug = os.environ.get("DEBUG", "False").lower() == "true"
+    run_server(host=host, port=port, debug=debug)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,21 @@ services:
     depends_on:
       - redis
 
+  backend:
+    build: .
+    image: ${IMAGE_NAME:-datacreek}
+    command: python -m datacreek.server.app
+    env_file: .env
+    environment:
+      - PORT=5000
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      - redis
+      - neo4j
+    ports:
+      - "5000:5000"
+
   frontend:
     build:
       context: ./frontend

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,7 +13,11 @@ fi
 
 "${ssh_cmd[@]}" "$DEPLOY_USER@$DEPLOY_HOST" <<'REMOTE'
 cd "$DEPLOY_PATH"
-docker compose pull
+if [ "${LOCAL_BUILD:-false}" = "true" ]; then
+  docker compose build
+else
+  docker compose pull
+fi
 docker compose up -d
 REMOTE
 


### PR DESCRIPTION
## Summary
- allow overriding host and port when launching Flask server
- add `backend` service to docker-compose
- document local backend and update docs to six container setup
- add `PORT` variable to `.env.example`
- let deploy script optionally build images locally instead of always pulling
- build and test container images in the CI pipeline

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f6080d700832f99774270b3273c27