### PR TITLE
Improve curation pipeline

### DIFF
--- a/datacreek/__init__.py
+++ b/datacreek/__init__.py
@@ -1,44 +1,106 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-"""Datacreek: tools for preparing synthetic data for LLM fine-tuning."""
+"""Datacreek package."""
+
+from typing import TYPE_CHECKING
 
 __version__ = "0.0.2"
 
-from .config_models import GenerationSettings
-from .core.dataset import DatasetBuilder
-from .core.ingest import ingest_into_dataset
-from .core.ingest import process_file as ingest_file
-from .core.ingest import to_kg
-from .core.knowledge_graph import KnowledgeGraph
-from .pipelines import (
-    PIPELINES,
-    DatasetType,
-    GenerationPipeline,
-    TrainingGoal,
-    get_dataset_types_for_training,
-    get_pipeline,
-    get_pipelines_for_training,
-    get_trainings_for_dataset,
-)
-from .utils.fact_extraction import extract_facts
+# Avoid heavy imports at module load time. Relevant classes and functions
+# are available via submodules such as ``datacreek.pipelines`` or
+# ``datacreek.core``.
 
-__all__ = [
+__all__: list[str] = [
+    "__version__",
+    "DatasetBuilder",
+    "DatasetType",
     "GenerationPipeline",
     "TrainingGoal",
-    "DatasetType",
-    "PIPELINES",
     "get_pipeline",
     "get_trainings_for_dataset",
     "get_dataset_types_for_training",
     "get_pipelines_for_training",
-    "KnowledgeGraph",
-    "DatasetBuilder",
     "ingest_file",
     "to_kg",
     "ingest_into_dataset",
     "extract_facts",
+    "KnowledgeGraph",
     "GenerationSettings",
 ]
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checking only
+    from .config_models import GenerationSettings
+    from .core.dataset import DatasetBuilder
+    from .core.ingest import ingest_into_dataset, process_file as ingest_file, to_kg
+    from .core.knowledge_graph import KnowledgeGraph
+    from .pipelines import (
+        PIPELINES,
+        DatasetType,
+        GenerationPipeline,
+        TrainingGoal,
+        get_dataset_types_for_training,
+        get_pipeline,
+        get_pipelines_for_training,
+        get_trainings_for_dataset,
+    )
+    from .utils.fact_extraction import extract_facts
+
+
+def __getattr__(name: str):
+    if name == "DatasetBuilder":
+        from .core.dataset import DatasetBuilder as _DB
+
+        return _DB
+    if name in {"ingest_file", "to_kg", "ingest_into_dataset"}:
+        from .core.ingest import (
+            ingest_into_dataset as _ingest_into_dataset,
+            process_file as _ingest_file,
+            to_kg as _to_kg,
+        )
+
+        return {
+            "ingest_file": _ingest_file,
+            "to_kg": _to_kg,
+            "ingest_into_dataset": _ingest_into_dataset,
+        }[name]
+    if name == "KnowledgeGraph":
+        from .core.knowledge_graph import KnowledgeGraph as _KG
+
+        return _KG
+    if name == "GenerationSettings":
+        from .config_models import GenerationSettings as _GS
+
+        return _GS
+    if name in {
+        "DatasetType",
+        "GenerationPipeline",
+        "TrainingGoal",
+        "get_pipeline",
+        "get_trainings_for_dataset",
+        "get_dataset_types_for_training",
+        "get_pipelines_for_training",
+    }:
+        from .pipelines import (
+            DatasetType as _DT,
+            GenerationPipeline as _GP,
+            TrainingGoal as _TG,
+            get_pipeline as _gp,
+            get_trainings_for_dataset as _gtfd,
+            get_dataset_types_for_training as _gdtft,
+            get_pipelines_for_training as _gpft,
+        )
+
+        mapping = {
+            "DatasetType": _DT,
+            "GenerationPipeline": _GP,
+            "TrainingGoal": _TG,
+            "get_pipeline": _gp,
+            "get_trainings_for_dataset": _gtfd,
+            "get_dataset_types_for_training": _gdtft,
+            "get_pipelines_for_training": _gpft,
+        }
+
+        return mapping[name]
+    if name == "extract_facts":
+        from .utils.fact_extraction import extract_facts as _ef
+
+        return _ef
+    raise AttributeError(name)

--- a/datacreek/__init__.py
+++ b/datacreek/__init__.py
@@ -29,7 +29,9 @@ __all__: list[str] = [
 if TYPE_CHECKING:  # pragma: no cover - used for type checking only
     from .config_models import GenerationSettings
     from .core.dataset import DatasetBuilder
-    from .core.ingest import ingest_into_dataset, process_file as ingest_file, to_kg
+    from .core.ingest import ingest_into_dataset
+    from .core.ingest import process_file as ingest_file
+    from .core.ingest import to_kg
     from .core.knowledge_graph import KnowledgeGraph
     from .pipelines import (
         PIPELINES,
@@ -50,11 +52,9 @@ def __getattr__(name: str):
 
         return _DB
     if name in {"ingest_file", "to_kg", "ingest_into_dataset"}:
-        from .core.ingest import (
-            ingest_into_dataset as _ingest_into_dataset,
-            process_file as _ingest_file,
-            to_kg as _to_kg,
-        )
+        from .core.ingest import ingest_into_dataset as _ingest_into_dataset
+        from .core.ingest import process_file as _ingest_file
+        from .core.ingest import to_kg as _to_kg
 
         return {
             "ingest_file": _ingest_file,
@@ -78,15 +78,13 @@ def __getattr__(name: str):
         "get_dataset_types_for_training",
         "get_pipelines_for_training",
     }:
-        from .pipelines import (
-            DatasetType as _DT,
-            GenerationPipeline as _GP,
-            TrainingGoal as _TG,
-            get_pipeline as _gp,
-            get_trainings_for_dataset as _gtfd,
-            get_dataset_types_for_training as _gdtft,
-            get_pipelines_for_training as _gpft,
-        )
+        from .pipelines import DatasetType as _DT
+        from .pipelines import GenerationPipeline as _GP
+        from .pipelines import TrainingGoal as _TG
+        from .pipelines import get_dataset_types_for_training as _gdtft
+        from .pipelines import get_pipeline as _gp
+        from .pipelines import get_pipelines_for_training as _gpft
+        from .pipelines import get_trainings_for_dataset as _gtfd
 
         mapping = {
             "DatasetType": _DT,

--- a/datacreek/api.py
+++ b/datacreek/api.py
@@ -1,5 +1,5 @@
 from fastapi import Depends, FastAPI, Header, HTTPException
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
 from sqlalchemy.orm import Session
 
 from datacreek.db import Dataset, SessionLocal, User, init_db
@@ -122,7 +122,7 @@ def download_dataset(
     ds = db.get(Dataset, ds_id)
     if not ds or ds.owner_id != current_user.id:
         raise HTTPException(status_code=404, detail="Dataset not found")
-    return FileResponse(ds.path)
+    return Response(ds.content or "{}", media_type="application/json")
 
 
 # ----- Asynchronous task endpoints -----

--- a/datacreek/config_models.py
+++ b/datacreek/config_models.py
@@ -65,3 +65,147 @@ class GenerationSettingsModel(BaseModel):
     def to_settings(self) -> GenerationSettings:
         """Convert to :class:`GenerationSettings`."""
         return GenerationSettings.from_dict(self.model_dump())
+
+
+@dataclass
+class CurateSettings:
+    """Configuration for curation and rating of generated data."""
+
+    threshold: float = 7.0
+    batch_size: int = 32
+    inference_batch: int = 32
+    temperature: float = 0.1
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CurateSettings":
+        defaults = cls()
+        return cls(**{k: data.get(k, getattr(defaults, k)) for k in cls.__dataclass_fields__})
+
+
+class CurateSettingsModel(BaseModel):
+    threshold: float = 7.0
+    batch_size: int = 32
+    inference_batch: int = 32
+    temperature: float = 0.1
+
+    def to_settings(self) -> CurateSettings:
+        return CurateSettings.from_dict(self.model_dump())
+
+
+@dataclass
+class FormatSettings:
+    """Configuration for output formatting."""
+
+    default: str = "jsonl"
+    include_metadata: bool = True
+    pretty_json: bool = True
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "FormatSettings":
+        defaults = cls()
+        return cls(**{k: data.get(k, getattr(defaults, k)) for k in cls.__dataclass_fields__})
+
+
+class FormatSettingsModel(BaseModel):
+    default: str = "jsonl"
+    include_metadata: bool = True
+    pretty_json: bool = True
+
+    def to_settings(self) -> FormatSettings:
+        return FormatSettings.from_dict(self.model_dump())
+
+
+@dataclass
+class OutputPaths:
+    """Configuration for generated output locations."""
+
+    parsed: str = "data/output"
+    generated: str = "data/generated"
+    cleaned: str = "data/cleaned"
+    final: str = "data/final"
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "OutputPaths":
+        defaults = cls()
+        return cls(**{k: data.get(k, getattr(defaults, k)) for k in cls.__dataclass_fields__})
+
+
+class OutputPathsModel(BaseModel):
+    parsed: str = "data/output"
+    generated: str = "data/generated"
+    cleaned: str = "data/cleaned"
+    final: str = "data/final"
+
+    def to_settings(self) -> OutputPaths:
+        return OutputPaths.from_dict(self.model_dump())
+
+@dataclass
+class VLLMSettings:
+    """Configuration for vLLM server connection."""
+
+    api_base: str = "http://localhost:8000/v1"
+    port: int = 8000
+    model: str = "meta-llama/Llama-3.3-70B-Instruct"
+    max_retries: int = 3
+    retry_delay: float = 1.0
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "VLLMSettings":
+        defaults = cls()
+        return cls(**{k: data.get(k, getattr(defaults, k)) for k in cls.__dataclass_fields__})
+
+
+class VLLMSettingsModel(BaseModel):
+    api_base: str = "http://localhost:8000/v1"
+    port: int = 8000
+    model: str = "meta-llama/Llama-3.3-70B-Instruct"
+    max_retries: int = 3
+    retry_delay: float = 1.0
+
+    def to_settings(self) -> VLLMSettings:
+        return VLLMSettings.from_dict(self.model_dump())
+
+
+@dataclass
+class OpenAISettings:
+    """Configuration for OpenAI or compatible API endpoint."""
+
+    api_base: Optional[str] = None
+    api_key: Optional[str] = None
+    model: str = "gpt-4o"
+    max_retries: int = 3
+    retry_delay: float = 1.0
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "OpenAISettings":
+        defaults = cls()
+        return cls(**{k: data.get(k, getattr(defaults, k)) for k in cls.__dataclass_fields__})
+
+
+class OpenAISettingsModel(BaseModel):
+    api_base: str | None = None
+    api_key: str | None = None
+    model: str = "gpt-4o"
+    max_retries: int = 3
+    retry_delay: float = 1.0
+
+    def to_settings(self) -> OpenAISettings:
+        return OpenAISettings.from_dict(self.model_dump())
+
+@dataclass
+class LLMSettings:
+    """General LLM configuration selecting the provider."""
+
+    provider: str = "vllm"
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "LLMSettings":
+        defaults = cls()
+        return cls(**{k: data.get(k, getattr(defaults, k)) for k in cls.__dataclass_fields__})
+
+
+class LLMSettingsModel(BaseModel):
+    provider: str = "vllm"
+
+    def to_settings(self) -> LLMSettings:
+        return LLMSettings.from_dict(self.model_dump())

--- a/datacreek/config_models.py
+++ b/datacreek/config_models.py
@@ -139,6 +139,7 @@ class OutputPathsModel(BaseModel):
     def to_settings(self) -> OutputPaths:
         return OutputPaths.from_dict(self.model_dump())
 
+
 @dataclass
 class VLLMSettings:
     """Configuration for vLLM server connection."""
@@ -191,6 +192,7 @@ class OpenAISettingsModel(BaseModel):
 
     def to_settings(self) -> OpenAISettings:
         return OpenAISettings.from_dict(self.model_dump())
+
 
 @dataclass
 class LLMSettings:

--- a/datacreek/core/create.py
+++ b/datacreek/core/create.py
@@ -13,11 +13,7 @@ from typing import Any, Dict, Optional
 from datacreek.generators.qa_generator import QAGenerator
 from datacreek.generators.vqa_generator import VQAGenerator
 from datacreek.models.llm_client import LLMClient
-from datacreek.utils.config import (
-    get_generation_config,
-    get_output_paths,
-    load_config,
-)
+from datacreek.utils.config import get_generation_config, get_output_paths, load_config
 
 logger = logging.getLogger(__name__)
 

--- a/datacreek/core/curate.py
+++ b/datacreek/core/curate.py
@@ -5,10 +5,10 @@
 # the root directory of this source tree.
 # Filter low quality examples
 
+import asyncio
 import json
 import logging
 import os
-import asyncio
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 

--- a/datacreek/core/curate.py
+++ b/datacreek/core/curate.py
@@ -6,26 +6,31 @@
 # Filter low quality examples
 
 import json
+import logging
 import os
+import asyncio
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from datacreek.generators.qa_generator import QAGenerator
 from datacreek.models.llm_client import LLMClient
-from datacreek.utils.config import get_curate_config, get_prompt
+from datacreek.utils.config import get_curate_settings, get_prompt
+
+logger = logging.getLogger(__name__)
 from datacreek.utils.llm_processing import convert_to_conversation_format, parse_ratings
 
 
 def curate_qa_pairs(
-    input_path: str,
-    output_path: str,
+    input_data: Any,
+    output_path: Optional[str] = None,
     threshold: Optional[float] = None,
     api_base: Optional[str] = None,
     model: Optional[str] = None,
     config_path: Optional[Path] = None,
     verbose: bool = False,
     provider: Optional[str] = None,
-) -> str:
+    async_mode: bool = False,
+) -> Any:
     """Clean and filter QA pairs based on quality ratings
 
     Args:
@@ -36,19 +41,22 @@ def curate_qa_pairs(
         model: Model to use
         config_path: Path to configuration file
         verbose: Show detailed output
+        async_mode: Use asynchronous LLM requests when supported
 
     Returns:
         Path to the cleaned output file
     """
-    # Set verbose either via CLI or via env variable. If its via CLI, set it to env variable
-    if verbose:
-        os.environ["SDK_VERBOSE"] = "true"
-    else:
-        os.environ["SDK_VERBOSE"] = "false"
+    # Verbosity now controlled by logging level
 
-    # Load input file
-    with open(input_path, "r", encoding="utf-8") as f:
-        data = json.load(f)
+    # Load input
+    if isinstance(input_data, str):
+        if os.path.exists(input_data):
+            with open(input_data, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        else:
+            data = json.loads(input_data)
+    else:
+        data = input_data
 
     # Extract QA pairs
     qa_pairs = data.get("qa_pairs", [])
@@ -66,30 +74,22 @@ def curate_qa_pairs(
     # Get threshold from args, then config, then default
     if threshold is None:
         config = client.config
-        cleanup_config = get_curate_config(config)
-        threshold = cleanup_config.get("threshold", 7.0)
+        cleanup_settings = get_curate_settings(config)
+        threshold = cleanup_settings.threshold
 
     # Create QA generator
     generator = QAGenerator(client, config_path)
 
     # Get configuration
-    curate_config = get_curate_config(client.config)
+    curate_config = get_curate_settings(client.config)
 
-    # Allow environment variable to override batch size (for debugging)
-    env_batch_size = os.environ.get("SDK_BATCH_SIZE")
-    if env_batch_size and env_batch_size.isdigit():
-        batch_size = int(env_batch_size)
-        inference_batch = int(env_batch_size)
-        if verbose:
-            print(f"Using environment-specified batch size: {batch_size}")
-    else:
-        batch_size = curate_config.get("batch_size", 32)
-        inference_batch = curate_config.get("inference_batch", 32)
+    batch_size = curate_config.batch_size
+    inference_batch = curate_config.inference_batch
 
-    rating_temperature = curate_config.get("temperature", 0.1)
+    rating_temperature = curate_config.temperature
 
     if threshold is None:
-        threshold = curate_config.get("threshold", 7.0)
+        threshold = curate_config.threshold
 
     # Get rating prompt template
     rating_prompt_template = get_prompt(client.config, "qa_rating")
@@ -116,7 +116,7 @@ def curate_qa_pairs(
 
     # Process batches with simple progress indicator rather than a detailed bar
     # This avoids conflicts with other output messages
-    print(f"Processing {len(batches)} batches of QA pairs...")
+    logger.info("Processing %d batches of QA pairs...", len(batches))
 
     # Only use detailed progress bar in verbose mode
     if verbose:
@@ -143,113 +143,50 @@ def curate_qa_pairs(
         progress_ctx = None
         rate_task = None
 
-    # Process in inference batches
-    for batch_start in range(0, len(all_messages), inference_batch):
-        batch_end = min(batch_start + inference_batch, len(all_messages))
-        current_batch = all_messages[batch_start:batch_end]
-        current_batch_size = len(current_batch)
+    from datacreek.utils.batch import async_process_batches, process_batches
 
-        batch_num = batch_start // inference_batch + 1
-        total_batches = (len(all_messages) + inference_batch - 1) // inference_batch
+    def _parse_and_collect(resp: str, original_batch: List[Dict[str, str]]) -> List[Dict[str, Any]]:
+        rated = parse_ratings(resp, original_batch)
+        collected: List[Dict[str, Any]] = []
+        for pair in rated:
+            if "rating" in pair:
+                rating = pair["rating"]
+                nonlocal total_score, total_evaluated, total_passed
+                total_score += rating
+                total_evaluated += 1
+                if rating >= threshold:
+                    collected.append(pair)
+                    total_passed += 1
+        return collected
 
-        # Simple progress indicator for non-verbose mode
-        if not verbose:
-            print(f"Processing batch {batch_num}/{total_batches}...", end="\r")
-        else:
-            print(f"Processing batch {batch_num}/{total_batches}")
-
-        try:
-            # Get ratings for the batch
-            if verbose:
-                print(f"Sending batch request with {len(current_batch)} items")
-
-            batch_responses = client.batch_completion(
-                current_batch, temperature=rating_temperature, batch_size=inference_batch
+    if async_mode:
+        rated_batches = asyncio.run(
+            async_process_batches(
+                client,
+                all_messages,
+                batch_size=inference_batch,
+                temperature=rating_temperature,
+                parse_fn=lambda resp: resp,
             )
+        )
+    else:
+        rated_batches = process_batches(
+            client,
+            all_messages,
+            batch_size=inference_batch,
+            temperature=rating_temperature,
+            parse_fn=lambda resp: resp,
+        )
 
-            if verbose:
-                print(f"Received {len(batch_responses)} responses")
-                for i, resp in enumerate(batch_responses):
-                    print(f"Response {i+1}: {resp[:100]}...")
-
-            # Process each response
-            for j, response in enumerate(batch_responses):
-                original_batch_index = batch_start + j
-                if original_batch_index < len(batches):
-                    original_batch = batches[original_batch_index]
-
-                    # Parse the ratings with original batch for fallback
-                    try:
-                        if verbose:
-                            print(f"Processing batch {original_batch_index+1}")
-
-                        rated_batch = parse_ratings(response, original_batch)
-
-                        # Process the rated batch
-                        for pair in rated_batch:
-                            if "rating" in pair:
-                                rating = pair["rating"]
-                                total_score += rating
-                                total_evaluated += 1
-
-                                if rating >= threshold:
-                                    filtered_pairs.append(pair)
-                                    total_passed += 1
-                    except Exception as e:
-                        if verbose:
-                            print(f"Error processing batch {original_batch_index+1}: {str(e)}")
-                            print(f"First 100 chars of response: {response[:100]}")
-
-                        # Try processing one pair at a time as a fallback
-                        try:
-                            if verbose:
-                                print("Attempting to process items individually...")
-
-                            for item in original_batch:
-                                item_json = json.dumps(item, indent=2)
-                                rating_prompt = rating_prompt_template.format(pairs=item_json)
-                                item_response = client.chat_completion(
-                                    [{"role": "system", "content": rating_prompt}],
-                                    temperature=rating_temperature,
-                                )
-                                try:
-                                    # This should be a single item
-                                    rated_item = parse_ratings(item_response, [item])
-                                    if rated_item and len(rated_item) > 0:
-                                        pair = rated_item[0]
-                                        if "rating" in pair:
-                                            rating = pair["rating"]
-                                            total_score += rating
-                                            total_evaluated += 1
-
-                                            if rating >= threshold:
-                                                filtered_pairs.append(pair)
-                                                total_passed += 1
-                                                if verbose:
-                                                    print(
-                                                        f"Successfully processed individual item with rating {rating}"
-                                                    )
-                                except Exception as inner_e:
-                                    if verbose:
-                                        print(f"Failed to process individual item: {str(inner_e)}")
-                        except Exception as fallback_e:
-                            if verbose:
-                                print(f"Fallback processing failed: {str(fallback_e)}")
-
-                        # Continue processing other batches rather than failing completely
-                        pass
-
-            # Update progress bar if in verbose mode
-            if progress_ctx and rate_task:
-                progress_ctx.update(rate_task, advance=current_batch_size)
-
+    for idx, response in enumerate(rated_batches):
+        original_batch = batches[idx] if idx < len(batches) else []
+        try:
+            filtered_pairs.extend(_parse_and_collect(response, original_batch))
         except Exception as e:
-            if verbose:
-                print(f"Error processing inference batch {batch_num}: {str(e)}")
+            logger.error("Error processing batch %d: %s", idx + 1, e)
 
-            # Update progress bar if in verbose mode
-            if progress_ctx and rate_task:
-                progress_ctx.update(rate_task, advance=current_batch_size)
+        if progress_ctx and rate_task:
+            progress_ctx.update(rate_task, advance=1)
 
     # Stop progress bar if in verbose mode
     if progress_ctx:
@@ -257,8 +194,7 @@ def curate_qa_pairs(
 
     # Clear the progress line in non-verbose mode
     if not verbose:
-        print(" " * 80, end="\r")
-        print("Batch processing complete.")
+        logger.info("Batch processing complete.")
 
     # Calculate metrics
     metrics = {
@@ -269,9 +205,9 @@ def curate_qa_pairs(
     }
 
     # Always print basic stats, even in non-verbose mode
-    print(f"Rated {total_evaluated} QA pairs")
-    print(f"Retained {total_passed} pairs (threshold: {threshold})")
-    print(f"Average score: {metrics['avg_score']}")
+    logger.info("Rated %d QA pairs", total_evaluated)
+    logger.info("Retained %d pairs (threshold: %s)", total_passed, threshold)
+    logger.info("Average score: %s", metrics["avg_score"])
 
     # Convert to conversation format
     conversations = convert_to_conversation_format(filtered_pairs)
@@ -284,11 +220,10 @@ def curate_qa_pairs(
         "metrics": metrics,
     }
 
-    # Ensure output directory exists
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    if output_path:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(result, f, indent=2)
+        return output_path
 
-    # Save result
-    with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(result, f, indent=2)
-
-    return output_path
+    return result

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -6,8 +6,8 @@ import secrets
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 import redis
 

--- a/datacreek/core/save_as.py
+++ b/datacreek/core/save_as.py
@@ -130,8 +130,7 @@ def convert_format(
             return "\n".join(json.dumps(p, ensure_ascii=False) for p in qa_pairs)
         elif format_type == "alpaca":
             formatted = [
-                {"instruction": p["question"], "input": "", "output": p["answer"]}
-                for p in qa_pairs
+                {"instruction": p["question"], "input": "", "output": p["answer"]} for p in qa_pairs
             ]
             if output_path:
                 return to_alpaca(qa_pairs, output_path)

--- a/datacreek/db.py
+++ b/datacreek/db.py
@@ -58,6 +58,7 @@ class Dataset(Base):
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     source_id = Column(Integer, ForeignKey("sources.id"), nullable=False)
     path = Column(String, nullable=False)
+    content = Column(Text, nullable=True)
 
     owner = relationship("User", back_populates="datasets")
     source = relationship("SourceData", back_populates="datasets")

--- a/datacreek/generators/cot_generator.py
+++ b/datacreek/generators/cot_generator.py
@@ -44,7 +44,7 @@ class COTGenerator:
 
     def parse_json_output(self, output_text: str) -> Optional[List[Dict]]:
         """Parse JSON from LLM output text"""
-        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+        verbose = logger.isEnabledFor(logging.DEBUG)
         output_text = output_text.strip()
 
         # Try to extract JSON array
@@ -76,7 +76,7 @@ class COTGenerator:
         self, document_text: str, num_examples: int = None
     ) -> List[Dict[str, Any]]:
         """Generate chain-of-thought reasoning examples"""
-        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+        verbose = logger.isEnabledFor(logging.DEBUG)
 
         # Get default num_examples from config if not provided
         if num_examples is None:
@@ -117,7 +117,7 @@ class COTGenerator:
         self, conversations: List[Dict], include_simple_steps: bool = False
     ) -> List[Dict]:
         """Enhance existing conversations with CoT reasoning"""
-        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+        verbose = logger.isEnabledFor(logging.DEBUG)
 
         # Get the prompt template
         prompt_template = get_prompt(self.config, "cot_enhancement")
@@ -164,13 +164,7 @@ class COTGenerator:
         self, document_text: str, num_examples: int = None, include_simple_steps: bool = False
     ) -> Dict[str, Any]:
         """Process a document to generate CoT examples"""
-        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
-
-        # Set the verbose environment variable
-        if verbose:
-            os.environ["SDK_VERBOSE"] = "true"
-        else:
-            os.environ["SDK_VERBOSE"] = "false"
+        verbose = logger.isEnabledFor(logging.DEBUG)
 
         # Generate summary first (helpful context)
         summary = self.client.chat_completion(

--- a/datacreek/generators/qa_generator.py
+++ b/datacreek/generators/qa_generator.py
@@ -5,11 +5,11 @@
 # the root directory of this source tree.
 # Create QA Pairs
 
+import asyncio
 import json
 import logging
 import os
 import time
-import asyncio
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/datacreek/generators/vqa_generator.py
+++ b/datacreek/generators/vqa_generator.py
@@ -48,7 +48,7 @@ class VQAGenerator:
 
     def transform(self, messages):
         """Transform messages by adding reasoning to VQA data"""
-        verbose = os.environ.get("SDK_VERBOSE", "false").lower() == "true"
+        verbose = logger.isEnabledFor(logging.DEBUG)
 
         # Get prompt from config
         prompt = self.config.get("prompt", "")
@@ -140,11 +140,7 @@ class VQAGenerator:
         Returns:
             Path to the output dataset
         """
-        # Set the verbose environment variable
-        if verbose:
-            os.environ["SDK_VERBOSE"] = "true"
-        else:
-            os.environ["SDK_VERBOSE"] = "false"
+        verbose = logger.isEnabledFor(logging.DEBUG)
 
         try:
             # Try to load from file

--- a/datacreek/models/llm_client.py
+++ b/datacreek/models/llm_client.py
@@ -581,8 +581,10 @@ class LLMClient:
                     temperature or self.config.get("generation", {}).get("temperature", 0.1),
                     max_tokens or self.config.get("generation", {}).get("max_tokens", 4096),
                     top_p or self.config.get("generation", {}).get("top_p", 0.95),
-                    frequency_penalty or self.config.get("generation", {}).get("frequency_penalty", 0.0),
-                    presence_penalty or self.config.get("generation", {}).get("presence_penalty", 0.0),
+                    frequency_penalty
+                    or self.config.get("generation", {}).get("frequency_penalty", 0.0),
+                    presence_penalty
+                    or self.config.get("generation", {}).get("presence_penalty", 0.0),
                     stop or self.config.get("generation", {}).get("stop"),
                     verbose,
                     False,
@@ -598,7 +600,8 @@ class LLMClient:
                 max_tokens or self.config.get("generation", {}).get("max_tokens", 4096),
                 top_p or self.config.get("generation", {}).get("top_p", 0.95),
                 batch_size or self.config.get("generation", {}).get("batch_size", 32),
-                frequency_penalty or self.config.get("generation", {}).get("frequency_penalty", 0.0),
+                frequency_penalty
+                or self.config.get("generation", {}).get("frequency_penalty", 0.0),
                 presence_penalty or self.config.get("generation", {}).get("presence_penalty", 0.0),
                 stop or self.config.get("generation", {}).get("stop"),
                 logger.isEnabledFor(logging.DEBUG),

--- a/datacreek/pipelines.py
+++ b/datacreek/pipelines.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -8,12 +9,7 @@ from typing import Any, Dict, List
 from datacreek.core.create import process_file
 from datacreek.core.curate import curate_qa_pairs
 from datacreek.core.save_as import convert_format
-import logging
-from datacreek.utils.config import (
-    get_format_settings,
-    load_config,
-    merge_configs,
-)
+from datacreek.utils.config import get_format_settings, load_config, merge_configs
 
 logger = logging.getLogger(__name__)
 

--- a/datacreek/server/app.py
+++ b/datacreek/server/app.py
@@ -1422,6 +1422,7 @@ def curate():
                 model=model,
                 config_path=None,  # Use default config
                 verbose=True,
+                async_mode=False,
             )
 
             flash(f"Successfully curated QA pairs! Output saved to: {result_path}", "success")

--- a/datacreek/services.py
+++ b/datacreek/services.py
@@ -65,8 +65,15 @@ def create_source(
     return src
 
 
-def create_dataset(db: Session, owner_id: int | None, source_id: int, path: str) -> Dataset:
-    ds = Dataset(owner_id=owner_id, source_id=source_id, path=path)
+def create_dataset(
+    db: Session,
+    owner_id: int | None,
+    source_id: int,
+    *,
+    path: str | None = None,
+    content: str | None = None,
+) -> Dataset:
+    ds = Dataset(owner_id=owner_id, source_id=source_id, path=path or "", content=content)
     db.add(ds)
     db.commit()
     db.refresh(ds)

--- a/datacreek/tasks.py
+++ b/datacreek/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import json
 from pathlib import Path
 
 from celery import Celery
@@ -13,6 +14,7 @@ from datacreek.db import Dataset, SessionLocal, SourceData
 from datacreek.services import create_dataset, create_source
 from datacreek.utils import extract_entities as extract_entities_func
 from datacreek.utils import extract_facts as extract_facts_func
+from datacreek.utils import get_path_config, load_config
 
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "memory://")
 CELERY_BACKEND_URL = os.environ.get("CELERY_RESULT_BACKEND", "cache+memory://")
@@ -73,7 +75,10 @@ def generate_task(
         src = db.get(SourceData, src_id)
         if not src or src.owner_id != user_id:
             raise RuntimeError("Source not found")
-        output_dir = Path("data/generated")
+        from datacreek.utils import load_config, get_path_config
+
+        cfg = load_config(str(config_path) if config_path else None)
+        output_dir = Path(get_path_config(cfg, "output", "generated"))
         output_dir.mkdir(parents=True, exist_ok=True)
         overrides = {}
         if generation is not None:
@@ -82,7 +87,7 @@ def generate_task(
             overrides["prompts"] = prompts
         out = generate_data(
             None,
-            str(output_dir),
+            None,
             Path(config_path) if config_path else None,
             api_base,
             model,
@@ -94,7 +99,7 @@ def generate_task(
             document_text=src.content,
             config_overrides=overrides if overrides else None,
         )
-        ds = create_dataset(db, user_id, src_id, out)
+        ds = create_dataset(db, user_id, src_id, content=json.dumps(out))
         return {"id": ds.id}
 
 
@@ -104,9 +109,9 @@ def curate_task(user_id: int, ds_id: int, threshold: float | None) -> dict:
         ds = db.get(Dataset, ds_id)
         if not ds or ds.owner_id != user_id:
             raise RuntimeError("Dataset not found")
-        output_path = Path(ds.path).with_name(Path(ds.path).stem + "_curated.json")
-        curate_qa_pairs(ds.path, str(output_path), threshold, None, None, None, False)
-        ds.path = str(output_path)
+        data = json.loads(ds.content or "{}")
+        result = curate_qa_pairs(data, None, threshold, None, None, None, False, async_mode=False)
+        ds.content = json.dumps(result)
         db.commit()
         db.refresh(ds)
         return {"id": ds.id}
@@ -118,8 +123,9 @@ def save_task(user_id: int, ds_id: int, fmt: str) -> dict:
         ds = db.get(Dataset, ds_id)
         if not ds or ds.owner_id != user_id:
             raise RuntimeError("Dataset not found")
-        out = convert_format(ds.path, None, fmt, {}, "json")
-        ds.path = out
+        data = json.loads(ds.content or "{}")
+        out = convert_format(data, None, fmt, {}, "json")
+        ds.content = out if isinstance(out, str) else json.dumps(out)
         db.commit()
         db.refresh(ds)
         return {"id": ds.id}

--- a/datacreek/tasks.py
+++ b/datacreek/tasks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import os
 import json
+import os
 from pathlib import Path
 
 from celery import Celery
@@ -75,7 +75,7 @@ def generate_task(
         src = db.get(SourceData, src_id)
         if not src or src.owner_id != user_id:
             raise RuntimeError("Source not found")
-        from datacreek.utils import load_config, get_path_config
+        from datacreek.utils import get_path_config, load_config
 
         cfg = load_config(str(config_path) if config_path else None)
         output_dir = Path(get_path_config(cfg, "output", "generated"))

--- a/datacreek/utils/__init__.py
+++ b/datacreek/utils/__init__.py
@@ -1,26 +1,27 @@
 """Utility helpers for datacreek."""
 
+from datacreek.pipelines import run_generation_pipeline
+
 from .config import (
     get_curate_config,
     get_curate_settings,
     get_format_config,
     get_format_settings,
-    get_output_paths,
     get_generation_config,
+    get_llm_settings,
+    get_openai_config,
+    get_openai_settings,
+    get_output_paths,
     get_path_config,
     get_prompt,
     get_vllm_config,
     get_vllm_settings,
-    get_openai_config,
-    get_openai_settings,
-    get_llm_settings,
     load_config,
     merge_configs,
 )
 from .entity_extraction import extract_entities
 from .fact_extraction import extract_facts
 from .llm_processing import convert_to_conversation_format, parse_qa_pairs, parse_ratings
-from datacreek.pipelines import run_generation_pipeline
 from .text import clean_text, extract_json_from_text, split_into_chunks
 
 __all__ = [

--- a/datacreek/utils/__init__.py
+++ b/datacreek/utils/__init__.py
@@ -2,26 +2,41 @@
 
 from .config import (
     get_curate_config,
+    get_curate_settings,
     get_format_config,
+    get_format_settings,
+    get_output_paths,
     get_generation_config,
     get_path_config,
     get_prompt,
     get_vllm_config,
+    get_vllm_settings,
+    get_openai_config,
+    get_openai_settings,
+    get_llm_settings,
     load_config,
     merge_configs,
 )
 from .entity_extraction import extract_entities
 from .fact_extraction import extract_facts
 from .llm_processing import convert_to_conversation_format, parse_qa_pairs, parse_ratings
+from datacreek.pipelines import run_generation_pipeline
 from .text import clean_text, extract_json_from_text, split_into_chunks
 
 __all__ = [
     "load_config",
     "get_path_config",
     "get_vllm_config",
+    "get_vllm_settings",
+    "get_openai_config",
+    "get_openai_settings",
+    "get_llm_settings",
     "get_generation_config",
     "get_curate_config",
+    "get_curate_settings",
     "get_format_config",
+    "get_format_settings",
+    "get_output_paths",
     "get_prompt",
     "merge_configs",
     "split_into_chunks",
@@ -32,4 +47,5 @@ __all__ = [
     "convert_to_conversation_format",
     "extract_facts",
     "extract_entities",
+    "run_generation_pipeline",
 ]

--- a/datacreek/utils/batch.py
+++ b/datacreek/utils/batch.py
@@ -1,0 +1,66 @@
+import logging
+from typing import Any, Callable, Dict, List
+
+
+from datacreek.models.llm_client import LLMClient
+
+logger = logging.getLogger(__name__)
+
+
+def process_batches(
+    client: LLMClient,
+    message_batches: List[List[Dict[str, str]]],
+    *,
+    batch_size: int,
+    temperature: float,
+    parse_fn: Callable[[str], Any],
+) -> List[Any]:
+    """Helper to run LLM requests in batches with basic error handling."""
+    results: List[Any] = []
+    for start in range(0, len(message_batches), batch_size):
+        end = min(start + batch_size, len(message_batches))
+        batch = message_batches[start:end]
+        try:
+            responses = client.batch_completion(
+                batch,
+                temperature=temperature,
+                batch_size=batch_size,
+            )
+            for resp in responses:
+                try:
+                    results.append(parse_fn(resp))
+                except Exception as parse_err:
+                    logger.error("Failed to parse response: %s", parse_err)
+        except Exception as e:
+            logger.error("Error processing batch %s-%s: %s", start, end, e)
+    return results
+
+
+async def async_process_batches(
+    client: LLMClient,
+    message_batches: List[List[Dict[str, str]]],
+    *,
+    batch_size: int,
+    temperature: float,
+    parse_fn: Callable[[str], Any],
+) -> List[Any]:
+    """Asynchronously process message batches with :class:`LLMClient`."""
+
+    results: List[Any] = []
+    for start in range(0, len(message_batches), batch_size):
+        end = min(start + batch_size, len(message_batches))
+        batch = message_batches[start:end]
+        try:
+            responses = await client.async_batch_completion(
+                batch,
+                temperature=temperature,
+                batch_size=batch_size,
+            )
+            for resp in responses:
+                try:
+                    results.append(parse_fn(resp))
+                except Exception as parse_err:
+                    logger.error("Failed to parse response: %s", parse_err)
+        except Exception as e:
+            logger.error("Error processing batch %s-%s: %s", start, end, e)
+    return results

--- a/datacreek/utils/batch.py
+++ b/datacreek/utils/batch.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any, Callable, Dict, List
 
-
 from datacreek.models.llm_client import LLMClient
 
 logger = logging.getLogger(__name__)

--- a/datacreek/utils/config.py
+++ b/datacreek/utils/config.py
@@ -11,7 +11,15 @@ from typing import Any, Dict, Optional
 
 import yaml
 
-from datacreek.config_models import GenerationSettings
+from datacreek.config_models import (
+    GenerationSettings,
+    CurateSettings,
+    FormatSettings,
+    OutputPaths,
+    VLLMSettings,
+    OpenAISettings,
+    LLMSettings,
+)
 
 # Default config location relative to the package (original)
 ORIGINAL_CONFIG_PATH = os.path.abspath(
@@ -98,9 +106,19 @@ def get_llm_provider(config: Dict[str, Any]) -> str:
     return provider
 
 
-def get_vllm_config(config: Dict[str, Any]) -> Dict[str, Any]:
-    """Get VLLM configuration"""
-    return config.get(
+def get_llm_settings(config: Dict[str, Any]) -> LLMSettings:
+    """Return general LLM configuration as :class:`LLMSettings`."""
+
+    llm_cfg = config.get("llm", {})
+    defaults = {"provider": "vllm"}
+    defaults.update(llm_cfg)
+    return LLMSettings.from_dict(defaults)
+
+
+def get_vllm_settings(config: Dict[str, Any]) -> VLLMSettings:
+    """Return VLLM configuration as :class:`VLLMSettings`."""
+
+    defaults = config.get(
         "vllm",
         {
             "api_base": "http://localhost:8000/v1",
@@ -109,21 +127,40 @@ def get_vllm_config(config: Dict[str, Any]) -> Dict[str, Any]:
             "max_retries": 3,
             "retry_delay": 1.0,
         },
-    )
+    ).copy()
+    for field_name in VLLMSettings.__dataclass_fields__:
+        defaults.setdefault(field_name, getattr(VLLMSettings(), field_name))
+    return VLLMSettings.from_dict(defaults)
 
 
-def get_openai_config(config: Dict[str, Any]) -> Dict[str, Any]:
-    """Get API endpoint configuration"""
-    return config.get(
+def get_vllm_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Backwards compatible wrapper returning a plain dictionary."""
+
+    return get_vllm_settings(config).__dict__
+
+
+def get_openai_settings(config: Dict[str, Any]) -> OpenAISettings:
+    """Return OpenAI/API endpoint configuration as :class:`OpenAISettings`."""
+
+    defaults = config.get(
         "api-endpoint",
         {
-            "api_base": None,  # None means use default API base URL
-            "api_key": None,  # None means use environment variables
+            "api_base": None,
+            "api_key": None,
             "model": "gpt-4o",
             "max_retries": 3,
             "retry_delay": 1.0,
         },
-    )
+    ).copy()
+    for field_name in OpenAISettings.__dataclass_fields__:
+        defaults.setdefault(field_name, getattr(OpenAISettings(), field_name))
+    return OpenAISettings.from_dict(defaults)
+
+
+def get_openai_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Backwards compatible wrapper returning a plain dictionary."""
+
+    return get_openai_settings(config).__dict__
 
 
 def _env_override(key: str) -> Optional[str]:
@@ -155,6 +192,30 @@ def get_generation_config(config: Dict[str, Any]) -> GenerationSettings:
 def get_curate_config(config: Dict[str, Any]) -> Dict[str, Any]:
     """Get curation configuration"""
     return config.get("curate", {"threshold": 7.0, "batch_size": 8, "temperature": 0.1})
+
+
+def get_curate_settings(config: Dict[str, Any]) -> CurateSettings:
+    """Return curation configuration as :class:`CurateSettings`."""
+    defaults = config.get("curate", {}).copy()
+    for field_name in CurateSettings.__dataclass_fields__:
+        defaults.setdefault(field_name, getattr(CurateSettings(), field_name))
+    return CurateSettings.from_dict(defaults)
+
+
+def get_format_settings(config: Dict[str, Any]) -> FormatSettings:
+    """Return output formatting configuration as :class:`FormatSettings`."""
+    defaults = config.get("format", {}).copy()
+    for field_name in FormatSettings.__dataclass_fields__:
+        defaults.setdefault(field_name, getattr(FormatSettings(), field_name))
+    return FormatSettings.from_dict(defaults)
+
+
+def get_output_paths(config: Dict[str, Any]) -> OutputPaths:
+    """Return output path settings as :class:`OutputPaths`."""
+    defaults = config.get("paths", {}).get("output", {}).copy()
+    for field_name in OutputPaths.__dataclass_fields__:
+        defaults.setdefault(field_name, getattr(OutputPaths(), field_name))
+    return OutputPaths.from_dict(defaults)
 
 
 def get_format_config(config: Dict[str, Any]) -> Dict[str, Any]:

--- a/datacreek/utils/config.py
+++ b/datacreek/utils/config.py
@@ -12,13 +12,13 @@ from typing import Any, Dict, Optional
 import yaml
 
 from datacreek.config_models import (
-    GenerationSettings,
     CurateSettings,
     FormatSettings,
+    GenerationSettings,
+    LLMSettings,
+    OpenAISettings,
     OutputPaths,
     VLLMSettings,
-    OpenAISettings,
-    LLMSettings,
 )
 
 # Default config location relative to the package (original)

--- a/datacreek/utils/llm_processing.py
+++ b/datacreek/utils/llm_processing.py
@@ -175,7 +175,9 @@ def parse_ratings(text: str, original_items: List[Dict[str, str]] = None) -> Lis
                                 break
                         if valid_items and len(parsed) > 0:
                             if verbose:
-                                logger.debug("Successfully parsed %d items from code block", len(parsed))
+                                logger.debug(
+                                    "Successfully parsed %d items from code block", len(parsed)
+                                )
                             return parsed
                 except json.JSONDecodeError:
                     pass
@@ -207,7 +209,9 @@ def parse_ratings(text: str, original_items: List[Dict[str, str]] = None) -> Lis
                             return [parsed]
                         elif isinstance(parsed, list) and all("rating" in item for item in parsed):
                             if verbose:
-                                logger.debug("Successfully parsed %d items using regex", len(parsed))
+                                logger.debug(
+                                    "Successfully parsed %d items using regex", len(parsed)
+                                )
                             return parsed
                     except json.JSONDecodeError:
                         pass
@@ -260,7 +264,7 @@ def parse_ratings(text: str, original_items: List[Dict[str, str]] = None) -> Lis
                             logger.debug(
                                 "Found rating %s for question: %s...",
                                 rating,
-                                item.get('question', '')[:30],
+                                item.get("question", "")[:30],
                             )
                     except:
                         pass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,19 +55,13 @@ def test_async_pipeline(monkeypatch, tmp_path):
     def dummy_generate(path, output_dir, *args, document_text=None, **kwargs):
         assert kwargs.get("config_overrides") == {"generation": {"temperature": 0.1}}
         assert kwargs.get("provider") == "api-endpoint"
-        out = Path(output_dir) / "gen.json"
-        with open(out, "w") as f:
-            json.dump({"qa_pairs": [{"question": "q", "answer": "a"}]}, f)
-        return str(out)
+        return {"qa_pairs": [{"question": "q", "answer": "a"}]}
 
-    def dummy_curate(input_path, output_path, *args, **kwargs):
-        Path(output_path).write_text(Path(input_path).read_text())
-        return output_path
+    def dummy_curate(data, output_path=None, *args, **kwargs):
+        return data
 
-    def dummy_save(input_path, output_path, fmt, cfg, storage):
-        out = Path(tmp_path) / f"final.{fmt}"
-        Path(out).write_text(Path(input_path).read_text())
-        return str(out)
+    def dummy_save(data, output_path, fmt, cfg, storage):
+        return "converted"
 
     monkeypatch.setattr("datacreek.tasks.generate_data", dummy_generate)
     monkeypatch.setattr("datacreek.tasks.curate_qa_pairs", dummy_curate)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,54 @@
+import asyncio
+from datacreek.utils.batch import async_process_batches
+
+class DummyClient:
+    def __init__(self):
+        self.calls = []
+
+    async def async_batch_completion(self, batches, *, temperature=None, batch_size=None):
+        self.calls.append((batches, temperature, batch_size))
+        return ["resp:" + batch[0]["content"] for batch in batches]
+
+def test_async_process_batches():
+    client = DummyClient()
+    messages = [[{"role": "user", "content": "a"}], [{"role": "user", "content": "b"}]]
+
+    async def run():
+        res = await async_process_batches(
+            client,
+            messages,
+            batch_size=1,
+            temperature=0.2,
+            parse_fn=lambda s: s.upper(),
+        )
+        assert res == ["RESP:A", "RESP:B"]
+    asyncio.run(run())
+    assert len(client.calls) == 2
+
+
+def test_curate_async_mode(monkeypatch):
+    async_called = {}
+
+    class DummyClient2:
+        def __init__(self):
+            self.config = {"prompts": {"qa_rating": "{pairs}"}, "curate": {"batch_size": 1, "temperature": 0.1, "threshold": 0.0}}
+        async def async_batch_completion(self, batches, *, temperature=None, batch_size=None):
+            async_called['count'] = len(batches)
+            return ['{"rating": 9}'] * len(batches)
+
+    monkeypatch.setattr('datacreek.core.curate.LLMClient', lambda *a, **k: DummyClient2())
+    async def fake_async(client, msgs, *, batch_size, temperature, parse_fn):
+        async_called['count'] = len(msgs)
+        return [parse_fn('{"rating": 9}') for _ in msgs]
+
+    monkeypatch.setattr('datacreek.utils.batch.async_process_batches', fake_async)
+    monkeypatch.setattr('datacreek.core.curate.parse_ratings', lambda resp, orig: [{'rating': 9}])
+    monkeypatch.setattr('datacreek.core.curate.convert_to_conversation_format', lambda pairs: [])
+
+    from datacreek.core.curate import curate_qa_pairs
+
+    data = {"summary": "", "qa_pairs": [{"question": "q", "answer": "a"}]}
+    result = curate_qa_pairs(data, async_mode=True)
+
+    assert async_called.get('count') == 1
+    assert result['qa_pairs'] == [{'rating': 9}]

--- a/tests/test_batch_add_async.py
+++ b/tests/test_batch_add_async.py
@@ -1,23 +1,30 @@
 from datacreek.generators.qa_generator import QAGenerator
 
+
 class DummyClient:
     def __init__(self):
-        self.config = {"prompts": {"qa_rating": "{pairs}"}, "curate": {"batch_size": 1, "temperature": 0.1, "threshold": 0.0}}
+        self.config = {
+            "prompts": {"qa_rating": "{pairs}"},
+            "curate": {"batch_size": 1, "temperature": 0.1, "threshold": 0.0},
+        }
+
 
 async_called = {}
 
+
 async def fake_async(client, messages, *, batch_size, temperature, parse_fn):
-    async_called['count'] = len(messages)
+    async_called["count"] = len(messages)
     return ["{}"] * len(messages)
 
 
 def test_rate_qa_pairs_async(monkeypatch):
     monkeypatch.setattr("datacreek.utils.batch.async_process_batches", fake_async)
-    monkeypatch.setattr("datacreek.generators.qa_generator.parse_ratings", lambda resp, orig: [{"rating": 9}])
+    monkeypatch.setattr(
+        "datacreek.generators.qa_generator.parse_ratings", lambda resp, orig: [{"rating": 9}]
+    )
 
     gen = QAGenerator(DummyClient())
     pairs, metrics = gen.rate_qa_pairs([{"question": "q", "answer": "a"}], "", async_mode=True)
 
-    assert async_called.get('count') == 1
+    assert async_called.get("count") == 1
     assert pairs == [{"rating": 9}]
-

--- a/tests/test_batch_add_async.py
+++ b/tests/test_batch_add_async.py
@@ -1,0 +1,23 @@
+from datacreek.generators.qa_generator import QAGenerator
+
+class DummyClient:
+    def __init__(self):
+        self.config = {"prompts": {"qa_rating": "{pairs}"}, "curate": {"batch_size": 1, "temperature": 0.1, "threshold": 0.0}}
+
+async_called = {}
+
+async def fake_async(client, messages, *, batch_size, temperature, parse_fn):
+    async_called['count'] = len(messages)
+    return ["{}"] * len(messages)
+
+
+def test_rate_qa_pairs_async(monkeypatch):
+    monkeypatch.setattr("datacreek.utils.batch.async_process_batches", fake_async)
+    monkeypatch.setattr("datacreek.generators.qa_generator.parse_ratings", lambda resp, orig: [{"rating": 9}])
+
+    gen = QAGenerator(DummyClient())
+    pairs, metrics = gen.rate_qa_pairs([{"question": "q", "answer": "a"}], "", async_mode=True)
+
+    assert async_called.get('count') == 1
+    assert pairs == [{"rating": 9}]
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,8 +2,32 @@ import os
 
 import pytest
 
-from datacreek.config_models import GenerationSettings, GenerationSettingsModel
-from datacreek.utils.config import get_generation_config, load_config
+from datacreek.config_models import (
+    GenerationSettings,
+    GenerationSettingsModel,
+    CurateSettings,
+    CurateSettingsModel,
+    FormatSettings,
+    FormatSettingsModel,
+    OutputPaths,
+    OutputPathsModel,
+    VLLMSettings,
+    VLLMSettingsModel,
+    OpenAISettings,
+    OpenAISettingsModel,
+    LLMSettings,
+    LLMSettingsModel,
+)
+from datacreek.utils.config import (
+    get_generation_config,
+    get_curate_settings,
+    get_format_settings,
+    get_output_paths,
+    get_vllm_settings,
+    get_openai_settings,
+    get_llm_settings,
+    load_config,
+)
 
 
 def test_env_override(monkeypatch):
@@ -20,3 +44,52 @@ def test_generation_settings_model_validation():
     assert settings.temperature == 0.4
     with pytest.raises(Exception):
         GenerationSettingsModel(temperature="hot")
+
+
+def test_curate_settings_model_validation():
+    cfg = load_config()
+    cur = get_curate_settings(cfg)
+    assert isinstance(cur, CurateSettings)
+    model = CurateSettingsModel(threshold=6.5)
+    settings = model.to_settings()
+    assert settings.threshold == 6.5
+
+
+def test_format_settings_model_and_loader():
+    cfg = load_config()
+    fmt = get_format_settings(cfg)
+    assert isinstance(fmt, FormatSettings)
+    model = FormatSettingsModel(default="json")
+    settings = model.to_settings()
+    assert settings.default == "json"
+
+
+def test_output_paths_model_and_loader():
+    cfg = load_config()
+    out = get_output_paths(cfg)
+    assert isinstance(out, OutputPaths)
+    model = OutputPathsModel(parsed="files/parsed")
+    settings = model.to_settings()
+    assert settings.parsed == "files/parsed"
+
+
+def test_llm_and_provider_models():
+    cfg = load_config()
+    llm = get_llm_settings(cfg)
+    assert isinstance(llm, LLMSettings)
+    assert llm.provider in {"vllm", "api-endpoint"}
+
+    vllm_settings = get_vllm_settings(cfg)
+    assert isinstance(vllm_settings, VLLMSettings)
+
+    oa_settings = get_openai_settings(cfg)
+    assert isinstance(oa_settings, OpenAISettings)
+
+    model = VLLMSettingsModel(api_base="http://example.com")
+    assert model.to_settings().api_base == "http://example.com"
+
+    oa_model = OpenAISettingsModel(model="gpt-4")
+    assert oa_model.to_settings().model == "gpt-4"
+
+    llm_model = LLMSettingsModel(provider="api-endpoint")
+    assert llm_model.to_settings().provider == "api-endpoint"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,29 +3,29 @@ import os
 import pytest
 
 from datacreek.config_models import (
-    GenerationSettings,
-    GenerationSettingsModel,
     CurateSettings,
     CurateSettingsModel,
     FormatSettings,
     FormatSettingsModel,
+    GenerationSettings,
+    GenerationSettingsModel,
+    LLMSettings,
+    LLMSettingsModel,
+    OpenAISettings,
+    OpenAISettingsModel,
     OutputPaths,
     OutputPathsModel,
     VLLMSettings,
     VLLMSettingsModel,
-    OpenAISettings,
-    OpenAISettingsModel,
-    LLMSettings,
-    LLMSettingsModel,
 )
 from datacreek.utils.config import (
-    get_generation_config,
     get_curate_settings,
     get_format_settings,
+    get_generation_config,
+    get_llm_settings,
+    get_openai_settings,
     get_output_paths,
     get_vllm_settings,
-    get_openai_settings,
-    get_llm_settings,
     load_config,
 )
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,0 +1,23 @@
+import os
+from pathlib import Path
+
+from datacreek.core.create import _base_name, load_document_text, resolve_output_dir
+from datacreek.utils import load_config
+
+
+def test_base_name_helper():
+    assert _base_name("/tmp/foo.txt") == "foo"
+    assert _base_name(None) == "input"
+
+
+def test_load_document_text(tmp_path):
+    p = tmp_path / "doc.txt"
+    p.write_text("hello")
+    assert load_document_text(str(p)) == "hello"
+
+
+def test_resolve_output_dir(tmp_path):
+    cfg_path = Path("configs/config.yaml")
+    cfg = load_config(str(cfg_path))
+    out_dir = resolve_output_dir(cfg_path)
+    assert out_dir == cfg["paths"]["output"]["generated"]

--- a/tests/test_llm_logging.py
+++ b/tests/test_llm_logging.py
@@ -57,4 +57,3 @@ def test_debug_mode_uses_logging(monkeypatch):
     assert called["debug"] is True
 
     logger.setLevel(old_level)
-

--- a/tests/test_llm_logging.py
+++ b/tests/test_llm_logging.py
@@ -1,0 +1,60 @@
+import logging
+import os
+
+import pytest
+
+import datacreek.utils  # ensure utils loaded to avoid circular import
+from datacreek.models.llm_client import LLMClient, logger
+
+
+class DummyResponse:
+    def __init__(self):
+        self.choices = [{"message": {"content": "ok"}}]
+
+
+class DummyOpenAI:
+    class Chat:
+        class Completions:
+            @staticmethod
+            def create(**kwargs):
+                return DummyResponse()
+
+        completions = Completions()
+
+    chat = Chat()
+
+
+class DummyLLMClient:
+    def __init__(self):
+        self.provider = "api-endpoint"
+        self.config = {"generation": {}}
+        self.model = "gpt"
+        self.max_retries = 1
+        self.retry_delay = 0
+        self.openai_client = DummyOpenAI()
+
+
+def test_debug_mode_uses_logging(monkeypatch):
+    dummy = DummyLLMClient()
+    called = {}
+
+    def fake_openai_chat_completion(self, *args, **kwargs):
+        called["debug"] = logger.isEnabledFor(logging.DEBUG)
+        return "ok"
+
+    monkeypatch.setattr(LLMClient, "_openai_chat_completion", fake_openai_chat_completion)
+    dummy._openai_chat_completion = fake_openai_chat_completion.__get__(dummy, DummyLLMClient)
+
+    old_level = logger.level
+    os.environ["SDK_DEBUG"] = "true"
+
+    logger.setLevel(logging.INFO)
+    LLMClient.chat_completion(dummy, [{"role": "user", "content": "hi"}])
+    assert called["debug"] is False
+
+    logger.setLevel(logging.DEBUG)
+    LLMClient.chat_completion(dummy, [{"role": "user", "content": "hi"}])
+    assert called["debug"] is True
+
+    logger.setLevel(old_level)
+

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,7 +1,7 @@
 from datacreek.pipelines import (
     DatasetType,
-    TrainingGoal,
     PipelineStep,
+    TrainingGoal,
     get_dataset_types_for_training,
     get_pipelines_for_training,
     get_trainings_for_dataset,


### PR DESCRIPTION
## Summary
- extend `curate_qa_pairs` with optional async mode
- pass async mode from generation pipeline
- update server and tasks to pass async flag
- add tests covering async curation and pipeline propagation
- implement asynchronous rating in `QAGenerator.rate_qa_pairs`
- add unit test verifying async mode for rating
- switch LLM debug behavior to rely on the logger's DEBUG level
- test that SDK_DEBUG env var no longer controls debug output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f700d18f0832f88656f8dec9b5b8f