### PR TITLE
Améliorer la génération QA

### DIFF
--- a/datacreek/core/curate.py
+++ b/datacreek/core/curate.py
@@ -17,9 +17,9 @@ from datacreek.models.llm_client import LLMClient
 from datacreek.utils.config import get_curate_settings, get_prompt
 
 logger = logging.getLogger(__name__)
-from datacreek.utils.llm_processing import convert_to_conversation_format, parse_ratings
-from datacreek.models.results import CurationMetrics, CurationResult
 from datacreek.models.qa import QAPair
+from datacreek.models.results import CurationMetrics, CurationResult
+from datacreek.utils.llm_processing import convert_to_conversation_format, parse_ratings
 
 
 def curate_qa_pairs(
@@ -216,7 +216,10 @@ def curate_qa_pairs(
 
     result = CurationResult(
         summary=summary,
-        qa_pairs=[QAPair(question=p["question"], answer=p["answer"], rating=p.get("rating")) for p in filtered_pairs],
+        qa_pairs=[
+            QAPair(question=p["question"], answer=p["answer"], rating=p.get("rating"))
+            for p in filtered_pairs
+        ],
         conversations=conversations,
         metrics=metrics,
     )

--- a/datacreek/core/save_as.py
+++ b/datacreek/core/save_as.py
@@ -27,10 +27,7 @@ def _format_pairs(qa_pairs: List[Dict[str, str]], fmt: str) -> Any:
         return "\n".join(json.dumps(p, ensure_ascii=False) for p in qa_pairs)
     if fmt == "alpaca":
         return json.dumps(
-            [
-                {"instruction": p["question"], "input": "", "output": p["answer"]}
-                for p in qa_pairs
-            ],
+            [{"instruction": p["question"], "input": "", "output": p["answer"]} for p in qa_pairs],
             indent=2,
         )
     if fmt in {"ft", "chatml"}:

--- a/datacreek/generators/cot_generator.py
+++ b/datacreek/generators/cot_generator.py
@@ -12,9 +12,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from datacreek.models.cot import COTExample
-from datacreek.models.results import COTGenerationResult
-
 from datacreek.models.llm_client import LLMClient
+from datacreek.models.results import COTGenerationResult
 from datacreek.utils.config import get_generation_config, get_prompt, load_config
 
 logger = logging.getLogger(__name__)

--- a/datacreek/generators/cot_generator.py
+++ b/datacreek/generators/cot_generator.py
@@ -11,8 +11,11 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from datacreek.models.cot import COTExample
+from datacreek.models.results import COTGenerationResult
+
 from datacreek.models.llm_client import LLMClient
-from datacreek.utils.config import get_generation_config, get_prompt
+from datacreek.utils.config import get_generation_config, get_prompt, load_config
 
 logger = logging.getLogger(__name__)
 
@@ -101,12 +104,26 @@ class COTGenerator:
         )
 
         # Parse response
-        examples = self.parse_json_output(response)
+        parsed = self.parse_json_output(response)
 
-        if examples is None:
+        examples: List[COTExample] = []
+        if parsed is None:
             if verbose:
                 logger.warning("Failed to parse CoT examples, returning empty list")
             return []
+
+        for item in parsed:
+            if not isinstance(item, dict):
+                if verbose:
+                    logger.debug("Skipping malformed item: %r", item)
+                continue
+            examples.append(
+                COTExample(
+                    question=item.get("question", ""),
+                    reasoning=item.get("reasoning", ""),
+                    answer=item.get("answer", ""),
+                )
+            )
 
         if verbose:
             logger.info("Successfully generated %d CoT examples", len(examples))
@@ -162,7 +179,7 @@ class COTGenerator:
 
     def process_document(
         self, document_text: str, num_examples: int = None, include_simple_steps: bool = False
-    ) -> Dict[str, Any]:
+    ) -> COTGenerationResult:
         """Process a document to generate CoT examples"""
         verbose = logger.isEnabledFor(logging.DEBUG)
 
@@ -181,22 +198,27 @@ class COTGenerator:
         # Format into simple conversation format as well
         conversations = []
         for example in examples:
