### PR TITLE
Add simple generators for new dataset types

### DIFF
--- a/datacreek/core/curate.py
+++ b/datacreek/core/curate.py
@@ -48,6 +48,20 @@ def curate_qa_pairs(
     Returns:
         Path to the cleaned output file
     """
+    if async_mode:
+        return asyncio.run(
+            curate_qa_pairs_async(
+                input_data,
+                output_path=output_path,
+                threshold=threshold,
+                api_base=api_base,
+                model=model,
+                config_path=config_path,
+                verbose=verbose,
+                provider=provider,
+            )
+        )
+
     # Verbosity now controlled by logging level
 
     # Load input
@@ -124,24 +138,9 @@ def curate_qa_pairs(
 
     # Only use detailed progress bar in verbose mode
     if verbose:
-        from rich.progress import (
-            BarColumn,
-            Progress,
-            TextColumn,
-            TimeElapsedColumn,
-            TimeRemainingColumn,
-        )
+        from datacreek.utils.progress import create_progress
 
-        progress_columns = [
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-            TimeElapsedColumn(),
-            TimeRemainingColumn(),
-        ]
-
-        progress_ctx = Progress(*progress_columns)
-        rate_task = progress_ctx.add_task(f"Rating QA pairs", total=len(batches))
+        progress_ctx, rate_task = create_progress("Rating QA pairs", len(batches))
         progress_ctx.start()
     else:
         progress_ctx = None
@@ -208,6 +207,144 @@ def curate_qa_pairs(
     )
 
     # Always print basic stats, even in non-verbose mode
+    logger.info("Rated %d QA pairs", total_evaluated)
+    logger.info("Retained %d pairs (threshold: %s)", total_passed, threshold)
+    logger.info("Average score: %s", metrics.avg_score)
+
+    conversations = convert_to_conversation_format(filtered_pairs)
+
+    result = CurationResult(
+        summary=summary,
+        qa_pairs=[
+            QAPair(question=p["question"], answer=p["answer"], rating=p.get("rating"))
+            for p in filtered_pairs
+        ],
+        conversations=conversations,
+        metrics=metrics,
+    )
+
+    if output_path:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(result.to_dict(), f, indent=2)
+        return output_path
+
+    return result.to_dict()
+
+
+async def curate_qa_pairs_async(
+    input_data: Any,
+    output_path: Optional[str] = None,
+    threshold: Optional[float] = None,
+    api_base: Optional[str] = None,
+    model: Optional[str] = None,
+    config_path: Optional[Path] = None,
+    verbose: bool = False,
+    provider: Optional[str] = None,
+) -> Any:
+    """Asynchronous version of :func:`curate_qa_pairs`."""
+    # Reuse the synchronous function's logic but run async batch processing.
+    # Load input
+    if isinstance(input_data, str):
+        if os.path.exists(input_data):
+            with open(input_data, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        else:
+            data = json.loads(input_data)
+    else:
+        data = input_data
+
+    qa_pairs = data.get("qa_pairs", [])
+    summary = data.get("summary", "")
+    if not qa_pairs:
+        raise ValueError("No QA pairs found in the input file")
+
+    client = LLMClient(
+        config_path=config_path, provider=provider, api_base=api_base, model_name=model
+    )
+
+    if threshold is None:
+        config = client.config
+        cleanup_settings = get_curate_settings(config)
+        threshold = cleanup_settings.threshold
+    elif not 0 <= threshold <= 10:
+        raise ValueError("threshold must be between 0 and 10")
+
+    generator = QAGenerator(client, config_path)
+    curate_config = get_curate_settings(client.config)
+
+    batch_size = curate_config.batch_size
+    inference_batch = curate_config.inference_batch
+    rating_temperature = curate_config.temperature
+    if threshold is None:
+        threshold = curate_config.threshold
+
+    rating_prompt_template = get_prompt(client.config, "qa_rating")
+
+    batches = []
+    for i in range(0, len(qa_pairs), batch_size):
+        batch = qa_pairs[i : i + batch_size]
+        batches.append(batch)
+
+    all_messages = []
+    for batch in batches:
+        batch_json = json.dumps(batch, indent=2)
+        rating_prompt = rating_prompt_template.format(pairs=batch_json)
+        messages = [{"role": "system", "content": rating_prompt}]
+        all_messages.append(messages)
+
+    filtered_pairs = []
+    total_score = 0
+    total_evaluated = 0
+    total_passed = 0
+
+    from datacreek.utils.batch import async_process_batches
+
+    if verbose:
+        progress_ctx, rate_task = create_progress("Rating QA pairs", len(batches))
+        progress_ctx.start()
+    else:
+        progress_ctx = None
+        rate_task = None
+
+    rated_batches = await async_process_batches(
+        client,
+        all_messages,
+        batch_size=inference_batch,
+        temperature=rating_temperature,
+        parse_fn=lambda resp: resp,
+    )
+
+    for idx, response in enumerate(rated_batches):
+        original_batch = batches[idx] if idx < len(batches) else []
+        try:
+            rated = parse_ratings(response, original_batch)
+            for pair in rated:
+                if pair.rating is not None:
+                    total_score += pair.rating
+                    total_evaluated += 1
+                    if pair.rating >= threshold:
+                        filtered_pairs.append(pair.to_dict())
+                        total_passed += 1
+        except Exception as e:
+            logger.error("Error processing batch %d: %s", idx + 1, e)
+
+        if progress_ctx and rate_task:
+            progress_ctx.update(rate_task, advance=1)
+
+    if progress_ctx:
+        progress_ctx.stop()
+
+    if not verbose:
+        logger.info("Batch processing complete.")
+
+    metrics = CurationMetrics(
+        total=len(qa_pairs),
+        filtered=len(filtered_pairs),
+        retention_rate=round(len(filtered_pairs) / len(qa_pairs), 2) if qa_pairs else 0,
+        avg_score=round(total_score / total_evaluated, 1) if total_evaluated else 0,
+    )
+
     logger.info("Rated %d QA pairs", total_evaluated)
     logger.info("Retained %d pairs (threshold: %s)", total_passed, threshold)
     logger.info("Average score: %s", metrics.avg_score)

--- a/datacreek/generators/__init__.py
+++ b/datacreek/generators/__init__.py
@@ -4,4 +4,23 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 # Generator logic for both QA
-from datacreek.generators.qa_generator import QAGenerator
+from .conversation_generator import ConversationGenerator
+from .cot_generator import COTGenerator
+from .kg_generator import KGGenerator
+from .multi_tool_generator import MultiToolGenerator
+from .pref_generator import PrefListGenerator, PrefPairGenerator
+from .qa_generator import QAGenerator
+from .tool_generator import ToolCallGenerator
+from .vqa_generator import VQAGenerator
+
+__all__ = [
+    "QAGenerator",
+    "COTGenerator",
+    "VQAGenerator",
+    "KGGenerator",
+    "ToolCallGenerator",
+    "ConversationGenerator",
+    "MultiToolGenerator",
+    "PrefPairGenerator",
+    "PrefListGenerator",
+]

--- a/datacreek/generators/base.py
+++ b/datacreek/generators/base.py
@@ -1,0 +1,31 @@
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from datacreek.models.llm_client import LLMClient
+from datacreek.utils.config import get_generation_config, load_config, merge_configs
+
+logger = logging.getLogger(__name__)
+
+
+class BaseGenerator:
+    """Common initializer for dataset generators."""
+
+    def __init__(
+        self,
+        client: LLMClient,
+        config_path: Optional[Path] = None,
+        config_overrides: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.client = client
+        if config_path:
+            base_cfg = load_config(config_path)
+        else:
+            base_cfg = client.config
+        if config_overrides:
+            base_cfg = merge_configs(base_cfg, config_overrides)
+        self.config = base_cfg
+        self.generation_config = get_generation_config(self.config)
+
+    def process_document(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - base stub
+        raise NotImplementedError

--- a/datacreek/generators/conversation_generator.py
+++ b/datacreek/generators/conversation_generator.py
@@ -1,0 +1,65 @@
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from datacreek.core.knowledge_graph import KnowledgeGraph
+from datacreek.models.llm_client import LLMClient
+from datacreek.utils import convert_to_conversation_format
+
+from .base import BaseGenerator
+
+logger = logging.getLogger(__name__)
+
+
+class ConversationGenerator(BaseGenerator):
+    """Generate simple conversations from document text.
+
+    This generator builds on :class:`QAGenerator` to first create QA pairs and
+    then converts them to a dialogue style dataset. Each conversation keeps track
+    of the originating text chunk and source document.
+    """
+
+    def __init__(
+        self,
+        client: LLMClient,
+        config_path: Optional[Path] = None,
+        kg: Optional[KnowledgeGraph] = None,
+        config_overrides: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(client, config_path, config_overrides)
+        self.kg = kg
+
+    def process_document(
+        self,
+        document_text: str,
+        *,
+        num_pairs: int = 25,
+        verbose: bool = False,
+        async_mode: bool = False,
+    ) -> Dict[str, Any]:
+        """Return conversations generated from ``document_text``."""
+
+        from .qa_generator import QAGenerator
+
+        qa_gen = QAGenerator(self.client, self.config_path, kg=self.kg, config_overrides=None)
+
+        if async_mode:
+            result = asyncio.run(
+                qa_gen.process_document_async(document_text, num_pairs=num_pairs, verbose=verbose)
+            )
+        else:
+            result = qa_gen.process_document(document_text, num_pairs=num_pairs, verbose=verbose)
+
+        conversations: List[Dict[str, Any]] = []
+        for pair in result.qa_pairs:
+            conv = convert_to_conversation_format([pair])[0]
+            conversations.append(
+                {
+                    "conversations": conv,
+                    "chunk": pair.chunk,
+                    "source": pair.source,
+                }
+            )
+
+        return {"summary": result.summary, "conversations": conversations}

--- a/datacreek/generators/kg_generator.py
+++ b/datacreek/generators/kg_generator.py
@@ -1,0 +1,48 @@
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from datacreek.core.knowledge_graph import KnowledgeGraph
+from datacreek.models.llm_client import LLMClient
+from datacreek.utils.config import get_prompt
+
+from .base import BaseGenerator
+
+logger = logging.getLogger(__name__)
+
+
+class KGGenerator(BaseGenerator):
+    """Generate QA examples from a knowledge graph."""
+
+    def process_graph(
+        self,
+        kg: KnowledgeGraph,
+        num_pairs: int = 25,
+        *,
+        verbose: bool = False,
+    ) -> Dict[str, Any]:
+        """Return QA pairs generated from ``kg``.
+
+        This is a simplified placeholder implementation that serializes a small
+        portion of the graph and uses the QA prompt.
+        """
+        nodes = list(kg.graph.nodes(data=True))[:5]
+        text_parts = []
+        for node, data in nodes:
+            label = data.get("label") or node
+            summary = data.get("summary") or data.get("text", "")
+            text_parts.append(f"{label}: {summary}")
+        prompt = get_prompt(self.config, "qa_generation")
+        prompt_filled = prompt.format(num_pairs=num_pairs, summary="", text="\n".join(text_parts))
+        messages = [{"role": "system", "content": prompt_filled}]
+        temperature = self.generation_config.temperature
+        max_tokens = self.generation_config.max_tokens
+        if verbose:
+            logger.info("Generating QA from knowledge graph with %d nodes", len(nodes))
+        response = self.client.chat_completion(
+            messages, temperature=temperature, max_tokens=max_tokens
+        )
+        from datacreek.utils.llm_processing import parse_qa_pairs
+
+        qa_pairs = parse_qa_pairs(response)
+        return {"qa_pairs": [p.to_dict() for p in qa_pairs]}

--- a/datacreek/generators/multi_tool_generator.py
+++ b/datacreek/generators/multi_tool_generator.py
@@ -1,0 +1,82 @@
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from datacreek.core.knowledge_graph import KnowledgeGraph
+from datacreek.models.llm_client import LLMClient
+from datacreek.utils import convert_to_conversation_format
+
+from .base import BaseGenerator
+
+logger = logging.getLogger(__name__)
+
+
+class MultiToolGenerator(BaseGenerator):
+    """Generate simple multi-tool conversations."""
+
+    def __init__(
+        self,
+        client: LLMClient,
+        config_path: Optional[Path] = None,
+        kg: Optional[KnowledgeGraph] = None,
+        config_overrides: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(client, config_path, config_overrides)
+        self.kg = kg
+
+    def process_document(
+        self,
+        document_text: str,
+        *,
+        num_pairs: int = 25,
+        verbose: bool = False,
+        async_mode: bool = False,
+    ) -> Dict[str, Any]:
+        """Return multi-tool conversations generated from ``document_text``."""
+
+        from .qa_generator import QAGenerator
+
+        qa_gen = QAGenerator(self.client, self.config_path, kg=self.kg, config_overrides=None)
+
+        if async_mode:
+            result = asyncio.run(
+                qa_gen.process_document_async(document_text, num_pairs=num_pairs, verbose=verbose)
+            )
+        else:
+            result = qa_gen.process_document(document_text, num_pairs=num_pairs, verbose=verbose)
+
+        conversations: List[Dict[str, Any]] = []
+        for pair in result.qa_pairs:
+            conv = convert_to_conversation_format([pair])[0]
+            conv.insert(
+                2,
+                {
+                    "role": "assistant",
+                    "tool_call": {"name": "search", "arguments": {"query": pair.question}},
+                },
+            )
+            conv.insert(
+                3,
+                {"role": "tool", "name": "search", "content": pair.answer},
+            )
+            conv.insert(
+                4,
+                {
+                    "role": "assistant",
+                    "tool_call": {"name": "calculator", "arguments": {"input": pair.answer}},
+                },
+            )
+            conv.insert(
+                5,
+                {"role": "tool", "name": "calculator", "content": pair.answer},
+            )
+            conversations.append(
+                {
+                    "conversations": conv,
+                    "chunk": pair.chunk,
+                    "source": pair.source,
+                }
+            )
+
+        return {"summary": result.summary, "conversations": conversations}

--- a/datacreek/generators/pref_generator.py
+++ b/datacreek/generators/pref_generator.py
@@ -1,0 +1,122 @@
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from datacreek.core.knowledge_graph import KnowledgeGraph
+from datacreek.models.llm_client import LLMClient
+
+from .base import BaseGenerator
+
+logger = logging.getLogger(__name__)
+
+
+class PrefPairGenerator(BaseGenerator):
+    """Generate simple pairwise preference data."""
+
+    def __init__(
+        self,
+        client: LLMClient,
+        config_path: Optional[Path] = None,
+        kg: Optional[KnowledgeGraph] = None,
+        config_overrides: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(client, config_path, config_overrides)
+        self.kg = kg
+
+    def process_document(
+        self,
+        document_text: str,
+        *,
+        num_pairs: int = 10,
+        verbose: bool = False,
+        async_mode: bool = False,
+    ) -> Dict[str, Any]:
+        """Return pairwise preference data from ``document_text``."""
+
+        from .qa_generator import QAGenerator
+
+        qa_gen = QAGenerator(self.client, self.config_path, kg=self.kg, config_overrides=None)
+
+        if async_mode:
+            result = asyncio.run(
+                qa_gen.process_document_async(
+                    document_text, num_pairs=num_pairs * 2, verbose=verbose
+                )
+            )
+        else:
+            result = qa_gen.process_document(
+                document_text, num_pairs=num_pairs * 2, verbose=verbose
+            )
+
+        pairs: List[Dict[str, Any]] = []
+        qa_iter = iter(result.qa_pairs)
+        for _ in range(num_pairs):
+            try:
+                a = next(qa_iter)
+                b = next(qa_iter)
+            except StopIteration:
+                break
+            pairs.append(
+                {
+                    "question": a.question,
+                    "chosen": a.answer,
+                    "rejected": b.answer,
+                    "chunk": a.chunk,
+                    "source": a.source,
+                }
+            )
+
+        return {"summary": result.summary, "pairs": pairs}
+
+
+class PrefListGenerator(BaseGenerator):
+    """Generate simple listwise ranking data."""
+
+    def __init__(
+        self,
+        client: LLMClient,
+        config_path: Optional[Path] = None,
+        kg: Optional[KnowledgeGraph] = None,
+        config_overrides: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(client, config_path, config_overrides)
+        self.kg = kg
+
+    def process_document(
+        self,
+        document_text: str,
+        *,
+        num_lists: int = 10,
+        list_size: int = 3,
+        verbose: bool = False,
+        async_mode: bool = False,
+    ) -> Dict[str, Any]:
+        """Return listwise preference data from ``document_text``."""
+
+        from .qa_generator import QAGenerator
+
+        qa_gen = QAGenerator(self.client, self.config_path, kg=self.kg, config_overrides=None)
+
+        total = num_lists * list_size
+        if async_mode:
+            result = asyncio.run(
+                qa_gen.process_document_async(document_text, num_pairs=total, verbose=verbose)
+            )
+        else:
+            result = qa_gen.process_document(document_text, num_pairs=total, verbose=verbose)
+
+        responses: List[Dict[str, Any]] = []
+        qa_iter = iter(result.qa_pairs)
+        for _ in range(num_lists):
+            items = []
+            for _ in range(list_size):
+                try:
+                    p = next(qa_iter)
+                except StopIteration:
+                    break
+                items.append({"text": p.answer, "chunk": p.chunk, "source": p.source})
+            if items:
+                responses.append({"question": items[0]["text"], "answers": items})
+
+        return {"summary": result.summary, "responses": responses}

--- a/datacreek/generators/qa_generator.py
+++ b/datacreek/generators/qa_generator.py
@@ -13,8 +13,6 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, TimeRemainingColumn
-
 from datacreek.core.knowledge_graph import KnowledgeGraph
 from datacreek.models.llm_client import LLMClient
 from datacreek.models.qa import QAPair
@@ -29,6 +27,7 @@ from datacreek.utils.llm_processing import (
     parse_qa_pairs,
     parse_ratings,
 )
+from datacreek.utils.progress import create_progress, progress_context
 from datacreek.utils.text import split_into_chunks
 
 logger = logging.getLogger(__name__)
@@ -64,9 +63,10 @@ class QAGenerator:
         self.generation_config = get_generation_config(self.config)
         self.curate_config = get_curate_settings(self.config)
 
-    def generate_summary(self, document_text: str) -> str:
+    def generate_summary(self, document_text: str, *, verbose: bool | None = None) -> str:
         """Generate a summary of the document"""
-        verbose = logger.isEnabledFor(logging.DEBUG)
+        if verbose is None:
+            verbose = logger.isEnabledFor(logging.DEBUG)
         if verbose:
             logger.info("Generating document summary...")
 
@@ -96,9 +96,11 @@ class QAGenerator:
         query: Optional[str] = None,
         *,
         async_mode: bool = False,
+        verbose: bool | None = None,
     ) -> List[QAPair]:
         """Generate QA pairs from the document using batched processing"""
-        verbose = logger.isEnabledFor(logging.DEBUG)
+        if verbose is None:
+            verbose = logger.isEnabledFor(logging.DEBUG)
 
         # Get generation config
         chunk_size = self.generation_config.chunk_size
@@ -118,16 +120,27 @@ class QAGenerator:
             similarity_drop=similarity_drop,
         )
 
+        chunk_meta: List[Tuple[str, str, Optional[str]]] = []
+
         if self.kg and chunk_method in {"sliding", "semantic", "contextual"}:
             # index chunks in knowledge graph if provided
             for i, chunk in enumerate(chunks):
                 cid = f"chunk-{i}"
                 self.kg.add_document("doc", source="inline") if "doc" not in self.kg.graph else None
                 self.kg.add_chunk("doc", cid, chunk)
+                chunk_meta.append((cid, chunk, self.kg.graph.nodes[cid].get("source")))
 
         if query and self.kg:
             selected_ids = self.kg.search_embeddings(query, k=top_k)
             chunks = [self.kg.graph.nodes[c]["text"] for c in selected_ids if c in self.kg.graph]
+            chunk_meta = [
+                (cid, self.kg.graph.nodes[cid]["text"], self.kg.graph.nodes[cid].get("source"))
+                for cid in selected_ids
+                if cid in self.kg.graph
+            ]
+        else:
+            if not chunk_meta:
+                chunk_meta = [(f"chunk-{i}", ch, None) for i, ch in enumerate(chunks)]
 
         if verbose:
             logger.info("Generating QA pairs...")
@@ -155,24 +168,7 @@ class QAGenerator:
 
         # Set up progress tracking based on verbose mode
         if verbose:
-            from rich.progress import (
-                BarColumn,
-                Progress,
-                TextColumn,
-                TimeElapsedColumn,
-                TimeRemainingColumn,
-            )
-
-            progress_columns = [
-                TextColumn("[progress.description]{task.description}"),
-                BarColumn(),
-                TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-                TimeElapsedColumn(),
-                TimeRemainingColumn(),
-            ]
-
-            progress_ctx = Progress(*progress_columns)
-            generate_task = progress_ctx.add_task(f"Generating QA pairs", total=len(chunks))
+            progress_ctx, generate_task = create_progress("Generating QA pairs", len(chunks))
             progress_ctx.start()
         else:
             progress_ctx = None
@@ -201,6 +197,10 @@ class QAGenerator:
             )
 
         for i, pairs in enumerate(batch_results):
+            cid, chunk_text, src = chunk_meta[i]
+            for p in pairs:
+                p.chunk = chunk_text
+                p.source = src or "inline"
             all_qa_pairs.extend(pairs)
             if verbose:
                 logger.info("  Generated %d pairs from chunk %d", len(pairs), i + 1)
@@ -219,6 +219,114 @@ class QAGenerator:
         logger.info("Generated %d QA pairs total", len(all_qa_pairs))
         return all_qa_pairs
 
+    async def generate_qa_pairs_async(
+        self,
+        document_text: str,
+        summary: str,
+        num_pairs: int = 25,
+        query: Optional[str] = None,
+        *,
+        verbose: bool | None = None,
+    ) -> List[QAPair]:
+        """Asynchronous counterpart to :meth:`generate_qa_pairs`."""
+        if verbose is None:
+            verbose = logger.isEnabledFor(logging.DEBUG)
+
+        chunk_size = self.generation_config.chunk_size
+        temperature = self.generation_config.temperature
+        overlap = self.generation_config.overlap
+        batch_size = self.generation_config.batch_size
+        chunk_method = self.generation_config.chunk_method
+        similarity_drop = self.generation_config.similarity_drop
+        top_k = self.generation_config.retrieval_top_k
+
+        chunks = split_into_chunks(
+            document_text,
+            chunk_size=chunk_size,
+            overlap=overlap,
+            method=chunk_method,
+            similarity_drop=similarity_drop,
+        )
+
+        chunk_meta: List[Tuple[str, str, Optional[str]]] = []
+
+        if self.kg and chunk_method in {"sliding", "semantic", "contextual"}:
+            for i, chunk in enumerate(chunks):
+                cid = f"chunk-{i}"
+                if "doc" not in self.kg.graph:
+                    self.kg.add_document("doc", source="inline")
+                self.kg.add_chunk("doc", cid, chunk)
+                chunk_meta.append((cid, chunk, self.kg.graph.nodes[cid].get("source")))
+
+        if query and self.kg:
+            selected_ids = self.kg.search_embeddings(query, k=top_k)
+            chunks = [self.kg.graph.nodes[c]["text"] for c in selected_ids if c in self.kg.graph]
+            chunk_meta = [
+                (cid, self.kg.graph.nodes[cid]["text"], self.kg.graph.nodes[cid].get("source"))
+                for cid in selected_ids
+                if cid in self.kg.graph
+            ]
+        else:
+            if not chunk_meta:
+                chunk_meta = [(f"chunk-{i}", ch, None) for i, ch in enumerate(chunks)]
+
+        if verbose:
+            logger.info("Generating QA pairs...")
+            logger.info("Document split into %d chunks", len(chunks))
+            logger.info("Using batch size of %d", batch_size)
+
+        all_qa_pairs: List[QAPair] = []
+        pairs_per_chunk = max(1, round(num_pairs / len(chunks)))
+
+        qa_prompt_template = get_prompt(self.config, "qa_generation")
+
+        all_messages = []
+        for i, chunk in enumerate(chunks):
+            qa_prompt = qa_prompt_template.format(
+                num_pairs=pairs_per_chunk, summary=summary[:100], text=chunk
+            )
+            all_messages.append([{"role": "system", "content": qa_prompt}])
+
+        logger.info("Processing %d chunks to generate QA pairs...", len(chunks))
+
+        if verbose:
+            progress_ctx, generate_task = create_progress("Generating QA pairs", len(chunks))
+            progress_ctx.start()
+        else:
+            progress_ctx = None
+            generate_task = None
+
+        from datacreek.utils.batch import async_process_batches
+
+        batch_results = await async_process_batches(
+            self.client,
+            all_messages,
+            batch_size=batch_size,
+            temperature=temperature,
+            parse_fn=parse_qa_pairs,
+        )
+
+        for i, pairs in enumerate(batch_results):
+            cid, chunk_text, src = chunk_meta[i]
+            for p in pairs:
+                p.chunk = chunk_text
+                p.source = src or "inline"
+            all_qa_pairs.extend(pairs)
+            if verbose:
+                logger.info("  Generated %d pairs from chunk %d", len(pairs), i + 1)
+
+            if progress_ctx and generate_task:
+                progress_ctx.update(generate_task, advance=1)
+
+        if progress_ctx:
+            progress_ctx.stop()
+
+        if not verbose:
+            logger.info("Batch processing complete.")
+
+        logger.info("Generated %d QA pairs total", len(all_qa_pairs))
+        return all_qa_pairs
+
     def rate_qa_pairs(
         self,
         qa_pairs: List[QAPair],
@@ -226,13 +334,15 @@ class QAGenerator:
         threshold: Optional[float] = None,
         *,
         async_mode: bool = False,
+        verbose: bool | None = None,
     ) -> Tuple[List[QAPair], Dict[str, Any]]:
         """Rate and filter QA pairs by quality.
 
         When ``async_mode`` is ``True`` the LLM calls are executed concurrently
         using :func:`async_process_batches`.
         """
-        verbose = logger.isEnabledFor(logging.DEBUG)
+        if verbose is None:
+            verbose = logger.isEnabledFor(logging.DEBUG)
 
         if not qa_pairs:
             return [], {"total": 0, "filtered": 0, "retention_rate": 0, "avg_score": 0}
@@ -257,23 +367,14 @@ class QAGenerator:
         rated_pairs: List[QAPair] = []
         total_score = 0.0
 
-        # Create progress bar
-        progress_columns = [
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-            TimeElapsedColumn(),
-            TimeRemainingColumn(),
-        ]
-
         from datacreek.utils.batch import async_process_batches, process_batches
 
-        with Progress(*progress_columns) as progress:
-            rating_task = progress.add_task("Rating QA pairs", total=len(batches))
+        with progress_context("Rating QA pairs", len(batches)) as (progress, rating_task):
 
             message_batches = []
             for batch in batches:
-                batch_json = json.dumps(batch, indent=2)
+                batch_dicts = [p.to_dict() if isinstance(p, QAPair) else p for p in batch]
+                batch_json = json.dumps(batch_dicts, indent=2)
                 rating_prompt = rating_prompt_template.format(pairs=batch_json)
                 message_batches.append([{"role": "system", "content": rating_prompt}])
 
@@ -298,7 +399,8 @@ class QAGenerator:
 
             for idx, response in enumerate(responses):
                 try:
-                    rated_batch = parse_ratings(response, batches[idx])
+                    orig_items = [p.to_dict() if isinstance(p, QAPair) else p for p in batches[idx]]
+                    rated_batch = parse_ratings(response, orig_items)
                     for pair in rated_batch:
                         if pair.rating is not None:
                             total_score += pair.rating
@@ -327,6 +429,83 @@ class QAGenerator:
         logger.info("Average score: %s", metrics["avg_score"])
         return [p.to_dict() for p in rated_pairs], metrics
 
+    async def rate_qa_pairs_async(
+        self,
+        qa_pairs: List[QAPair],
+        summary: str,
+        threshold: Optional[float] = None,
+        *,
+        verbose: bool | None = None,
+    ) -> Tuple[List[QAPair], Dict[str, Any]]:
+        """Asynchronous version of :meth:`rate_qa_pairs`."""
+        if verbose is None:
+            verbose = logger.isEnabledFor(logging.DEBUG)
+
+        if not qa_pairs:
+            return [], {"total": 0, "filtered": 0, "retention_rate": 0, "avg_score": 0}
+
+        if threshold is None:
+            threshold = self.curate_config.threshold
+
+        if verbose:
+            logger.info("Evaluating %d pairs...", len(qa_pairs))
+
+        batch_size = self.curate_config.batch_size
+        temperature = self.curate_config.temperature
+        rating_prompt_template = get_prompt(self.config, "qa_rating")
+
+        batches = [qa_pairs[i : i + batch_size] for i in range(0, len(qa_pairs), batch_size)]
+        rated_pairs: List[QAPair] = []
+        total_score = 0.0
+
+        from datacreek.utils.batch import async_process_batches
+
+        with progress_context("Rating QA pairs", len(batches)) as (progress, rating_task):
+            message_batches = []
+            for batch in batches:
+                batch_dicts = [p.to_dict() if isinstance(p, QAPair) else p for p in batch]
+                batch_json = json.dumps(batch_dicts, indent=2)
+                rating_prompt = rating_prompt_template.format(pairs=batch_json)
+                message_batches.append([{"role": "system", "content": rating_prompt}])
+
+            responses = await async_process_batches(
+                self.client,
+                message_batches,
+                batch_size=batch_size,
+                temperature=temperature,
+                parse_fn=lambda s: s,
+            )
+
+            for idx, response in enumerate(responses):
+                try:
+                    orig_items = [p.to_dict() if isinstance(p, QAPair) else p for p in batches[idx]]
+                    rated_batch = parse_ratings(response, orig_items)
+                    for pair in rated_batch:
+                        if pair.rating is not None:
+                            total_score += pair.rating
+                            if pair.rating >= threshold:
+                                rated_pairs.append(pair)
+                except Exception as e:
+                    logger.error("Error processing batch %d: %s", idx + 1, e)
+
+                progress.update(rating_task, advance=1)
+
+        metrics = {
+            "total": len(qa_pairs),
+            "filtered": len(rated_pairs),
+            "retention_rate": round(len(rated_pairs) / len(qa_pairs), 2) if qa_pairs else 0,
+            "avg_score": round(total_score / len(qa_pairs), 1) if qa_pairs else 0,
+        }
+
+        logger.info(
+            "Keeping %d out of %d pairs (threshold: %s)",
+            len(rated_pairs),
+            len(qa_pairs),
+            threshold,
+        )
+        logger.info("Average score: %s", metrics["avg_score"])
+        return [p.to_dict() for p in rated_pairs], metrics
+
     def process_document(
         self,
         document_text: str,
@@ -340,7 +519,7 @@ class QAGenerator:
         # Verbose mode is controlled by logging level
 
         # Generate summary
-        summary = self.generate_summary(document_text)
+        summary = self.generate_summary(document_text, verbose=verbose)
 
         # Generate QA pairs
         qa_pairs = self.generate_qa_pairs(
@@ -348,9 +527,28 @@ class QAGenerator:
             summary,
             num_pairs=num_pairs,
             async_mode=async_mode,
+            verbose=verbose,
         )
 
         # Prepare result - no rating at this stage
+        from datacreek.models.results import QAGenerationResult
+
+        return QAGenerationResult(summary=summary, qa_pairs=qa_pairs)
+
+    async def process_document_async(
+        self,
+        document_text: str,
+        num_pairs: int = 25,
+        verbose: bool = False,
+    ) -> "QAGenerationResult":
+        """Asynchronous version of :meth:`process_document`."""
+        summary = self.generate_summary(document_text, verbose=verbose)
+        qa_pairs = await self.generate_qa_pairs_async(
+            document_text,
+            summary,
+            num_pairs=num_pairs,
+            verbose=verbose,
+        )
         from datacreek.models.results import QAGenerationResult
 
         return QAGenerationResult(summary=summary, qa_pairs=qa_pairs)

--- a/datacreek/generators/tool_generator.py
+++ b/datacreek/generators/tool_generator.py
@@ -1,0 +1,71 @@
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from datacreek.core.knowledge_graph import KnowledgeGraph
+from datacreek.models.llm_client import LLMClient
+from datacreek.utils import convert_to_conversation_format
+
+from .base import BaseGenerator
+
+logger = logging.getLogger(__name__)
+
+
+class ToolCallGenerator(BaseGenerator):
+    """Generate single tool-call demonstrations from text."""
+
+    def __init__(
+        self,
+        client: LLMClient,
+        config_path: Optional[Path] = None,
+        kg: Optional[KnowledgeGraph] = None,
+        config_overrides: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(client, config_path, config_overrides)
+        self.kg = kg
+
+    def process_document(
+        self,
+        document_text: str,
+        *,
+        num_pairs: int = 25,
+        verbose: bool = False,
+        async_mode: bool = False,
+    ) -> Dict[str, Any]:
+        """Return tool-call conversations generated from ``document_text``."""
+
+        from .qa_generator import QAGenerator
+
+        qa_gen = QAGenerator(self.client, self.config_path, kg=self.kg, config_overrides=None)
+
+        if async_mode:
+            result = asyncio.run(
+                qa_gen.process_document_async(document_text, num_pairs=num_pairs, verbose=verbose)
+            )
+        else:
+            result = qa_gen.process_document(document_text, num_pairs=num_pairs, verbose=verbose)
+
+        conversations: List[Dict[str, Any]] = []
+        for pair in result.qa_pairs:
+            conv = convert_to_conversation_format([pair])[0]
+            conv.insert(
+                2,
+                {
+                    "role": "assistant",
+                    "tool_call": {"name": "search", "arguments": {"query": pair.question}},
+                },
+            )
+            conv.insert(
+                3,
+                {"role": "tool", "name": "search", "content": pair.answer},
+            )
+            conversations.append(
+                {
+                    "conversations": conv,
+                    "chunk": pair.chunk,
+                    "source": pair.source,
+                }
+            )
+
+        return {"summary": result.summary, "conversations": conversations}

--- a/datacreek/generators/vqa_generator.py
+++ b/datacreek/generators/vqa_generator.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # - datasets: For handling HuggingFace datasets
 # - huggingface_hub: For accessing HuggingFace repositories
 
+
 def _check_optional_deps() -> None:
     """Ensure optional dependencies are available."""
     try:
@@ -30,6 +31,8 @@ def _check_optional_deps() -> None:
         raise ImportError(
             "The 'datasets' and 'huggingface_hub' packages are required for VQA generation."
         ) from exc
+
+
 class VQAGenerator:
     """Generates Visual Question Answering data with reasoning"""
 

--- a/datacreek/generators/vqa_generator.py
+++ b/datacreek/generators/vqa_generator.py
@@ -21,7 +21,15 @@ logger = logging.getLogger(__name__)
 # - datasets: For handling HuggingFace datasets
 # - huggingface_hub: For accessing HuggingFace repositories
 
-
+def _check_optional_deps() -> None:
+    """Ensure optional dependencies are available."""
+    try:
+        import datasets  # noqa: F401
+        import huggingface_hub  # noqa: F401
+    except Exception as exc:  # pragma: no cover - runtime import
+        raise ImportError(
+            "The 'datasets' and 'huggingface_hub' packages are required for VQA generation."
+        ) from exc
 class VQAGenerator:
     """Generates Visual Question Answering data with reasoning"""
 
@@ -32,6 +40,8 @@ class VQAGenerator:
         config_overrides: Optional[Dict[str, Any]] = None,
     ):
         """Initialize the VQA Generator with an LLM client and optional config"""
+
+        _check_optional_deps()
 
         self.client = client
 

--- a/datacreek/models/content_type.py
+++ b/datacreek/models/content_type.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class ContentType(str, Enum):
+    """Supported data generation content types."""
+
+    QA = "qa"
+    SUMMARY = "summary"
+    COT = "cot"
+    COT_ENHANCE = "cot-enhance"
+    VQA_ADD_REASONING = "vqa_add_reasoning"
+    FROM_KG = "from_kg"
+    TOOL_CALL = "tool_call"
+    CONVERSATION = "conversation"
+    MULTI_TOOL = "multi_tool"
+    PREF_PAIR = "pref_pair"
+    PREF_LIST = "pref_list"

--- a/datacreek/models/qa.py
+++ b/datacreek/models/qa.py
@@ -9,9 +9,15 @@ class QAPair:
     question: str
     answer: str
     rating: Optional[float] = None
+    chunk: Optional[str] = None
+    source: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         data = {"question": self.question, "answer": self.answer}
         if self.rating is not None:
             data["rating"] = self.rating
+        if self.chunk is not None:
+            data["chunk"] = self.chunk
+        if self.source is not None:
+            data["source"] = self.source
         return data

--- a/datacreek/utils/__init__.py
+++ b/datacreek/utils/__init__.py
@@ -17,10 +17,23 @@ from .config import (
     load_config,
     merge_configs,
 )
-from .entity_extraction import extract_entities
-from .fact_extraction import extract_facts
 from .llm_processing import convert_to_conversation_format, parse_qa_pairs, parse_ratings
+from .progress import create_progress, progress_context
 from .text import clean_text, extract_json_from_text, split_into_chunks
+
+
+def __getattr__(name: str):
+    """Lazily import heavy utilities to avoid circular imports."""
+    if name == "extract_facts":
+        from .fact_extraction import extract_facts as func
+
+        return func
+    if name == "extract_entities":
+        from .entity_extraction import extract_entities as func
+
+        return func
+    raise AttributeError(name)
+
 
 __all__ = [
     "load_config",
@@ -43,6 +56,8 @@ __all__ = [
     "clean_text",
     "parse_qa_pairs",
     "parse_ratings",
+    "create_progress",
+    "progress_context",
     "convert_to_conversation_format",
     "extract_facts",
     "extract_entities",

--- a/datacreek/utils/progress.py
+++ b/datacreek/utils/progress.py
@@ -1,0 +1,28 @@
+from contextlib import contextmanager
+from typing import Tuple
+
+from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, TimeRemainingColumn
+
+
+def create_progress(description: str, total: int) -> Tuple[Progress, int]:
+    """Return a ``Progress`` instance and task ID for ``description``."""
+    progress = Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),
+    )
+    task_id = progress.add_task(description, total=total)
+    return progress, task_id
+
+
+@contextmanager
+def progress_context(description: str, total: int):
+    """Yield a started progress bar and stop it afterwards."""
+    progress, task_id = create_progress(description, total)
+    progress.start()
+    try:
+        yield progress, task_id
+    finally:
+        progress.stop()

--- a/tests/test_batch_add_async.py
+++ b/tests/test_batch_add_async.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from datacreek.generators.qa_generator import QAGenerator
 
 
@@ -52,4 +54,26 @@ def test_generate_qa_pairs_async(monkeypatch):
     pairs = gen.generate_qa_pairs("doc", "sum", num_pairs=1, async_mode=True)
 
     assert async_called.get("count") == 1
-    assert pairs == [QAPair(question="q", answer="a")]
+    assert pairs == [QAPair(question="q", answer="a", chunk="doc", source="inline")]
+
+
+def test_generate_qa_pairs_async_direct(monkeypatch):
+    async_called.clear()
+
+    async def fake_async3(client, messages, *, batch_size, temperature, parse_fn):
+        async_called["count"] = len(messages)
+        return [parse_fn('[{"question": "q", "answer": "a"}]') for _ in messages]
+
+    monkeypatch.setattr("datacreek.utils.batch.async_process_batches", fake_async3)
+    from datacreek.models.qa import QAPair
+
+    monkeypatch.setattr(
+        "datacreek.generators.qa_generator.parse_qa_pairs",
+        lambda resp: [QAPair(question="q", answer="a")],
+    )
+
+    gen = QAGenerator(DummyClient())
+    pairs = asyncio.run(gen.generate_qa_pairs_async("doc", "sum", num_pairs=1))
+
+    assert async_called.get("count") == 1
+    assert pairs == [QAPair(question="q", answer="a", chunk="doc", source="inline")]


### PR DESCRIPTION
## Summary
- implement conversation, tool, multi-tool and preference generators
- generators build on `QAGenerator` and record chunk/source info
- keep dataset metadata when converting QA pairs to other formats

## Testing
- `pre-commit run --files datacreek/generators/conversation_generator.py datacreek/generators/tool_generator.py datacreek/generators/multi_tool_generator.py datacreek/generators/pref_generator.py`
- `pytest -q tests/test_pipelines.py`

------
https://chatgpt.com/codex/tasks/task_e_685fdb7f8b78832f8f456e9e79e28cbc