### PR TITLE
Implement auto fractal level export

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ Below is a quick overview of the main options and operations exposed at each sta
 - `fmt` – choose the output format
 - `repo` – optionally push to a Hugging Face repo
 
+## Fractal metrics and confidence
+
+Knowledge graph utilities provide MDL-guided box covering to assign `fractal_level` annotations. QA generation records a `confidence` score computed by searching up to three hops between subject and object.
+Useful helpers:
+- `build_mdl_hierarchy` returns successive coarse graphs until the description length increases.
+- `annotate_mdl_levels` tags each node with its fractal level based on that hierarchy.
+- `fact_confidence` searches up to three hops to rate the reliability of a statement.
+- `DatasetBuilder.export_prompts(auto_fractal=True)` automatically annotates
+  nodes with fractal levels using the MDL hierarchy when none are present.
+- Generated QA pairs include a `confidence` field so downstream
+  applications can score factual reliability directly.
+
+
+
 # How does Datacreek offer it?
 
 The toolkit exposes a REST API that mirrors the main data preparation steps. All

--- a/datacreek/generators/kg_generator.py
+++ b/datacreek/generators/kg_generator.py
@@ -110,9 +110,7 @@ class KGGenerator(BaseGenerator):
                 max_tokens=max_tokens,
             ).strip()
 
-            confidence = kg.fact_confidence(
-                fact["subject"], fact["predicate"], fact["object"]
-            )
+            confidence = kg.fact_confidence(fact["subject"], fact["predicate"], fact["object"])
             answers = 2 if multi_answer else 1
             for _ in range(answers):
                 if len(qa_pairs) >= num_pairs:

--- a/datacreek/generators/kg_generator.py
+++ b/datacreek/generators/kg_generator.py
@@ -110,6 +110,9 @@ class KGGenerator(BaseGenerator):
                 max_tokens=max_tokens,
             ).strip()
 
+            confidence = kg.fact_confidence(
+                fact["subject"], fact["predicate"], fact["object"]
+            )
             answers = 2 if multi_answer else 1
             for _ in range(answers):
                 if len(qa_pairs) >= num_pairs:
@@ -121,6 +124,13 @@ class KGGenerator(BaseGenerator):
                         temperature=temperature,
                         max_tokens=max_tokens,
                     ).strip()
-                qa_pairs.append(QAPair(question=question, answer=answer, facts=[fid]))
+                qa_pairs.append(
+                    QAPair(
+                        question=question,
+                        answer=answer,
+                        facts=[fid],
+                        confidence=confidence,
+                    )
+                )
 
         return {"qa_pairs": [p.to_dict() for p in qa_pairs]}

--- a/datacreek/models/qa.py
+++ b/datacreek/models/qa.py
@@ -9,6 +9,7 @@ class QAPair:
     question: str
     answer: str
     rating: Optional[float] = None
+    confidence: Optional[float] = None
     chunk: Optional[str] = None
     source: Optional[str] = None
     facts: Optional[list[str]] = None
@@ -17,6 +18,8 @@ class QAPair:
         data = {"question": self.question, "answer": self.answer}
         if self.rating is not None:
             data["rating"] = self.rating
+        if self.confidence is not None:
+            data["confidence"] = self.confidence
         if self.chunk is not None:
             data["chunk"] = self.chunk
         if self.source is not None:

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -927,6 +927,17 @@ def test_compute_fractal_features_and_export():
     assert any(e.operation == "export_prompts" for e in ds.events)
 
 
+def test_export_prompts_auto_fractal():
+    ds = DatasetBuilder(DatasetType.TEXT)
+    ds.add_document("d", source="s")
+    ds.add_chunk("d", "c1", "hello")
+    ds.add_chunk("d", "c2", "world")
+    records = ds.export_prompts(auto_fractal=True, radii=[1], max_levels=1)
+    levels = {r["fractal_level"] for r in records}
+    assert levels == {1}
+    assert any(e.operation == "annotate_mdl_levels" for e in ds.events)
+
+
 def test_dimension_distortion_wrapper():
     ds = DatasetBuilder(DatasetType.TEXT)
     ds.add_document("d", source="s")
