### PR TITLE
Enforce KG usage across pipelines

### DIFF
--- a/datacreek/config.yaml
+++ b/datacreek/config.yaml
@@ -116,6 +116,37 @@ prompts:
     
     Text:
     {text}
+
+  kg_summary: |
+    Summarize the following knowledge graph in 3-5 sentences.
+
+    Graph:
+    {graph}
+
+  kg_qa_generation: |
+    Using only the information from this knowledge graph, create {num_pairs} question-answer pairs.
+
+    Return JSON format only:
+
+    [
+      {{"question": "Question?", "answer": "Answer."}}
+    ]
+
+    Graph:
+    {graph}
+
+  kg_question: |
+    Given the following facts, craft a concise question that can be answered using only this information.
+
+    Facts:
+    {facts}
+
+  kg_answer: |
+    Provide a factual answer to the question using only the given facts.
+
+    Facts:
+    {facts}
+    Question: {question}
   
   # QA pair rating prompt
   qa_rating: |
@@ -141,6 +172,16 @@ prompts:
     *** YOUR RESPONSE MUST BE VALID JSON AND NOTHING ELSE - NO EXPLANATION, NO MARKDOWN ***
     
     QA pairs to rate:
+    {pairs}
+
+  kg_qa_rating: |
+    Rate each question-answer pair using the knowledge graph facts below.
+    Apply the same 1-10 scale as for qa_rating.
+
+    Facts:
+    {facts}
+
+    Pairs:
     {pairs}
     
   # Chain of Thought generation prompt

--- a/datacreek/core/knowledge_graph.py
+++ b/datacreek/core/knowledge_graph.py
@@ -1727,6 +1727,25 @@ class KnowledgeGraph:
         kg.index.build()
         return kg
 
+    def to_text(self) -> str:
+        """Return all chunk texts concatenated in document order."""
+
+        parts: list[str] = []
+        docs = [n for n, d in self.graph.nodes(data=True) if d.get("type") == "document"]
+        docs.sort()
+        for doc_id in docs:
+            chunks = self.get_chunks_for_document(doc_id)
+            if chunks:
+                for cid in chunks:
+                    text = self.graph.nodes[cid].get("text")
+                    if text:
+                        parts.append(text)
+            else:
+                text = self.graph.nodes[doc_id].get("text")
+                if text:
+                    parts.append(text)
+        return "\n\n".join(parts)
+
     def to_json(self, path: str) -> str:
         """Save the graph to a JSON file."""
 

--- a/datacreek/generators/kg_generator.py
+++ b/datacreek/generators/kg_generator.py
@@ -1,9 +1,10 @@
 import logging
-from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
+
+from sklearn.cluster import KMeans
 
 from datacreek.core.knowledge_graph import KnowledgeGraph
-from datacreek.models.llm_client import LLMClient
+from datacreek.models.qa import QAPair
 from datacreek.utils.config import get_prompt
 
 from .base import BaseGenerator
@@ -14,35 +15,106 @@ logger = logging.getLogger(__name__)
 class KGGenerator(BaseGenerator):
     """Generate QA examples from a knowledge graph."""
 
+    def _select_facts(self, kg: KnowledgeGraph, num: int) -> List[str]:
+        """Return ``num`` fact IDs chosen to maximize coverage."""
+
+        fact_nodes = [n for n, d in kg.graph.nodes(data=True) if d.get("type") == "fact"]
+        if len(fact_nodes) <= num:
+            return fact_nodes
+
+        texts = [
+            f"{kg.graph.nodes[f]['subject']} {kg.graph.nodes[f]['predicate']} {kg.graph.nodes[f]['object']}"
+            for f in fact_nodes
+        ]
+        embeddings = kg.index.transform(texts)
+        if embeddings.size == 0:
+            fact_nodes.sort(key=lambda n: kg.graph.degree(n), reverse=True)
+            return fact_nodes[:num]
+
+        kmeans = KMeans(n_clusters=num, n_init="auto", random_state=0)
+        labels = kmeans.fit_predict(embeddings)
+        selected: List[str] = []
+        for cluster_id in range(num):
+            members = [f for f, l in zip(fact_nodes, labels) if l == cluster_id]
+            if not members:
+                continue
+            members.sort(key=lambda n: kg.graph.degree(n), reverse=True)
+            selected.append(members[0])
+        return selected
+
     def process_graph(
         self,
         kg: KnowledgeGraph,
         num_pairs: int = 25,
         *,
         verbose: bool = False,
+        multi_answer: bool = False,
     ) -> Dict[str, Any]:
-        """Return QA pairs generated from ``kg``.
+        """Generate QA pairs by sampling facts from ``kg``.
 
-        This is a simplified placeholder implementation that serializes a small
-        portion of the graph and uses the QA prompt.
+        Facts are selected using clustering to maximise coverage. For each
+        chosen fact (``subject``-``predicate``-``object`` triple) a question is
+        generated first. The question together with the fact text is then sent
+        again to obtain a factual answer. Only a small portion of the graph is
+        ever passed to the LLM which avoids context explosion.
         """
-        nodes = list(kg.graph.nodes(data=True))[:5]
-        text_parts = []
-        for node, data in nodes:
-            label = data.get("label") or node
-            summary = data.get("summary") or data.get("text", "")
-            text_parts.append(f"{label}: {summary}")
-        prompt = get_prompt(self.config, "qa_generation")
-        prompt_filled = prompt.format(num_pairs=num_pairs, summary="", text="\n".join(text_parts))
-        messages = [{"role": "system", "content": prompt_filled}]
+
+        fact_nodes = self._select_facts(kg, num_pairs)
+
+        if not fact_nodes:
+            return {"qa_pairs": []}
+
         temperature = self.generation_config.temperature
         max_tokens = self.generation_config.max_tokens
-        if verbose:
-            logger.info("Generating QA from knowledge graph with %d nodes", len(nodes))
-        response = self.client.chat_completion(
-            messages, temperature=temperature, max_tokens=max_tokens
-        )
-        from datacreek.utils.llm_processing import parse_qa_pairs
 
-        qa_pairs = parse_qa_pairs(response)
+        question_prompt = get_prompt(self.config, "kg_question")
+        answer_prompt = get_prompt(self.config, "kg_answer")
+
+        qa_pairs: list[QAPair] = []
+
+        if verbose:
+            logger.info("Generating QA from %d facts", len(fact_nodes))
+
+        for fid in fact_nodes:
+            if len(qa_pairs) >= num_pairs:
+                break
+
+            fact = kg.graph.nodes[fid]
+            fact_text = f"{fact['subject']} {fact['predicate']} {fact['object']}"
+
+            context_chunks = [
+                kg.graph.nodes[cid].get("text")
+                for cid in kg.get_chunks_for_fact(fid)
+                if "text" in kg.graph.nodes[cid]
+            ]
+            if context_chunks:
+                fact_text += "\n" + "\n".join(context_chunks[:3])
+
+            q_msg = question_prompt.format(facts=fact_text)
+            question = self.client.chat_completion(
+                [{"role": "system", "content": q_msg}],
+                temperature=temperature,
+                max_tokens=max_tokens,
+            ).strip()
+
+            a_msg = answer_prompt.format(facts=fact_text, question=question)
+            answer = self.client.chat_completion(
+                [{"role": "system", "content": a_msg}],
+                temperature=temperature,
+                max_tokens=max_tokens,
+            ).strip()
+
+            answers = 2 if multi_answer else 1
+            for _ in range(answers):
+                if len(qa_pairs) >= num_pairs:
+                    break
+                if _ > 0:
+                    a_msg = answer_prompt.format(facts=fact_text, question=question)
+                    answer = self.client.chat_completion(
+                        [{"role": "system", "content": a_msg}],
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                    ).strip()
+                qa_pairs.append(QAPair(question=question, answer=answer, facts=[fid]))
+
         return {"qa_pairs": [p.to_dict() for p in qa_pairs]}

--- a/datacreek/models/qa.py
+++ b/datacreek/models/qa.py
@@ -11,6 +11,7 @@ class QAPair:
     rating: Optional[float] = None
     chunk: Optional[str] = None
     source: Optional[str] = None
+    facts: Optional[list[str]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         data = {"question": self.question, "answer": self.answer}
@@ -20,4 +21,6 @@ class QAPair:
             data["chunk"] = self.chunk
         if self.source is not None:
             data["source"] = self.source
+        if self.facts:
+            data["facts"] = self.facts
         return data

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -722,9 +722,9 @@ def test_get_raw_text_and_run_pipeline(monkeypatch):
 
     calls = {}
 
-    def fake_run(dtype, doc_text, **kwargs):
+    def fake_run(dtype, graph, **kwargs):
         calls["dtype"] = dtype
-        calls["text"] = doc_text
+        calls["graph"] = graph
         calls["kwargs"] = kwargs
         return "ok"
 
@@ -734,6 +734,7 @@ def test_get_raw_text_and_run_pipeline(monkeypatch):
 
     assert result == "ok"
     assert calls["dtype"] == DatasetType.QA
-    assert "hello" in calls["text"] and "world" in calls["text"]
+    assert calls["graph"] is ds.graph
     assert calls["kwargs"]["num_pairs"] == 5
     assert calls["kwargs"]["async_mode"] is True
+    assert calls["kwargs"]["multi_answer"] is False

--- a/tests/test_kg_generator.py
+++ b/tests/test_kg_generator.py
@@ -1,0 +1,48 @@
+import pytest
+
+from datacreek.core.knowledge_graph import KnowledgeGraph
+from datacreek.generators.kg_generator import KGGenerator
+
+
+class DummyClient:
+    def __init__(self):
+        self.calls = []
+        self.config = {
+            "prompts": {"kg_question": "{facts}", "kg_answer": "{question} {facts}"},
+            "generation": {"temperature": 0.1, "max_tokens": 50},
+        }
+
+    def chat_completion(self, messages, *, temperature=None, max_tokens=None):
+        self.calls.append(messages[0]["content"])
+        if len(self.calls) % 2 == 1:
+            return "What?"
+        return "Because"
+
+
+def test_kg_generator_basic():
+    kg = KnowledgeGraph()
+    fid = kg.add_fact("Earth", "is", "round")
+    gen = KGGenerator(DummyClient())
+    result = gen.process_graph(kg, num_pairs=1)
+    assert result == {"qa_pairs": [{"question": "What?", "answer": "Because", "facts": [fid]}]}
+    assert len(gen.client.calls) == 2
+
+
+def test_kg_generator_multi_answer():
+    kg = KnowledgeGraph()
+    fid = kg.add_fact("Sky", "is", "blue")
+    gen = KGGenerator(DummyClient())
+    res = gen.process_graph(kg, num_pairs=2, multi_answer=True)
+    assert len(res["qa_pairs"]) == 2
+    assert res["qa_pairs"][0]["question"] == "What?"
+    assert len(gen.client.calls) == 3
+
+
+def test_kg_generator_select_limit():
+    kg = KnowledgeGraph()
+    for i in range(5):
+        kg.add_fact(f"S{i}", "is", f"O{i}")
+
+    gen = KGGenerator(DummyClient())
+    res = gen.process_graph(kg, num_pairs=2)
+    assert len(res["qa_pairs"]) == 2


### PR DESCRIPTION
## Summary
- extend QA generation prompts with KG-specific rating
- store fact IDs in `QAPair` and allow multiple answers per fact
- use KG context in QA rating and curation
- pass KG through pipelines to the curation step
- add tests for new KG generator behaviour
- expose `multi_answer` flag through pipelines and dataset builder
- select diverse facts using KMeans when generating from the knowledge graph
- include the KG when generating candidate preference data
- expand pipeline tests to cover conversation, multi-tool and preference datasets

## Testing
- `pre-commit run --files datacreek/pipelines.py tests/test_pipelines.py`
- `pytest -q tests/test_pipelines.py`


------
https://chatgpt.com/codex/tasks/task_e_6860b24c4894832fa37e72316730522d