-            if "question" in example and "reasoning" in example and "answer" in example:
-                conv = [
-                    {
-                        "role": "system",
-                        "content": "You are a helpful assistant that provides detailed explanations.",
-                    },
-                    {"role": "user", "content": example["question"]},
-                    {
-                        "role": "assistant",
-                        "content": f"Let me think through this step by step:\n\n{example['reasoning']}\n\nSo the answer is: {example['answer']}",
-                    },
-                ]
-                conversations.append(conv)
+            conv = [
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant that provides detailed explanations.",
+                },
+                {"role": "user", "content": example.question},
+                {
+                    "role": "assistant",
+                    "content": (
+                        "Let me think through this step by step:\n\n"
+                        f"{example.reasoning}\n\nSo the answer is: {example.answer}"
+                    ),
+                },
+            ]
+            conversations.append(conv)
 
-        # Prepare result
-        result = {"summary": summary, "cot_examples": examples, "conversations": conversations}
+        result = COTGenerationResult(
+            summary=summary,
+            cot_examples=examples,
+            conversations=conversations,
+        )
 
         logger.info("Generated %d chain-of-thought examples", len(examples))
 

--- a/datacreek/generators/qa_generator.py
+++ b/datacreek/generators/qa_generator.py
@@ -28,6 +28,7 @@ from datacreek.utils.llm_processing import (
     parse_qa_pairs,
     parse_ratings,
 )
+from datacreek.models.qa import QAPair
 from datacreek.utils.text import split_into_chunks
 
 logger = logging.getLogger(__name__)
@@ -45,12 +46,19 @@ class QAGenerator:
         self.client = client
         self.kg = kg
 
-        # Load config and merge overrides if provided
-        self.config = load_config(config_path)
+        # Load base configuration from file or use the client's config
+        if config_path:
+            base_cfg = load_config(config_path)
+        else:
+            base_cfg = client.config
+
+        # Merge overrides if provided
         if config_overrides:
             from datacreek.utils.config import merge_configs
 
-            self.config = merge_configs(self.config, config_overrides)
+            base_cfg = merge_configs(base_cfg, config_overrides)
+
+        self.config = base_cfg
 
         # Get specific configurations
         self.generation_config = get_generation_config(self.config)
@@ -88,7 +96,7 @@ class QAGenerator:
         query: Optional[str] = None,
         *,
         async_mode: bool = False,
-    ) -> List[Dict[str, str]]:
+    ) -> List[QAPair]:
         """Generate QA pairs from the document using batched processing"""
         verbose = logger.isEnabledFor(logging.DEBUG)
 
@@ -126,7 +134,7 @@ class QAGenerator:
             logger.info("Document split into %d chunks", len(chunks))
             logger.info("Using batch size of %d", batch_size)
 
-        all_qa_pairs = []
+        all_qa_pairs: List[QAPair] = []
         pairs_per_chunk = max(1, round(num_pairs / len(chunks)))
 
         # Get QA generation prompt template
