### PR TITLE
Implement pipeline enhancements

### DIFF
--- a/datacreek/core/cleanup.py
+++ b/datacreek/core/cleanup.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+
+from .knowledge_graph import KnowledgeGraph
+from datacreek.models.results import KGCleanupStats
+
+if TYPE_CHECKING:  # pragma: no cover - avoid circular import at runtime
+    from .dataset import DatasetBuilder
+
+
+def cleanup_knowledge_graph(
+    kg: KnowledgeGraph,
+    *,
+    dataset_builder: Optional[DatasetBuilder] = None,
+    resolve_threshold: float = 0.8,
+    resolve_aliases: dict[str, list[str]] | None = None,
+    dedup_similarity: float = 1.0,
+) -> KGCleanupStats:
+    """Run standard cleanup operations on ``kg``.
+
+    Parameters
+    ----------
+    dataset_builder:
+        Optional :class:`DatasetBuilder` to log events on.
+    resolve_threshold:
+        Similarity used when merging entities.
+    resolve_aliases:
+        Mapping of canonical labels to aliases used during entity resolution.
+    dedup_similarity:
+        Similarity threshold for deduplicating chunk text.
+    """
+    if dataset_builder is not None:
+        removed, cleaned = dataset_builder.cleanup_graph(
+            resolve_threshold=resolve_threshold,
+            resolve_aliases=resolve_aliases,
+            dedup_similarity=dedup_similarity,
+        )
+    else:
+        removed = kg.deduplicate_chunks(dedup_similarity)
+        cleaned = kg.clean_chunk_texts()
+        kg.resolve_entities(threshold=resolve_threshold, aliases=resolve_aliases)
+    return KGCleanupStats(removed=removed, cleaned=cleaned)

--- a/datacreek/models/results.py
+++ b/datacreek/models/results.py
@@ -106,3 +106,14 @@ class PrefListResult:
 
     def to_dict(self) -> Dict[str, Any]:
         return {"summary": self.summary, "responses": self.responses}
+
+
+@dataclass
+class KGCleanupStats:
+    """Statistics returned after cleaning up a knowledge graph."""
+
+    removed: int
+    cleaned: int
+
+    def to_dict(self) -> Dict[str, int]:
+        return {"removed": self.removed, "cleaned": self.cleaned}

--- a/datacreek/pipelines.py
+++ b/datacreek/pipelines.py
@@ -17,6 +17,8 @@ from datacreek.core.create import process_file, process_file_async
 from datacreek.core.curate import curate_qa_pairs, curate_qa_pairs_async
 from datacreek.core.knowledge_graph import KnowledgeGraph
 from datacreek.core.save_as import convert_format