@@ -989,6 +1000,17 @@ def test_annotate_fractal_levels_wrapper():
     assert ds.graph.graph.nodes["c1"].get("fractal_level")
     assert ds.graph.graph.nodes["c2"].get("fractal_level")
     assert any(e.operation == "annotate_fractal_levels" for e in ds.events)
+
+
+def test_annotate_mdl_levels_wrapper():
+    ds = DatasetBuilder(DatasetType.TEXT)
+    ds.add_document("d", source="s")
+    ds.add_chunk("d", "c1", "hello")
+    ds.add_chunk("d", "c2", "world")
+    ds.annotate_mdl_levels([1, 2], max_levels=2)
+    assert ds.graph.graph.nodes["c1"].get("fractal_level")
+    assert ds.graph.graph.nodes["c2"].get("fractal_level")
+    assert any(e.operation == "annotate_mdl_levels" for e in ds.events)
 
 
 def test_optimize_topology_wrapper():

--- a/tests/test_kg_generator.py
+++ b/tests/test_kg_generator.py
@@ -46,3 +46,13 @@ def test_kg_generator_select_limit():
     gen = KGGenerator(DummyClient())
     res = gen.process_graph(kg, num_pairs=2)
     assert len(res["qa_pairs"]) == 2
+
+
+def test_kg_generator_confidence():
+    kg = KnowledgeGraph()
+    fid = kg.add_fact("A", "related", "B")
+    gen = KGGenerator(DummyClient())
+    res = gen.process_graph(kg, num_pairs=1)
+    pair = res["qa_pairs"][0]
+    assert pair["facts"] == [fid]
+    assert "confidence" in pair

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -960,6 +960,28 @@ def test_find_facts():
     assert set(kg.find_facts(subject="A", predicate="likes")) == {"f1", "f2"}
 
 
+def test_fact_confidence_short_path():
+    kg = KnowledgeGraph()
+    kg.add_fact("X", "related", "Y")
+    conf = kg.fact_confidence("X", "related", "Y")
+    assert conf == 1.0
+
+    kg.add_entity("Z", "Z")
+    kg.graph.add_edge("Y", "Z", relation="other")
+    conf2 = kg.fact_confidence("X", "related", "Z", max_hops=3)
+    assert conf2 < 0.5
+
+
+def test_annotate_mdl_levels_method():
+    kg = KnowledgeGraph()
+    kg.add_document("d", source="s")
+    kg.add_chunk("d", "c1", "hello")
+    kg.add_chunk("d", "c2", "world")
+    kg.annotate_mdl_levels([1, 2], max_levels=2)
+    assert kg.graph.nodes["c1"].get("fractal_level")
+    assert kg.graph.nodes["c2"].get("fractal_level")
+
+
 def test_entity_lookup_helpers():
     kg = KnowledgeGraph()
     kg.add_document("doc", source="s")


### PR DESCRIPTION
## Summary
- export prompts optionally annotates fractal levels via MDL hierarchy
- document auto-fractal export helper in README
- test automatic fractal annotation on export
- clarify README about confidence field in QA pairs

## Testing
- `PYTHONPATH=. pytest tests/test_dataset_builder.py::test_export_prompts_auto_fractal -q`
- `PYTHONPATH=. pytest tests/test_dataset_builder.py::test_annotate_mdl_levels_wrapper tests/test_knowledge_graph.py::test_fact_confidence_short_path tests/test_knowledge_graph.py::test_annotate_mdl_levels_method tests/test_kg_generator.py::test_kg_generator_confidence tests/test_fractal_dimension.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686ce83674b8832fb056b6d679a90ff4