### PR TITLE
Refine post-KG validation

### DIFF
--- a/datacreek/generators/base.py
+++ b/datacreek/generators/base.py
@@ -18,13 +18,14 @@ class BaseGenerator:
         config_overrides: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.client = client
-        if config_path:
-            base_cfg = load_config(config_path)
+        if config_path or config_overrides:
+            from datacreek.utils.config import load_config_with_overrides
+
+            self.config = load_config_with_overrides(
+                str(config_path) if config_path else None, config_overrides
+            )
         else:
-            base_cfg = client.config
-        if config_overrides:
-            base_cfg = merge_configs(base_cfg, config_overrides)
-        self.config = base_cfg
+            self.config = client.config
         self.generation_config = get_generation_config(self.config)
 
     def process_document(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - base stub

--- a/datacreek/generators/cot_generator.py
+++ b/datacreek/generators/cot_generator.py
@@ -32,17 +32,14 @@ class COTGenerator:
         """Initialize the CoT Generator with an LLM client and optional config"""
         self.client = client
 
-        if config_path:
-            base_cfg = load_config(config_path)
+        if config_path or config_overrides:
+            from datacreek.utils.config import load_config_with_overrides
+
+            self.config = load_config_with_overrides(
+                str(config_path) if config_path else None, config_overrides
+            )
         else:
-            base_cfg = client.config
-
-        if config_overrides:
-            from datacreek.utils.config import merge_configs
-
-            base_cfg = merge_configs(base_cfg, config_overrides)
-
-        self.config = base_cfg
+            self.config = client.config
         self.generation_config = get_generation_config(self.config)
 
     def parse_json_output(self, output_text: str) -> Optional[List[Dict]]:

--- a/datacreek/generators/vqa_generator.py
+++ b/datacreek/generators/vqa_generator.py
@@ -48,19 +48,14 @@ class VQAGenerator:
 
         self.client = client
 
-        # Load base config from file or client
-        if config_path:
-            base_cfg = load_config(config_path)
+        if config_path or config_overrides:
+            from datacreek.utils.config import load_config_with_overrides
+
+            self.config = load_config_with_overrides(
+                str(config_path) if config_path else None, config_overrides
+            )
         else:
-            base_cfg = client.config
-
-        # Merge overrides if provided
-        if config_overrides:
-            from datacreek.utils.config import merge_configs
-
-            base_cfg = merge_configs(base_cfg, config_overrides)
-
-        self.config = base_cfg
+            self.config = client.config
 
         # Get specific configurations
         self.generation_config = get_generation_config(self.config)

--- a/datacreek/pipelines.py
+++ b/datacreek/pipelines.py
@@ -11,7 +11,10 @@ from datacreek.core.curate import curate_qa_pairs
 from datacreek.core.knowledge_graph import KnowledgeGraph
 from datacreek.core.save_as import convert_format
 from datacreek.models.content_type import ContentType
-from datacreek.utils.config import get_format_settings, load_config, merge_configs
+from datacreek.utils.config import (
+    get_format_settings,
+    load_config_with_overrides,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -325,10 +328,9 @@ def run_generation_pipeline(
     ``multi_answer`` controls whether multiple answers are generated per fact
     when using the knowledge graph generator.
 
-    At the moment only the QA, COT and VQA pipelines are implemented here. They
-    share a common post-knowledge-graph flow consisting of generation, optional
-    curation and output formatting. Other dataset types require additional
-    specialised steps which are not yet supported.
+    All dataset types except ``TEXT`` share a common post-knowledge-graph flow
+    consisting of generation, optional curation and output formatting. This
+    helper executes those steps in-memory and returns the resulting dataset.
     """
 
     try:
@@ -360,150 +362,59 @@ def run_generation_pipeline(
     data: Any = document_text
 
     def _save(d: Any) -> Any:
-        cfg = load_config(str(config_path) if config_path else None)
-        if overrides:
-            cfg = merge_configs(cfg, overrides)
+        cfg = load_config_with_overrides(
+            str(config_path) if config_path else None, overrides
+        )
         fmt_cfg = get_format_settings(cfg)
         format_type = fmt or fmt_cfg.default
         return convert_format(d, None, format_type, cfg)
 
-    handlers = {
-        PipelineStep.GENERATE_QA: lambda d: process_file(
+    def _generate(ct: ContentType, text: str) -> Any:
+        return process_file(
             None,
             None,
             options.config_path,
             options.api_base,
             options.model,
-            ContentType.QA,
+            ct,
             options.num_pairs,
             options.verbose,
             async_mode=options.async_mode,
             provider=options.provider,
             profile=options.profile,
-            document_text=d,
+            document_text=text,
             kg=options.kg,
             config_overrides=options.overrides,
-        ),
-        PipelineStep.GENERATE_COT: lambda d: process_file(
-            None,
-            None,
-            options.config_path,
-            options.api_base,
-            options.model,
-            ContentType.COT,
-            options.num_pairs,
-            options.verbose,
-            async_mode=options.async_mode,
-            provider=options.provider,
-            profile=options.profile,
-            document_text=d,
-            kg=options.kg,
-            config_overrides=options.overrides,
-        ),
-        PipelineStep.GENERATE_VQA: lambda d: process_file(
-            None,
-            None,
-            options.config_path,
-            options.api_base,
-            options.model,
-            ContentType.VQA_ADD_REASONING,
-            options.num_pairs,
-            options.verbose,
-            async_mode=options.async_mode,
-            provider=options.provider,
-            profile=options.profile,
-            document_text=d,
-            kg=options.kg,
-            config_overrides=options.overrides,
-        ),
-        PipelineStep.GENERATE_FROM_KG: lambda d: process_file(
-            None,
-            None,
-            options.config_path,
-            options.api_base,
-            options.model,
-            ContentType.FROM_KG,
-            options.num_pairs,
-            options.verbose,
-            async_mode=options.async_mode,
-            provider=options.provider,
-            profile=options.profile,
-            document_text=d,
-            kg=options.kg,
-            config_overrides=options.overrides,
-            multi_answer=options.multi_answer,
-        ),
-        PipelineStep.GENERATE_TOOL_CALL: lambda d: process_file(
-            None,
-            None,
-            options.config_path,
-            options.api_base,
-            options.model,
-            ContentType.TOOL_CALL,
-            options.num_pairs,
-            options.verbose,
-            async_mode=options.async_mode,
-            provider=options.provider,
-            profile=options.profile,
-            document_text=d,
-            kg=options.kg,
-            config_overrides=options.overrides,
-        ),
-        PipelineStep.GENERATE_CONVERSATION: lambda d: process_file(
-            None,
-            None,
-            options.config_path,
-            options.api_base,
-            options.model,
-            ContentType.CONVERSATION,
-            options.num_pairs,
-            options.verbose,
-            async_mode=options.async_mode,
-            provider=options.provider,
-            profile=options.profile,
-            document_text=d,
-            kg=options.kg,
-            config_overrides=options.overrides,
-        ),
-        PipelineStep.GENERATE_MULTI_TOOL: lambda d: process_file(
-            None,
-            None,
-            options.config_path,
-            options.api_base,
-            options.model,
-            ContentType.MULTI_TOOL,
-            options.num_pairs,
-            options.verbose,
-            async_mode=options.async_mode,
-            provider=options.provider,
-            profile=options.profile,
-            document_text=d,
-            kg=options.kg,
-            config_overrides=options.overrides,
-        ),
-        PipelineStep.GENERATE_CANDIDATES: lambda d: process_file(
-            None,
-            None,
-            options.config_path,
-            options.api_base,
-            options.model,
-            (
-                ContentType.PREF_PAIR
-                if dataset_type == DatasetType.PREF_PAIR
-                else ContentType.PREF_LIST
-            ),
-            options.num_pairs,
-            options.verbose,
-            async_mode=options.async_mode,
-            provider=options.provider,
-            profile=options.profile,
-            document_text=d,
-            kg=options.kg,
-            config_overrides=options.overrides,
-        ),
-        PipelineStep.LABEL_PAIRS: lambda d: d,
-        PipelineStep.RANK_RESPONSES: lambda d: d,
-        PipelineStep.CURATE: lambda d: curate_qa_pairs(
+            multi_answer=options.multi_answer if ct is ContentType.FROM_KG else False,
+        )
+
+    def _validate(step: PipelineStep, result: Any) -> Any:
+        """Basic sanity checks for generation results."""
+        if step in {
+            PipelineStep.GENERATE_QA,
+            PipelineStep.GENERATE_FROM_KG,
+        }:
+            if not isinstance(result, dict) or "qa_pairs" not in result:
+                raise ValueError("QA generation did not produce 'qa_pairs'")
+        elif step is PipelineStep.GENERATE_COT:
+            if not isinstance(result, dict) or "cot_examples" not in result:
+                raise ValueError("CoT generation did not produce 'cot_examples'")
+        elif step in {
+            PipelineStep.GENERATE_TOOL_CALL,
+            PipelineStep.GENERATE_CONVERSATION,
+            PipelineStep.GENERATE_MULTI_TOOL,
+        }:
+            if not isinstance(result, dict) or "conversations" not in result:
+                raise ValueError("Conversation generation missing 'conversations'")
+        elif step is PipelineStep.GENERATE_CANDIDATES:
+            if not isinstance(result, dict) or not (
+                "pairs" in result or "responses" in result
+            ):
+                raise ValueError("Candidate generation returned invalid data")
+        return result
+
+    def _curate(d: Any) -> Any:
+        return curate_qa_pairs(
             d,
             None,
             threshold,
@@ -514,8 +425,24 @@ def run_generation_pipeline(
             options.provider,
             async_mode=options.async_mode,
             kg=options.kg,
+        )
+
+    handlers = {
+        PipelineStep.GENERATE_QA: lambda d: _generate(ContentType.QA, d),
+        PipelineStep.GENERATE_COT: lambda d: _generate(ContentType.COT, d),
+        PipelineStep.GENERATE_VQA: lambda d: _generate(ContentType.VQA_ADD_REASONING, d),
+        PipelineStep.GENERATE_FROM_KG: lambda d: _generate(ContentType.FROM_KG, d),
+        PipelineStep.GENERATE_TOOL_CALL: lambda d: _generate(ContentType.TOOL_CALL, d),
+        PipelineStep.GENERATE_CONVERSATION: lambda d: _generate(ContentType.CONVERSATION, d),
+        PipelineStep.GENERATE_MULTI_TOOL: lambda d: _generate(ContentType.MULTI_TOOL, d),
+        PipelineStep.GENERATE_CANDIDATES: lambda d: _generate(
+            ContentType.PREF_PAIR if dataset_type == DatasetType.PREF_PAIR else ContentType.PREF_LIST,
+            d,
         ),
-        PipelineStep.SAVE: lambda d: _save(d),
+        PipelineStep.LABEL_PAIRS: lambda d: d,
+        PipelineStep.RANK_RESPONSES: lambda d: d,
+        PipelineStep.CURATE: _curate,
+        PipelineStep.SAVE: _save,
     }
 
     for step in pipeline.steps:
@@ -525,6 +452,10 @@ def run_generation_pipeline(
             logger.info("Running step %s", step.value)
         handler = handlers.get(step)
         if handler:
-            data = handler(data)
+            result = handler(data)
+            if step.name.startswith("GENERATE"):
+                data = _validate(step, result)
+            else:
+                data = result
 
     return data

--- a/datacreek/pipelines.py
+++ b/datacreek/pipelines.py
@@ -11,10 +11,7 @@ from datacreek.core.curate import curate_qa_pairs
 from datacreek.core.knowledge_graph import KnowledgeGraph
 from datacreek.core.save_as import convert_format
 from datacreek.models.content_type import ContentType
-from datacreek.utils.config import (
-    get_format_settings,
-    load_config_with_overrides,
-)
+from datacreek.utils.config import get_format_settings, load_config_with_overrides
 
 logger = logging.getLogger(__name__)
 
@@ -362,9 +359,7 @@ def run_generation_pipeline(
     data: Any = document_text
 
     def _save(d: Any) -> Any:
-        cfg = load_config_with_overrides(
-            str(config_path) if config_path else None, overrides
-        )
+        cfg = load_config_with_overrides(str(config_path) if config_path else None, overrides)
         fmt_cfg = get_format_settings(cfg)
         format_type = fmt or fmt_cfg.default
         return convert_format(d, None, format_type, cfg)
@@ -407,9 +402,7 @@ def run_generation_pipeline(
             if not isinstance(result, dict) or "conversations" not in result:
                 raise ValueError("Conversation generation missing 'conversations'")
         elif step is PipelineStep.GENERATE_CANDIDATES:
-            if not isinstance(result, dict) or not (
-                "pairs" in result or "responses" in result
-            ):
+            if not isinstance(result, dict) or not ("pairs" in result or "responses" in result):
                 raise ValueError("Candidate generation returned invalid data")
         return result
 
@@ -436,7 +429,11 @@ def run_generation_pipeline(
         PipelineStep.GENERATE_CONVERSATION: lambda d: _generate(ContentType.CONVERSATION, d),
         PipelineStep.GENERATE_MULTI_TOOL: lambda d: _generate(ContentType.MULTI_TOOL, d),
         PipelineStep.GENERATE_CANDIDATES: lambda d: _generate(
-            ContentType.PREF_PAIR if dataset_type == DatasetType.PREF_PAIR else ContentType.PREF_LIST,
+            (
+                ContentType.PREF_PAIR
+                if dataset_type == DatasetType.PREF_PAIR
+                else ContentType.PREF_LIST
+            ),
             d,
         ),
         PipelineStep.LABEL_PAIRS: lambda d: d,

--- a/datacreek/tasks.py
+++ b/datacreek/tasks.py
@@ -75,16 +75,19 @@ def generate_task(
         src = db.get(SourceData, src_id)
         if not src or src.owner_id != user_id:
             raise RuntimeError("Source not found")
-        from datacreek.utils import get_path_config, load_config
+        from datacreek.utils import get_path_config
+        from datacreek.utils.config import load_config_with_overrides
 
-        cfg = load_config(str(config_path) if config_path else None)
-        output_dir = Path(get_path_config(cfg, "output", "generated"))
-        output_dir.mkdir(parents=True, exist_ok=True)
         overrides = {}
         if generation is not None:
             overrides["generation"] = generation
         if prompts is not None:
             overrides["prompts"] = prompts
+        cfg = load_config_with_overrides(
+            str(config_path) if config_path else None, overrides if overrides else None
+        )
+        output_dir = Path(get_path_config(cfg, "output", "generated"))
+        output_dir.mkdir(parents=True, exist_ok=True)
         out = generate_data(
             None,
             None,

--- a/datacreek/utils/batch.py
+++ b/datacreek/utils/batch.py
@@ -13,8 +13,9 @@ def process_batches(
     batch_size: int,
     temperature: float,
     parse_fn: Callable[[str], Any],
+    raise_on_error: bool = False,
 ) -> List[Any]:
-    """Helper to run LLM requests in batches with basic error handling."""
+    """Helper to run LLM requests in batches with optional error propagation."""
     results: List[Any] = []
     for start in range(0, len(message_batches), batch_size):
         end = min(start + batch_size, len(message_batches))
@@ -31,6 +32,8 @@ def process_batches(
                 except Exception as parse_err:
                     logger.error("Failed to parse response: %s", parse_err)
         except Exception as e:
+            if raise_on_error:
+                raise
             logger.error("Error processing batch %s-%s: %s", start, end, e)
     return results
 
@@ -42,6 +45,7 @@ async def async_process_batches(
     batch_size: int,
     temperature: float,
     parse_fn: Callable[[str], Any],
+    raise_on_error: bool = False,
 ) -> List[Any]:
     """Asynchronously process message batches with :class:`LLMClient`."""
 
@@ -61,5 +65,7 @@ async def async_process_batches(
                 except Exception as parse_err:
                     logger.error("Failed to parse response: %s", parse_err)
         except Exception as e:
+            if raise_on_error:
+                raise
             logger.error("Error processing batch %s-%s: %s", start, end, e)
     return results

--- a/datacreek/utils/config.py
+++ b/datacreek/utils/config.py
@@ -242,6 +242,17 @@ def merge_configs(base_config: Dict[str, Any], override_config: Dict[str, Any]) 
     return result
 
 
+def load_config_with_overrides(
+    config_path: str | None = None, overrides: Dict[str, Any] | None = None
+) -> Dict[str, Any]:
+    """Convenience wrapper around :func:`load_config` applying ``overrides``."""
+
+    cfg = load_config(config_path)
+    if overrides:
+        cfg = merge_configs(cfg, overrides)
+    return cfg
+
+
 def get_model_profile(config: Dict[str, Any], name: str) -> Dict[str, Any]:
     """Retrieve a model profile by name."""
     profiles = config.get("models", {})

--- a/tests/test_batch_add_async.py
+++ b/tests/test_batch_add_async.py
@@ -14,7 +14,7 @@ class DummyClient:
 async_called = {}
 
 
-async def fake_async(client, messages, *, batch_size, temperature, parse_fn):
+async def fake_async(client, messages, *, batch_size, temperature, parse_fn, **kwargs):
     async_called["count"] = len(messages)
     return ["{}"] * len(messages)
 
@@ -38,7 +38,7 @@ def test_rate_qa_pairs_async(monkeypatch):
 def test_generate_qa_pairs_async(monkeypatch):
     async_called.clear()
 
-    async def fake_async2(client, messages, *, batch_size, temperature, parse_fn):
+    async def fake_async2(client, messages, *, batch_size, temperature, parse_fn, **kwargs):
         async_called["count"] = len(messages)
         return [parse_fn('[{"question": "q", "answer": "a"}]') for _ in messages]
 
@@ -60,7 +60,7 @@ def test_generate_qa_pairs_async(monkeypatch):
 def test_generate_qa_pairs_async_direct(monkeypatch):
     async_called.clear()
 
-    async def fake_async3(client, messages, *, batch_size, temperature, parse_fn):
+    async def fake_async3(client, messages, *, batch_size, temperature, parse_fn, **kwargs):
         async_called["count"] = len(messages)
         return [parse_fn('[{"question": "q", "answer": "a"}]') for _ in messages]
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -314,6 +314,19 @@ def test_run_generation_pipeline_overrides(monkeypatch):
     assert received["overrides"] == {"foo": 1}
 
 
+def test_run_generation_pipeline_validation(monkeypatch):
+    """Ensure missing keys raise an error during validation."""
+
+    monkeypatch.setattr("datacreek.pipelines.process_file", lambda *a, **k: {})
+    monkeypatch.setattr("datacreek.pipelines.convert_format", lambda *a, **k: {})
+
+    kg = KnowledgeGraph()
+    kg.add_document("d", source="s", text="text")
+
+    with pytest.raises(ValueError):
+        run_generation_pipeline(DatasetType.QA, kg)
+
+
 def test_run_generation_pipeline_unsupported(monkeypatch):
     """Ensure unsupported dataset types raise errors."""
 


### PR DESCRIPTION
## Summary
- ensure generation steps output expected keys
- test validation error path in generation pipeline

## Testing
- `pytest tests/test_batch.py::test_curate_async_mode tests/test_batch_add_async.py::test_rate_qa_pairs_async tests/test_batch_add_async.py::test_generate_qa_pairs_async tests/test_batch_add_async.py::test_generate_qa_pairs_async_direct -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860d5cba13c832fabaf546e5c482486