+from datacreek.core.cleanup import cleanup_knowledge_graph
+from datacreek.utils.progress import create_progress
 from datacreek.models.content_type import ContentType
 from datacreek.models.results import (
     ConversationResult,
@@ -109,6 +111,9 @@ class ProcessOptions:
     checkpoint_dir: Path | None = None
     keep_ratings: bool = False
     dedup_similarity: float = 1.0
+    curation_temperature: float | None = None
+    curation_threshold: float | None = None
+    resume_curation: bool = False
 
 
 # Expected dataclass types for generation results
@@ -135,15 +140,20 @@ STEP_FIELDS = {
 
 def _validate_step_result(
     dataset_type: DatasetType, step: PipelineStep, result: Any
-) -> Dict[str, Any]:
-    """Return ``result`` as a dict and verify it matches ``step`` expectations."""
+) -> Any:
+    """Validate ``result`` for ``step`` and return it unchanged.
+
+    Dataclass instances are accepted and preserved so later steps can rely on
+    structured types. If ``result`` is a plain mapping, it is checked directly.
+    """
 
     step_name = step.value
     expected_cls = STEP_DATACLASSES.get(step)
     if step is PipelineStep.GENERATE_CANDIDATES:
         expected_cls = PrefPairResult if dataset_type == DatasetType.PREF_PAIR else PrefListResult
 
-    if is_dataclass(result):
+    is_dc = is_dataclass(result)
+    if is_dc:
         if expected_cls and not isinstance(result, expected_cls):
             raise ValueError(
                 f"{step_name}: expected {expected_cls.__name__}, got {type(result).__name__}"
@@ -241,7 +251,7 @@ def _validate_step_result(
                         if not str(ans.get("text", "")).strip():
                             raise ValueError(f"{step_name}: answer text is empty")
 
-    return result_dict
+    return result
 
 
 def _serialize(data: Any) -> Any:
@@ -255,17 +265,42 @@ def _serialize(data: Any) -> Any:
     return data
 
 
+@dataclass
+class StepError:
+    """Detailed information about a pipeline step failure."""
+
+    step: PipelineStep
+    exc_type: str
+    message: str
+    traceback: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "step": self.step.value,
+            "exc_type": self.exc_type,
+            "message": self.message,
+            "traceback": self.traceback,
+        }
+
+
 class PipelineExecutionError(RuntimeError):
     """Raised when a generation pipeline step fails with additional context."""
 
     def __init__(self, step: PipelineStep, original_exception: Exception):
-        self.step = step
-        self.original_exception = original_exception
-        self.traceback = "".join(
+        tb = "".join(
             traceback.format_exception(
                 type(original_exception), original_exception, original_exception.__traceback__
             )
         )
+        self.info = StepError(
+            step=step,
+            exc_type=type(original_exception).__name__,
+            message=str(original_exception),
+            traceback=tb,
+        )
+        self.step = step
+        self.original_exception = original_exception
+        self.traceback = tb
         super().__init__(f"{step.value} failed: {original_exception}")
 
 
@@ -535,6 +570,8 @@ async def _run_generation_pipeline_impl(
     checkpoint_dir: Path | None = None,
     dedup_similarity: float = 1.0,
     keep_ratings: bool = False,
+    curation_temperature: float | None = None,
+    resume_curation: bool = False,
 ) -> Any:
     """Shared implementation for sync and async generation pipelines."""
 
@@ -575,6 +612,9 @@ async def _run_generation_pipeline_impl(
         checkpoint_dir=checkpoint_dir,
         keep_ratings=keep_ratings,
         dedup_similarity=dedup_similarity,
+        curation_temperature=curation_temperature,
+        curation_threshold=threshold,
+        resume_curation=resume_curation,
     )
     if checkpoint_dir:
         checkpoint_dir = Path(checkpoint_dir)
@@ -603,7 +643,7 @@ async def _run_generation_pipeline_impl(
 
     async def _save(d: Any) -> Any:
         format_type = fmt or fmt_cfg.default
-        return await asyncio.to_thread(convert_format, d, None, format_type, cfg)
+        return await asyncio.to_thread(convert_format, _serialize(d), None, format_type, cfg)
 
     async def _generate(ct: ContentType, text: str) -> Any:
         if use_async_handlers:
@@ -657,6 +697,9 @@ async def _run_generation_pipeline_impl(
                 batch_size=options.batch_size,
                 inference_batch=options.inference_batch,
                 keep_ratings=options.keep_ratings,
+                temperature=options.curation_temperature,
+                resume=options.resume_curation,
+                as_dataclass=True,
             )
         else:
             result = await asyncio.to_thread(
@@ -674,6 +717,9 @@ async def _run_generation_pipeline_impl(
                 batch_size=options.batch_size,
                 inference_batch=options.inference_batch,
                 keep_ratings=options.keep_ratings,
+                temperature=options.curation_temperature,
+                resume=options.resume_curation,
+                as_dataclass=True,
             )
 
         if dataset_builder is not None:
@@ -700,18 +746,16 @@ async def _run_generation_pipeline_impl(
         return result
 
     async def _kg_cleanup(d: Any) -> Any:
-        if dataset_builder is not None:
-            removed, cleaned = dataset_builder.cleanup_graph(
-                resolve_threshold=resolve_threshold,
-                resolve_aliases=resolve_aliases,
-                dedup_similarity=dedup_similarity,
-            )
-        else:
-            removed = kg.deduplicate_chunks(dedup_similarity)
-            cleaned = kg.clean_chunk_texts()
-            kg.resolve_entities(threshold=resolve_threshold, aliases=resolve_aliases)
+        stats = await asyncio.to_thread(
+            cleanup_knowledge_graph,
+            kg,
+            dataset_builder=dataset_builder,
+            resolve_threshold=resolve_threshold,
+            resolve_aliases=resolve_aliases,
+            dedup_similarity=dedup_similarity,
+        )
         if verbose:
-            logger.info("  KG cleanup - removed:%d cleaned:%d", removed, cleaned)
+            logger.info("  KG cleanup - removed:%d cleaned:%d", stats.removed, stats.cleaned)
         return d
 
     handlers = {
@@ -740,36 +784,50 @@ async def _run_generation_pipeline_impl(
     start_idx = 0
     if start_step and start_step in pipeline.steps:
         start_idx = pipeline.steps.index(start_step)
-    for step in pipeline.steps[start_idx:]:
-        if step in {PipelineStep.INGEST, PipelineStep.TO_KG}:
-            continue
-        if verbose:
-            logger.info("Running step %s", step.value)
-        handler = handlers.get(step)
-        if handler:
-            start = time.perf_counter()
-            try:
-                result = await handler(data)
-            except Exception as exc:
-                logger.exception("Step %s failed", step.value)
-                raise PipelineExecutionError(step, exc) from exc
-            duration = time.perf_counter() - start
-            if step.name.startswith("GENERATE"):
-                data = _validate_step_result(dataset_type, step, result)
-            else:
-                data = result
-            if options.checkpoint_dir:
-                cp_file = Path(options.checkpoint_dir) / f"{step.value}.json"
-                cp_file.write_text(json.dumps(_serialize(data)))
+
+    exec_steps = [s for s in pipeline.steps[start_idx:] if s not in {PipelineStep.INGEST, PipelineStep.TO_KG}]
+    progress = None
+    task = None
+    if verbose:
+        progress, task = create_progress("Generation pipeline", len(exec_steps))
+        progress.start()
+
+    try:
+        for step in exec_steps:
+            if step in {PipelineStep.INGEST, PipelineStep.TO_KG}:
+                continue
             if verbose:
-                logger.info("Finished %s in %.2fs", step.value, duration)
-                if isinstance(data, dict):
-                    if "qa_pairs" in data:
-                        logger.info("  Pairs: %d", len(data["qa_pairs"]))
-                    if "conversations" in data:
-                        logger.info("  Conversations: %d", len(data["conversations"]))
-                    if step is PipelineStep.CURATE and "metrics" in data:
-                        m = data["metrics"]
+                logger.info("Running step %s", step.value)
+            handler = handlers.get(step)
+            if handler:
+                start = time.perf_counter()
+                try:
+                    result = await handler(data)
+                except Exception as exc:
+                    logger.exception("Step %s failed", step.value)
+                    raise PipelineExecutionError(step, exc) from exc
+                duration = time.perf_counter() - start
+                if step.name.startswith("GENERATE"):
+                    data = _validate_step_result(dataset_type, step, result)
+                else:
+                    data = result
+                if options.checkpoint_dir:
+                    cp_file = Path(options.checkpoint_dir) / f"{step.value}.json"
+                    cp_file.write_text(json.dumps(_serialize(data)))
+                if verbose:
+                    logger.info("Finished %s in %.2fs", step.value, duration)
+                if progress:
+                    progress.update(task, advance=1)
+                if isinstance(data, dict) or is_dataclass(data):
+                    info = asdict(data) if is_dataclass(data) else data
+                    if "qa_pairs" in info:
+                        logger.info("  Pairs: %d", len(info["qa_pairs"]))
+                    if "conversations" in info:
+                        logger.info("  Conversations: %d", len(info["conversations"]))
+                    if step is PipelineStep.CURATE and "metrics" in info:
+                        m = info["metrics"]
+                        if is_dataclass(m):
+                            m = asdict(m)
                         logger.info(
                             "  Curation metrics - total:%d filtered:%d retention:%.2f avg:%.1f",
                             m.get("total", 0),
@@ -777,6 +835,9 @@ async def _run_generation_pipeline_impl(
                             m.get("retention_rate", 0.0),
                             m.get("avg_score", 0.0),
                         )
+    finally:
+        if progress:
+            progress.stop()
 
     return data
 
@@ -791,6 +852,9 @@ def run_generation_pipeline(
     inference_batch: int | None = None,
     dedup_similarity: float = 1.0,
     keep_ratings: bool = False,
+    curation_threshold: float | None = None,
+    curation_temperature: float | None = None,
+    resume_curation: bool = False,
     resolve_threshold: float = 0.8,
     resolve_aliases: dict[str, list[str]] | None = None,
     start_step: PipelineStep | None = None,
@@ -811,6 +875,12 @@ def run_generation_pipeline(
         Similarity used when removing duplicate chunks during KG cleanup.
     keep_ratings:
         Return ratings for all generated pairs after curation.
+    curation_threshold:
+        Override the quality threshold used during curation.
+    curation_temperature:
+        Override the temperature used when rating pairs during curation.
+    resume_curation:
+        Continue curation from ``checkpoint_dir`` if previous ratings exist.
     resolve_threshold:
         Similarity threshold used when merging entities during knowledge graph
         cleanup.
@@ -836,6 +906,9 @@ def run_generation_pipeline(
             inference_batch=inference_batch,
             dedup_similarity=dedup_similarity,
             keep_ratings=keep_ratings,
+            threshold=curation_threshold,
+            curation_temperature=curation_temperature,
+            resume_curation=resume_curation,
             resolve_threshold=resolve_threshold,
             resolve_aliases=resolve_aliases,
             start_step=start_step,
@@ -855,6 +928,9 @@ async def run_generation_pipeline_async(
     inference_batch: int | None = None,
     dedup_similarity: float = 1.0,
     keep_ratings: bool = False,
+    curation_threshold: float | None = None,
+    curation_temperature: float | None = None,
+    resume_curation: bool = False,
     resolve_threshold: float = 0.8,
     resolve_aliases: dict[str, list[str]] | None = None,
     start_step: PipelineStep | None = None,
@@ -871,6 +947,12 @@ async def run_generation_pipeline_async(
         Similarity used when removing duplicate chunks during KG cleanup.
     keep_ratings:
         Return ratings for all generated pairs after curation.
+    curation_threshold:
+        Override the quality threshold used during curation.
+    curation_temperature:
+        Override the temperature used when rating pairs during curation.
+    resume_curation:
+        Continue curation from ``checkpoint_dir`` if previous ratings exist.
     resolve_threshold:
         Similarity threshold used when merging entities during knowledge graph
         cleanup.
@@ -896,6 +978,9 @@ async def run_generation_pipeline_async(
         inference_batch=inference_batch,
         dedup_similarity=dedup_similarity,
         keep_ratings=keep_ratings,
+        threshold=curation_threshold,
+        curation_temperature=curation_temperature,
+        resume_curation=resume_curation,
         resolve_threshold=resolve_threshold,
         resolve_aliases=resolve_aliases,
         start_step=start_step,

--- a/tests/test_curate.py
+++ b/tests/test_curate.py
@@ -79,6 +79,52 @@ def test_curate_parse_error(monkeypatch):
         curate.curate_qa_pairs(data, batch_size=1, inference_batch=1)
 
 
+def test_curate_resume(monkeypatch, tmp_path):
+    monkeypatch.setattr(curate, "LLMClient", DummyClient)
+    monkeypatch.setattr("datacreek.utils.batch.process_batches", fake_batch)
+    monkeypatch.setattr(curate, "parse_ratings", fake_parse)
+    monkeypatch.setattr(
+        "datacreek.utils.progress.create_progress", lambda *a, **k: (DummyProgress(), 0)
+    )
+    monkeypatch.setattr(curate, "get_prompt", lambda cfg, name: "{pairs}")
+
+    existing = {
+        "summary": "",
+        "qa_pairs": [],
+        "conversations": [],
+        "metrics": {"total": 1, "filtered": 1, "retention_rate": 1.0, "avg_score": 10},
+        "rated_pairs": [{"question": "q1", "answer": "a1", "rating": 10}],
+    }
+    out = tmp_path / "cur.json"
+    out.write_text(json.dumps(existing))
+
+    data = {
+        "summary": "",
+        "qa_pairs": [
+            {"question": "q1", "answer": "a1"},
+            {"question": "q2", "answer": "a2"},
+        ],
+    }
+
+    res = curate.curate_qa_pairs(data, output_path=str(out), batch_size=1, inference_batch=1, resume=True)
+    assert len(res["qa_pairs"]) == 2
+
+
+def test_curate_as_dataclass(monkeypatch):
+    monkeypatch.setattr(curate, "LLMClient", DummyClient)
+    monkeypatch.setattr("datacreek.utils.batch.process_batches", fake_batch)
+    monkeypatch.setattr(curate, "parse_ratings", fake_parse)
+    monkeypatch.setattr(
+        "datacreek.utils.progress.create_progress", lambda *a, **k: (DummyProgress(), 0)
+    )
+    monkeypatch.setattr(curate, "get_prompt", lambda cfg, name: "{pairs}")
+
+    data = {"summary": "", "qa_pairs": [{"question": "q", "answer": "a"}]}
+
+    res = curate.curate_qa_pairs(data, batch_size=1, inference_batch=1, as_dataclass=True)
+    assert isinstance(res, curate.CurationResult)
+
+
 def test_filter_rated_pairs():
     pairs = [
         QAPair(question="q1", answer="a1", rating=9),

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -611,6 +611,22 @@ def test_pipeline_curation_error(monkeypatch):
     assert exc.value.step is PipelineStep.CURATE
 
 
+def test_pipeline_error_details(monkeypatch):
+    def bad_generate(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("datacreek.pipelines.process_file", bad_generate)
+    kg = KnowledgeGraph()
+    kg.add_document("d", source="s", text="t")
+    with pytest.raises(PipelineExecutionError) as exc:
+        run_generation_pipeline(DatasetType.QA, kg)
+
+    info = exc.value.info
+    assert info.step is PipelineStep.GENERATE_QA
+    assert info.exc_type == "RuntimeError"
+    assert "boom" in info.traceback
+
+
 def test_start_step_resume(monkeypatch):
     """Pipeline should resume from the specified step."""
 
@@ -638,7 +654,7 @@ def test_start_step_resume(monkeypatch):
 
     assert "generate" not in called
     assert called.get("curate") is True
-    assert res == {"qa_pairs": []}
+    assert isinstance(res, curate.CurationResult)
 
 
 def test_checkpoint_resume(monkeypatch, tmp_path):
@@ -673,7 +689,8 @@ def test_checkpoint_resume(monkeypatch, tmp_path):
 
     assert called["generate"] == 1
     assert called["curate"] == 2
-    assert res == {"qa_pairs": [{"question": "q", "answer": "a"}]}
+    assert isinstance(res, curate.CurationResult)
+    assert len(res.qa_pairs) == 1
 
 
 def test_kg_cleanup_step(monkeypatch):
@@ -735,3 +752,55 @@ def test_kg_cleanup_with_params(monkeypatch):
     assert called["threshold"] == 0.9
     assert called["aliases"] == {"IBM": ["International Business Machines"]}
     assert called["sim"] == 1.0
+
+
+def test_curation_threshold_param(monkeypatch):
+    """Pipeline should pass curation_threshold to curate_qa_pairs."""
+
+    received = {}
+
+    def fake_generate(*a, **k):
+        return {"qa_pairs": []}
+
+    def fake_curate(data, *a, **k):
+        # threshold is passed positionally
+        received["threshold"] = a[1] if len(a) > 1 else None
+        return {}
+
+    monkeypatch.setattr("datacreek.pipelines.process_file", fake_generate)
+    monkeypatch.setattr("datacreek.pipelines.curate_qa_pairs", fake_curate)
+    monkeypatch.setattr("datacreek.pipelines.convert_format", lambda *a, **k: {})
+
+    kg = KnowledgeGraph()
+    kg.add_document("d", source="s")
+
+    run_generation_pipeline(DatasetType.QA, kg, curation_threshold=7)
+
+    assert received["threshold"] == 7
+
+
+def test_kg_cleanup_failure(monkeypatch):
+    """Errors during KG cleanup should raise PipelineExecutionError."""
+
+    def bad_cleanup(self, *a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "datacreek.core.dataset.DatasetBuilder.cleanup_graph", bad_cleanup
+    )
+    monkeypatch.setattr("datacreek.pipelines.process_file", lambda *a, **k: {})
+    monkeypatch.setattr("datacreek.pipelines.curate_qa_pairs", lambda d, *a, **k: d)
+    monkeypatch.setattr("datacreek.pipelines.convert_format", lambda *a, **k: a[0])
+
+    kg = KnowledgeGraph()
+    kg.add_document("d", source="s")
+
+    with pytest.raises(PipelineExecutionError) as exc:
+        run_generation_pipeline(
+            DatasetType.QA,
+            kg,
+            dataset_builder=DatasetBuilder(DatasetType.QA),
+            start_step=PipelineStep.KG_CLEANUP,
+        )
+
+    assert exc.value.step is PipelineStep.KG_CLEANUP


### PR DESCRIPTION
## Summary
- add `KGCleanupStats` dataclass and cleanup helper
- refine `PipelineExecutionError` with structured info
- expose curation resume/temperature options
- provide progress reporting during generation
- document new resume workflow and error inspection
- test curation resume and error details
- add dataclass option for curation
- fix cleanup import cycle and pipeline params
- preserve dataclasses in pipeline results
- expose curation threshold as a pipeline parameter
- test KG cleanup failures

## Testing
- `pip install fastapi networkx numpy httpx requests python-dateutil pyyaml rich redis scikit-learn beautifulsoup4 fakeredis sqlalchemy neo4j unstructured pdfminer.six` *(passed)*
- `PYTHONPATH=. pytest tests/test_curate.py::test_curate_resume tests/test_curate.py::test_curate_as_dataclass tests/test_pipelines.py::test_kg_cleanup_step tests/test_pipelines.py::test_pipeline_error_details tests/test_pipelines.py::test_curation_threshold_param tests/test_pipelines.py::test_kg_cleanup_failure -q` *(passed)*

------
https://chatgpt.com/codex/tasks/task_e_6862c8b3434c832fb0d55be48d2c3818