@@ -213,12 +221,12 @@ class QAGenerator:
 
     def rate_qa_pairs(
         self,
-        qa_pairs: List[Dict[str, str]],
+        qa_pairs: List[QAPair],
         summary: str,
         threshold: Optional[float] = None,
         *,
         async_mode: bool = False,
-    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    ) -> Tuple[List[QAPair], Dict[str, Any]]:
         """Rate and filter QA pairs by quality.
 
         When ``async_mode`` is ``True`` the LLM calls are executed concurrently
@@ -246,7 +254,7 @@ class QAGenerator:
         # Process in batches
         batches = [qa_pairs[i : i + batch_size] for i in range(0, len(qa_pairs), batch_size)]
 
-        rated_pairs: List[Dict[str, Any]] = []
+        rated_pairs: List[QAPair] = []
         total_score = 0.0
 
         # Create progress bar
@@ -292,9 +300,9 @@ class QAGenerator:
                 try:
                     rated_batch = parse_ratings(response, batches[idx])
                     for pair in rated_batch:
-                        if "rating" in pair:
-                            total_score += pair["rating"]
-                            if pair["rating"] >= threshold:
+                        if pair.rating is not None:
+                            total_score += pair.rating
+                            if pair.rating >= threshold:
                                 rated_pairs.append(pair)
                 except Exception as e:
                     logger.error("Error processing batch %d: %s", idx + 1, e)
@@ -317,7 +325,7 @@ class QAGenerator:
             threshold,
         )
         logger.info("Average score: %s", metrics["avg_score"])
-        return rated_pairs, metrics
+        return [p.to_dict() for p in rated_pairs], metrics
 
     def process_document(
         self,
@@ -326,7 +334,7 @@ class QAGenerator:
         verbose: bool = False,
         *,
         async_mode: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> "QAGenerationResult":
         """Process a document to generate QA pairs without rating."""
         # Set the verbose environment variable
         # Verbose mode is controlled by logging level
@@ -343,6 +351,6 @@ class QAGenerator:
         )
 
         # Prepare result - no rating at this stage
-        result = {"summary": summary, "qa_pairs": qa_pairs}
+        from datacreek.models.results import QAGenerationResult
 
-        return result
+        return QAGenerationResult(summary=summary, qa_pairs=qa_pairs)

--- a/datacreek/generators/qa_generator.py
+++ b/datacreek/generators/qa_generator.py
@@ -17,6 +17,7 @@ from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, Ti
 
 from datacreek.core.knowledge_graph import KnowledgeGraph
 from datacreek.models.llm_client import LLMClient
+from datacreek.models.qa import QAPair
 from datacreek.utils.config import (
     get_curate_settings,
     get_generation_config,
@@ -28,7 +29,6 @@ from datacreek.utils.llm_processing import (
     parse_qa_pairs,
     parse_ratings,
 )
-from datacreek.models.qa import QAPair
 from datacreek.utils.text import split_into_chunks
 
 logger = logging.getLogger(__name__)

--- a/datacreek/models/__init__.py
+++ b/datacreek/models/__init__.py
@@ -1,11 +1,11 @@
+from datacreek.models.cot import COTExample
 from datacreek.models.llm_client import LLMClient
 from datacreek.models.qa import QAPair
-from datacreek.models.cot import COTExample
 from datacreek.models.results import (
+    COTGenerationResult,
     CurationMetrics,
     CurationResult,
     QAGenerationResult,
-    COTGenerationResult,
 )
 
 __all__ = [

--- a/datacreek/models/__init__.py
+++ b/datacreek/models/__init__.py
@@ -1,7 +1,19 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-# vLLM client. We will expand to Cerebras, ollama. See RFC for more details
 from datacreek.models.llm_client import LLMClient
+from datacreek.models.qa import QAPair
+from datacreek.models.cot import COTExample
+from datacreek.models.results import (
+    CurationMetrics,
+    CurationResult,
+    QAGenerationResult,
+    COTGenerationResult,
+)
+
+__all__ = [
+    "LLMClient",
+    "QAPair",
+    "COTExample",
+    "QAGenerationResult",
+    "COTGenerationResult",
+    "CurationMetrics",
+    "CurationResult",
+]

--- a/datacreek/models/cot.py
+++ b/datacreek/models/cot.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+@dataclass
+class COTExample:
+    """Representation of a chain-of-thought example."""
+
+    question: str
+    reasoning: str
+    answer: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "question": self.question,
+            "reasoning": self.reasoning,
+            "answer": self.answer,
+        }

--- a/datacreek/models/cot.py
+++ b/datacreek/models/cot.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict
 
+
 @dataclass
 class COTExample:
     """Representation of a chain-of-thought example."""

--- a/datacreek/models/qa.py
+++ b/datacreek/models/qa.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+
 @dataclass
 class QAPair:
     """Representation of a question-answer pair."""

--- a/datacreek/models/qa.py
+++ b/datacreek/models/qa.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+@dataclass
+class QAPair:
+    """Representation of a question-answer pair."""
+
+    question: str
+    answer: str
+    rating: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = {"question": self.question, "answer": self.answer}
+        if self.rating is not None:
+            data["rating"] = self.rating
+        return data

--- a/datacreek/models/results.py
+++ b/datacreek/models/results.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from .cot import COTExample
+from .qa import QAPair
+
+
+@dataclass
+class QAGenerationResult:
+    """Output of QA generation."""
+
+    summary: str
+    qa_pairs: List[QAPair]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "summary": self.summary,
+            "qa_pairs": [p.to_dict() for p in self.qa_pairs],
+        }
+
+
+@dataclass
+class CurationMetrics:
+    """Statistics about QA pair curation."""
+
+    total: int
+    filtered: int
+    retention_rate: float
+    avg_score: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "total": self.total,
+            "filtered": self.filtered,
+            "retention_rate": self.retention_rate,
+            "avg_score": self.avg_score,
+        }
+
+
+@dataclass
+class CurationResult:
+    """Result of QA curation."""
+
+    summary: str
+    qa_pairs: List[QAPair]
+    conversations: List[List[Dict[str, str]]]
+    metrics: CurationMetrics
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "summary": self.summary,
+            "qa_pairs": [p.to_dict() for p in self.qa_pairs],
+            "conversations": self.conversations,
+            "metrics": self.metrics.to_dict(),
+        }
+
+
+@dataclass
+class COTGenerationResult:
+    """Output of chain-of-thought generation."""
+
+    summary: str
+    cot_examples: List[COTExample]
+    conversations: List[List[Dict[str, str]]]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "summary": self.summary,
+            "cot_examples": [ex.to_dict() for ex in self.cot_examples],
+            "conversations": self.conversations,
+        }

--- a/datacreek/pipelines.py
+++ b/datacreek/pipelines.py
@@ -313,8 +313,13 @@ def run_generation_pipeline(
     Only steps after the knowledge graph construction are executed. In practice
     this means generation, curation and formatting steps. The function returns
     the final in-memory representation of the dataset without writing files.
-    When ``async_mode`` is True, generation steps use asynchronous LLM
-    requests when supported by the client.
+    When ``async_mode`` is True, generation steps use asynchronous LLM requests
+    when supported by the client.
+
+    At the moment only the QA, COT and VQA pipelines are implemented here. They
+    share a common post-knowledge-graph flow consisting of generation, optional
+    curation and output formatting. Other dataset types require additional
+    specialised steps which are not yet supported.
     """
 
     try:
@@ -322,6 +327,8 @@ def run_generation_pipeline(
     except KeyError as exc:
         raise ValueError(str(exc)) from exc
 
+    # Currently only pipelines with generation after the knowledge graph are
+    # supported. Other dataset types will require bespoke processing logic.
     if dataset_type not in {DatasetType.QA, DatasetType.COT, DatasetType.VQA}:
         raise ValueError(
             f"run_generation_pipeline only supports QA, COT and VQA datasets (got {dataset_type})"

--- a/datacreek/pipelines.py
+++ b/datacreek/pipelines.py
@@ -322,6 +322,11 @@ def run_generation_pipeline(
     except KeyError as exc:
         raise ValueError(str(exc)) from exc
 
+    if dataset_type not in {DatasetType.QA, DatasetType.COT, DatasetType.VQA}:
+        raise ValueError(
+            f"run_generation_pipeline only supports QA, COT and VQA datasets (got {dataset_type})"
+        )
+
     options = ProcessOptions(
         config_path=config_path,
         provider=provider,

--- a/datacreek/utils/__init__.py
+++ b/datacreek/utils/__init__.py
@@ -1,6 +1,5 @@
 """Utility helpers for datacreek."""
 
-
 from .config import (
     get_curate_config,
     get_curate_settings,

--- a/datacreek/utils/__init__.py
+++ b/datacreek/utils/__init__.py
@@ -1,6 +1,5 @@
 """Utility helpers for datacreek."""
 
-from datacreek.pipelines import run_generation_pipeline
 
 from .config import (
     get_curate_config,
@@ -48,5 +47,4 @@ __all__ = [
     "convert_to_conversation_format",
     "extract_facts",
     "extract_entities",
-    "run_generation_pipeline",
 ]

--- a/datacreek/utils/llm_processing.py
+++ b/datacreek/utils/llm_processing.py
@@ -129,11 +129,13 @@ def parse_ratings(text: str, original_items: List[Dict[str, str]] = None) -> Lis
                 if isinstance(parsed, dict) and "rating" in parsed:
                     if verbose:
                         logger.debug("Successfully parsed single JSON object")
-                    return [QAPair(
-                        question=parsed.get("question", ""),
-                        answer=parsed.get("answer", ""),
-                        rating=float(parsed["rating"]),
-                    )]
+                    return [
+                        QAPair(
+                            question=parsed.get("question", ""),
+                            answer=parsed.get("answer", ""),
+                            rating=float(parsed["rating"]),
+                        )
+                    ]
             except json.JSONDecodeError as e:
                 if verbose:
                     logger.debug("JSON parse error for object: %s", e)
@@ -186,7 +188,13 @@ def parse_ratings(text: str, original_items: List[Dict[str, str]] = None) -> Lis
                     if isinstance(parsed, dict) and "rating" in parsed:
                         if verbose:
                             logger.debug("Successfully parsed from code block (single object)")
-                        return [QAPair(question=parsed.get("question", ""), answer=parsed.get("answer", ""), rating=float(parsed["rating"]))]
+                        return [
+                            QAPair(
+                                question=parsed.get("question", ""),
+                                answer=parsed.get("answer", ""),
+                                rating=float(parsed["rating"]),
+                            )
+                        ]
                     elif isinstance(parsed, list):
                         valid_items = True
                         for item in parsed:
@@ -233,7 +241,13 @@ def parse_ratings(text: str, original_items: List[Dict[str, str]] = None) -> Lis
                         if isinstance(parsed, dict) and "rating" in parsed:
                             if verbose:
                                 logger.debug("Successfully parsed using regex (single object)")
-                            return [QAPair(question=parsed.get("question", ""), answer=parsed.get("answer", ""), rating=float(parsed["rating"]))]
+                            return [
+                                QAPair(
+                                    question=parsed.get("question", ""),
+                                    answer=parsed.get("answer", ""),
+                                    rating=float(parsed["rating"]),
+                                )
+                            ]
                         elif isinstance(parsed, list) and all("rating" in item for item in parsed):
                             if verbose:
                                 logger.debug(
@@ -262,7 +276,13 @@ def parse_ratings(text: str, original_items: List[Dict[str, str]] = None) -> Lis
             if isinstance(parsed, dict) and "rating" in parsed:
                 if verbose:
                     logger.debug("Successfully parsed using json5 (single object)")
-                return [QAPair(question=parsed.get("question", ""), answer=parsed.get("answer", ""), rating=float(parsed["rating"]))]
+                return [
+                    QAPair(
+                        question=parsed.get("question", ""),
+                        answer=parsed.get("answer", ""),
+                        rating=float(parsed["rating"]),
+                    )
+                ]
             elif isinstance(parsed, list) and all("rating" in item for item in parsed):
                 if verbose:
                     logger.debug("Successfully parsed %d items using json5", len(parsed))

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,4 +1,5 @@
 import asyncio
+import pytest
 
 from datacreek.utils.batch import async_process_batches
 
@@ -51,7 +52,8 @@ def test_curate_async_mode(monkeypatch):
         return [parse_fn('{"rating": 9}') for _ in msgs]
 
     monkeypatch.setattr("datacreek.utils.batch.async_process_batches", fake_async)
-    monkeypatch.setattr("datacreek.core.curate.parse_ratings", lambda resp, orig: [{"rating": 9}])
+    from datacreek.models.qa import QAPair
+    monkeypatch.setattr("datacreek.core.curate.parse_ratings", lambda resp, orig: [QAPair(question="q", answer="a", rating=9)])
     monkeypatch.setattr("datacreek.core.curate.convert_to_conversation_format", lambda pairs: [])
 
     from datacreek.core.curate import curate_qa_pairs
@@ -60,4 +62,11 @@ def test_curate_async_mode(monkeypatch):
     result = curate_qa_pairs(data, async_mode=True)
 
     assert async_called.get("count") == 1
-    assert result["qa_pairs"] == [{"rating": 9}]
+    assert result["qa_pairs"] == [{"question": "q", "answer": "a", "rating": 9}]
+
+
+def test_curate_threshold_validation():
+    from datacreek.core.curate import curate_qa_pairs
+
+    with pytest.raises(ValueError):
+        curate_qa_pairs({"summary": "", "qa_pairs": [{"question": "q", "answer": "a"}]}, threshold=11)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import pytest
 
 from datacreek.utils.batch import async_process_batches
@@ -53,7 +54,11 @@ def test_curate_async_mode(monkeypatch):
 
     monkeypatch.setattr("datacreek.utils.batch.async_process_batches", fake_async)
     from datacreek.models.qa import QAPair
-    monkeypatch.setattr("datacreek.core.curate.parse_ratings", lambda resp, orig: [QAPair(question="q", answer="a", rating=9)])
+
+    monkeypatch.setattr(
+        "datacreek.core.curate.parse_ratings",
+        lambda resp, orig: [QAPair(question="q", answer="a", rating=9)],
+    )
     monkeypatch.setattr("datacreek.core.curate.convert_to_conversation_format", lambda pairs: [])
 
     from datacreek.core.curate import curate_qa_pairs
@@ -69,4 +74,6 @@ def test_curate_threshold_validation():
     from datacreek.core.curate import curate_qa_pairs
 
     with pytest.raises(ValueError):
-        curate_qa_pairs({"summary": "", "qa_pairs": [{"question": "q", "answer": "a"}]}, threshold=11)
+        curate_qa_pairs(
+            {"summary": "", "qa_pairs": [{"question": "q", "answer": "a"}]}, threshold=11
+        )

--- a/tests/test_batch_add_async.py
+++ b/tests/test_batch_add_async.py
@@ -20,6 +20,7 @@ async def fake_async(client, messages, *, batch_size, temperature, parse_fn):
 def test_rate_qa_pairs_async(monkeypatch):
     monkeypatch.setattr("datacreek.utils.batch.async_process_batches", fake_async)
     from datacreek.models.qa import QAPair
+
     monkeypatch.setattr(
         "datacreek.generators.qa_generator.parse_ratings",
         lambda resp, orig: [QAPair(question="q", answer="a", rating=9)],
@@ -41,6 +42,7 @@ def test_generate_qa_pairs_async(monkeypatch):
 
     monkeypatch.setattr("datacreek.utils.batch.async_process_batches", fake_async2)
     from datacreek.models.qa import QAPair
+
     monkeypatch.setattr(
         "datacreek.generators.qa_generator.parse_qa_pairs",
         lambda resp: [QAPair(question="q", answer="a")],

--- a/tests/test_batch_add_async.py
+++ b/tests/test_batch_add_async.py
@@ -4,7 +4,7 @@ from datacreek.generators.qa_generator import QAGenerator
 class DummyClient:
     def __init__(self):
         self.config = {
-            "prompts": {"qa_rating": "{pairs}"},
+            "prompts": {"qa_rating": "{pairs}", "qa_generation": "prompt"},
             "curate": {"batch_size": 1, "temperature": 0.1, "threshold": 0.0},
         }
 
@@ -19,12 +19,35 @@ async def fake_async(client, messages, *, batch_size, temperature, parse_fn):
 
 def test_rate_qa_pairs_async(monkeypatch):
     monkeypatch.setattr("datacreek.utils.batch.async_process_batches", fake_async)
+    from datacreek.models.qa import QAPair
     monkeypatch.setattr(
-        "datacreek.generators.qa_generator.parse_ratings", lambda resp, orig: [{"rating": 9}]
+        "datacreek.generators.qa_generator.parse_ratings",
+        lambda resp, orig: [QAPair(question="q", answer="a", rating=9)],
     )
 
     gen = QAGenerator(DummyClient())
     pairs, metrics = gen.rate_qa_pairs([{"question": "q", "answer": "a"}], "", async_mode=True)
 
     assert async_called.get("count") == 1
-    assert pairs == [{"rating": 9}]
+    assert pairs == [{"question": "q", "answer": "a", "rating": 9}]
+
+
+def test_generate_qa_pairs_async(monkeypatch):
+    async_called.clear()
+
+    async def fake_async2(client, messages, *, batch_size, temperature, parse_fn):
+        async_called["count"] = len(messages)
+        return [parse_fn('[{"question": "q", "answer": "a"}]') for _ in messages]
+
+    monkeypatch.setattr("datacreek.utils.batch.async_process_batches", fake_async2)
+    from datacreek.models.qa import QAPair
+    monkeypatch.setattr(
+        "datacreek.generators.qa_generator.parse_qa_pairs",
+        lambda resp: [QAPair(question="q", answer="a")],
+    )
+
+    gen = QAGenerator(DummyClient())
+    pairs = gen.generate_qa_pairs("doc", "sum", num_pairs=1, async_mode=True)
+
+    assert async_called.get("count") == 1
+    assert pairs == [QAPair(question="q", answer="a")]

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,7 @@
+import pytest
+from datacreek.core.save_as import convert_format
+
+
+def test_convert_format_invalid():
+    with pytest.raises(ValueError):
+        convert_format({"qa_pairs": []}, None, "bad")

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,4 +1,5 @@
 import pytest
+
 from datacreek.core.save_as import convert_format
 
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -158,3 +158,10 @@ def test_run_generation_pipeline_overrides(monkeypatch):
     run_generation_pipeline(DatasetType.QA, "text", overrides={"foo": 1})
 
     assert received["overrides"] == {"foo": 1}
+
+
+def test_run_generation_pipeline_unsupported(monkeypatch):
+    """Ensure unsupported dataset types raise errors."""
+
+    with pytest.raises(ValueError):
+        run_generation_pipeline(DatasetType.TEXT, "text")

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,3 +1,4 @@
+import pytest
 from datacreek.pipelines import (
     DatasetType,
     PipelineStep,
@@ -83,3 +84,77 @@ def test_run_generation_pipeline(monkeypatch):
 
     assert result == "done"
     assert calls == ["gen", "curate", "save"]
+
+
+def test_run_generation_pipeline_invalid():
+    with pytest.raises(ValueError):
+        run_generation_pipeline("wrong", "text")
+
+
+def test_run_generation_pipeline_cot(monkeypatch):
+    calls = []
+
+    def fake_generate(*args, **kwargs):
+        assert args[5] == "cot"
+        calls.append("gen")
+        return {"cot_examples": [{"question": "q", "reasoning": "r", "answer": "a"}]}
+
+    def fake_curate(data, *args, **kwargs):
+        calls.append("curate")
+        return {"qa_pairs": [{"question": "q", "answer": "a"}], "summary": ""}
+
+    def fake_save(data, output_path, fmt, cfg, storage_format="json"):
+        calls.append("save")
+        return "done"
+
+    monkeypatch.setattr("datacreek.pipelines.process_file", fake_generate)
+    monkeypatch.setattr("datacreek.pipelines.curate_qa_pairs", fake_curate)
+    monkeypatch.setattr("datacreek.pipelines.convert_format", fake_save)
+
+    result = run_generation_pipeline(DatasetType.COT, "text")
+
+    assert result == "done"
+    assert calls == ["gen", "curate", "save"]
+
+
+def test_run_generation_pipeline_vqa(monkeypatch):
+    calls = []
+
+    def fake_generate(*args, **kwargs):
+        # VQA pipeline uses the special content type
+        assert args[5] == "vqa_add_reasoning"
+        calls.append("gen")
+        return {"qa_pairs": [{"question": "q", "answer": "a"}]}
+
+    def fake_curate(data, *args, **kwargs):
+        calls.append("curate")
+        return {"qa_pairs": data["qa_pairs"], "summary": ""}
+
+    def fake_save(data, output_path, fmt, cfg, storage_format="json"):
+        calls.append("save")
+        return "done"
+
+    monkeypatch.setattr("datacreek.pipelines.process_file", fake_generate)
+    monkeypatch.setattr("datacreek.pipelines.curate_qa_pairs", fake_curate)
+    monkeypatch.setattr("datacreek.pipelines.convert_format", fake_save)
+
+    result = run_generation_pipeline(DatasetType.VQA, "text")
+
+    assert result == "done"
+    assert calls == ["gen", "curate", "save"]
+
+
+def test_run_generation_pipeline_overrides(monkeypatch):
+    received = {}
+
+    def fake_generate(*args, **kwargs):
+        received["overrides"] = kwargs.get("config_overrides")
+        return {"qa_pairs": []}
+
+    monkeypatch.setattr("datacreek.pipelines.process_file", fake_generate)
+    monkeypatch.setattr("datacreek.pipelines.curate_qa_pairs", lambda *a, **k: {})
+    monkeypatch.setattr("datacreek.pipelines.convert_format", lambda *a, **k: "done")
+
+    run_generation_pipeline(DatasetType.QA, "text", overrides={"foo": 1})
+
+    assert received["overrides"] == {"foo": 1}

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,4 +1,5 @@
 import pytest
+
 from datacreek.pipelines import (
     DatasetType,
     PipelineStep,


### PR DESCRIPTION
## Summary
- add `QAGenerationResult` dataclass and re-export
- switch QA generator to return `QAGenerationResult`
- update `process_file` to handle dataclass results
- refactor `convert_format` with a helper and add test for invalid format
- extend pipeline tests to cover CoT pipelines
- add `COTGenerationResult` dataclass and return it from `COTGenerator`
- add pipeline tests for VQA and override handling
- allow overrides in VQA generator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa841fbc4832f874dc702e145fccf