### PR TITLE
Implement template validation and coverage metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,6 +773,31 @@ npm run dev  # start the Vite dev server
 Point your browser to `http://localhost:5173` while the Flask API runs on
 `http://localhost:8000`.
 
+## SaaS Pipeline Logic
+
+The service orchestrates several stages to turn raw content into fine‑tuning
+records.
+
+1. **Template selection** – `get_template()` loads a prompt template definition
+   with schema constraints and maximum length. Responses are validated with
+   `validate_output()` before being accepted.
+2. **Hybrid search** – `search_with_links()` combines lexical lookup with
+   embedding neighbors. The optional `fractal_level` parameter restricts
+   traversal depth for coarse or fine context.
+3. **Graph‑to‑text encoding** – `neighborhood_to_sentence()` transforms graph
+   paths into sentences, recursively summarizing neighbors for richer prompts.
+4. **Self‑Instruct generation** – `generate_with_self_instruct()` repeatedly
+   queries the LLM until the template validation succeeds. Tool call examples can
+   be inserted via `auto_tool_calls()`.
+5. **Fact verification** – `verify_statements()` checks generated triples against
+   the knowledge graph using shortest paths to assign a confidence score.
+6. **Diversification** – `select_diverse_nodes()` picks nodes that maximize the
+   `diversification_score()` ensuring coverage of new graph regions.
+7. **Prompt export** – `export_prompts()` attaches a MD5 `signature_hash` of the
+   topological signature and a `prompt_hash` so duplicates can be detected. User
+   feedback can be recorded with `record_feedback()` for continuous
+   improvements. Edge traversal is tracked for statistics via `coverage_stats()`.
+
 ## License
 
 Read more about the [License](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -793,10 +793,11 @@ records.
    the knowledge graph using shortest paths to assign a confidence score.
 6. **Diversification** – `select_diverse_nodes()` picks nodes that maximize the
    `diversification_score()` ensuring coverage of new graph regions.
-7. **Prompt export** – `export_prompts()` attaches a MD5 `signature_hash` of the
-   topological signature and a `prompt_hash` so duplicates can be detected. User
-   feedback can be recorded with `record_feedback()` for continuous
-   improvements. Edge traversal is tracked for statistics via `coverage_stats()`.
+7. **Prompt export & coverage** – `export_prompts()` attaches a MD5
+   `signature_hash` of the topological signature and a `prompt_hash` so
+   duplicates can be detected. Edge traversal is recorded so
+   `coverage_stats()` can report how much of the graph has been explored. User
+   feedback is stored via `record_feedback()` for continuous improvements.
 
 ## License
 

--- a/datacreek/__init__.py
+++ b/datacreek/__init__.py
@@ -421,10 +421,9 @@ def __getattr__(name: str):
 
         return _DB.coverage_stats
     if name == "get_template" or name == "PromptTemplate" or name == "validate_output":
-        from .templates.library import (
-            get_template as _gtmpl,
-            PromptTemplate as _PT,
-            validate_output as _vo,
-        )
+        from .templates.library import PromptTemplate as _PT
+        from .templates.library import get_template as _gtmpl
+        from .templates.library import validate_output as _vo
+
         return {"get_template": _gtmpl, "PromptTemplate": _PT, "validate_output": _vo}[name]
     raise AttributeError(name)

--- a/datacreek/__init__.py
+++ b/datacreek/__init__.py
@@ -78,6 +78,11 @@ __all__: list[str] = [
     "fractalize_optimal",
     "build_fractal_hierarchy",
     "build_mdl_hierarchy",
+    "PromptTemplate",
+    "get_template",
+    "validate_output",
+    "betti_number",
+    "coverage_stats",
 ]
 
 if TYPE_CHECKING:  # pragma: no cover - used for type checking only
@@ -407,4 +412,19 @@ def __getattr__(name: str):
         from .utils.graph_text import graph_to_text as _gt
 
         return _gt
+    if name == "betti_number":
+        from .core.knowledge_graph import KnowledgeGraph as _KG
+
+        return _KG.betti_number
+    if name == "coverage_stats":
+        from .core.dataset import DatasetBuilder as _DB
+
+        return _DB.coverage_stats
+    if name == "get_template" or name == "PromptTemplate" or name == "validate_output":
+        from .templates.library import (
+            get_template as _gtmpl,
+            PromptTemplate as _PT,
+            validate_output as _vo,
+        )
+        return {"get_template": _gtmpl, "PromptTemplate": _PT, "validate_output": _vo}[name]
     raise AttributeError(name)

--- a/datacreek/analysis/fractal.py
+++ b/datacreek/analysis/fractal.py
@@ -1,6 +1,6 @@
 import math
 import random
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple, Optional
 
 try:  # optional dependency
     import gudhi as gd

--- a/datacreek/analysis/fractal.py
+++ b/datacreek/analysis/fractal.py
@@ -1,6 +1,6 @@
 import math
 import random
-from typing import Any, Dict, Iterable, List, Tuple, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 try:  # optional dependency
     import gudhi as gd

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -1162,7 +1162,12 @@ class DatasetBuilder:
         return selected
 
     def sample_diverse_chunks(self, count: int, radii: Iterable[int]) -> list[str]:
-        """Return ``count`` chunk IDs maximizing diversification."""
+        """Return ``count`` chunk IDs that best cover unexplored graph regions.
+
+        The helper computes diversification scores using ``radii`` and
+        returns chunk IDs that maximize the score so subsequent prompts
+        sample from novel subgraphs.
+        """
 
         candidates = [n for n, d in self.graph.graph.nodes(data=True) if d.get("type") == "chunk"]
         selected = self.select_diverse_nodes(candidates, count, radii)
@@ -1619,7 +1624,13 @@ class DatasetBuilder:
             self.edge_usage[key] = self.edge_usage.get(key, 0) + 1
 
     def coverage_stats(self) -> Dict[str, float]:
-        """Return coverage statistics based on traversed edges."""
+        """Return coverage statistics based on traversed edges.
+
+        ``edge_coverage`` measures the ratio of unique edges encountered during
+        generation versus the total number present in the graph. ``betti_coverage``
+        applies the Betti-1 formula on the subgraph induced by those edges to
+        indicate how much of the global cycle structure was explored.
+        """
 
         total = self.graph.graph.number_of_edges()
         used_pairs = {tuple(k.split("->", 1)) for k in self.edge_usage}

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import hashlib
+import json
 import logging
 import os
 import re
@@ -1161,16 +1161,10 @@ class DatasetBuilder:
         )
         return selected
 
-    def sample_diverse_chunks(
-        self, count: int, radii: Iterable[int]
-    ) -> list[str]:
+    def sample_diverse_chunks(self, count: int, radii: Iterable[int]) -> list[str]:
         """Return ``count`` chunk IDs maximizing diversification."""
 
-        candidates = [
-            n
-            for n, d in self.graph.graph.nodes(data=True)
-            if d.get("type") == "chunk"
-        ]
+        candidates = [n for n, d in self.graph.graph.nodes(data=True) if d.get("type") == "chunk"]
         selected = self.select_diverse_nodes(candidates, count, radii)
         self._record_event(
             "sample_diverse_chunks",
@@ -1555,7 +1549,11 @@ class DatasetBuilder:
     def record_feedback(self, record_id: str, comment: str) -> None:
         """Store user feedback linked to a dataset record."""
 
-        entry = {"record_id": record_id, "comment": comment, "time": datetime.now(timezone.utc).isoformat()}
+        entry = {
+            "record_id": record_id,
+            "comment": comment,
+            "time": datetime.now(timezone.utc).isoformat(),
+        }
         self.feedback.append(entry)
         self._record_event("record_feedback", "Feedback recorded", record_id=record_id)
 
@@ -1585,9 +1583,7 @@ class DatasetBuilder:
         from ..utils.fact_extraction import extract_facts
 
         facts = extract_facts(answer)
-        triples = [
-            (f["subject"], f["predicate"], f["object"]) for f in facts
-        ]
+        triples = [(f["subject"], f["predicate"], f["object"]) for f in facts]
         score = self.verify_statements(triples, max_hops=max_hops) if triples else 0.0
         self._record_event(
             "verify_answer",
@@ -1597,9 +1593,7 @@ class DatasetBuilder:
         )
         return score
 
-    def verify_qa_pairs(
-        self, pairs: Iterable["QAPair"], *, max_hops: int = 3
-    ) -> list["QAPair"]:
+    def verify_qa_pairs(self, pairs: Iterable["QAPair"], *, max_hops: int = 3) -> list["QAPair"]:
         """Annotate ``pairs`` with a confidence score using graph verification."""
 
         from datacreek.models.qa import QAPair
@@ -1638,9 +1632,7 @@ class DatasetBuilder:
             + nx.number_connected_components(self.graph.graph)
         )
         betti_sub = (
-            sub.number_of_edges()
-            - sub.number_of_nodes()
-            + nx.number_connected_components(sub)
+            sub.number_of_edges() - sub.number_of_nodes() + nx.number_connected_components(sub)
         )
         edge_cov = len(used_pairs) / total if total else 0.0
         betti_cov = betti_sub / betti_total if betti_total else 0.0
@@ -2611,8 +2603,8 @@ class DatasetBuilder:
 
         if self.dataset_type == DatasetType.QA:
             try:
-                from datacreek.models.results import CurationResult, QAGenerationResult
                 from datacreek.models.qa import QAPair
+                from datacreek.models.results import CurationResult, QAGenerationResult
 
                 if isinstance(result, CurationResult):
                     result.qa_pairs = self.verify_qa_pairs(result.qa_pairs)
@@ -2621,9 +2613,7 @@ class DatasetBuilder:
                 elif isinstance(result, QAGenerationResult):
                     result.qa_pairs = self.verify_qa_pairs(result.qa_pairs)
                 elif isinstance(result, dict) and "qa_pairs" in result:
-                    pairs = [
-                        QAPair(**p) if isinstance(p, dict) else p for p in result["qa_pairs"]
-                    ]
+                    pairs = [QAPair(**p) if isinstance(p, dict) else p for p in result["qa_pairs"]]
                     verified = self.verify_qa_pairs(pairs)
                     result["qa_pairs"] = [p.to_dict() for p in verified]
             except Exception:

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import hashlib
 import logging
 import os
 import re
@@ -66,6 +67,9 @@ class DatasetBuilder:
     owner_id: int | None = None
     history: List[str] = field(default_factory=list)
     events: List[HistoryEvent] = field(default_factory=list)
+    feedback: List[Dict[str, Any]] = field(default_factory=list)
+    # track how often specific edges are traversed during generation
+    edge_usage: Dict[str, int] = field(default_factory=dict)
     versions: List[Dict[str, Any]] = field(default_factory=list)
     ingested_docs: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     accessed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
@@ -482,18 +486,30 @@ class DatasetBuilder:
             node_type=node_type,
         )
 
-    def search_with_links(self, query: str, k: int = 5, hops: int = 1) -> list[str]:
+    def search_with_links(
+        self, query: str, k: int = 5, hops: int = 1, *, fractal_level: int | None = None
+    ) -> list[str]:
         """Wrapper for :meth:`KnowledgeGraph.search_with_links`."""
 
-        return self.graph.search_with_links(query, k=k, hops=hops)
+        return self.graph.search_with_links(query, k=k, hops=hops, fractal_level=fractal_level)
 
-    def search_with_links_data(self, query: str, k: int = 5, hops: int = 1) -> List[Dict[str, Any]]:
+    def search_with_links_data(
+        self, query: str, k: int = 5, hops: int = 1, *, fractal_level: int | None = None
+    ) -> List[Dict[str, Any]]:
         """Wrapper for :meth:`KnowledgeGraph.search_with_links_data`.
 
         Returns detailed chunk information, hop depth and traversal path.
         """
 
-        return self.graph.search_with_links_data(query, k=k, hops=hops)
+        results = self.graph.search_with_links_data(
+            query, k=k, hops=hops, fractal_level=fractal_level
+        )
+        for item in results:
+            path = item.get("path")
+            if not path:
+                continue
+            self._update_edge_usage(path)
+        return results
 
     def link_similar_chunks(self, k: int = 3) -> None:
         """Create similarity edges between chunks using embeddings."""
@@ -1131,6 +1147,39 @@ class DatasetBuilder:
         )
         return val
 
+    def select_diverse_nodes(
+        self, candidates: Iterable[str], count: int, radii: Iterable[int]
+    ) -> list[str]:
+        """Wrapper for :meth:`KnowledgeGraph.select_diverse_nodes`."""
+
+        selected = self.graph.select_diverse_nodes(candidates, count, radii)
+        self._record_event(
+            "select_diverse_nodes",
+            "Diversification filter applied",
+            count=count,
+            selected=selected,
+        )
+        return selected
+
+    def sample_diverse_chunks(
+        self, count: int, radii: Iterable[int]
+    ) -> list[str]:
+        """Return ``count`` chunk IDs maximizing diversification."""
+
+        candidates = [
+            n
+            for n, d in self.graph.graph.nodes(data=True)
+            if d.get("type") == "chunk"
+        ]
+        selected = self.select_diverse_nodes(candidates, count, radii)
+        self._record_event(
+            "sample_diverse_chunks",
+            "Diverse chunks selected",
+            count=count,
+            selected=selected,
+        )
+        return selected
+
     def hyperbolic_neighbors(self, node_id: str, k: int = 5) -> List[tuple[str, float]]:
         """Wrapper for :meth:`KnowledgeGraph.hyperbolic_neighbors`."""
 
@@ -1502,6 +1551,106 @@ class DatasetBuilder:
             chosen_radius=radius,
         )
         return coarse, mapping, radius
+
+    def record_feedback(self, record_id: str, comment: str) -> None:
+        """Store user feedback linked to a dataset record."""
+
+        entry = {"record_id": record_id, "comment": comment, "time": datetime.now(timezone.utc).isoformat()}
+        self.feedback.append(entry)
+        self._record_event("record_feedback", "Feedback recorded", record_id=record_id)
+
+    def verify_statements(
+        self, statements: Iterable[tuple[str, str, str]], *, max_hops: int = 3
+    ) -> float:
+        """Wrapper for :meth:`KnowledgeGraph.verify_statements`."""
+
+        stmts = list(statements)
+        score = self.graph.verify_statements(stmts, max_hops=max_hops)
+        self._record_event(
+            "verify_statements",
+            "Statements verified",
+            count=len(stmts),
+            score=score,
+        )
+        return score
+
+    def verify_answer(self, answer: str, *, max_hops: int = 3) -> float:
+        """Return confidence score for ``answer`` based on graph facts.
+
+        The text is parsed with :func:`extract_facts` to obtain triples which are
+        then passed to :meth:`verify_statements`. The average confidence is
+        returned and also recorded in the dataset history.
+        """
+
+        from ..utils.fact_extraction import extract_facts
+
+        facts = extract_facts(answer)
+        triples = [
+            (f["subject"], f["predicate"], f["object"]) for f in facts
+        ]
+        score = self.verify_statements(triples, max_hops=max_hops) if triples else 0.0
+        self._record_event(
+            "verify_answer",
+            "Answer verified",
+            score=score,
+            facts=len(triples),
+        )
+        return score
+
+    def verify_qa_pairs(
+        self, pairs: Iterable["QAPair"], *, max_hops: int = 3
+    ) -> list["QAPair"]:
+        """Annotate ``pairs`` with a confidence score using graph verification."""
+
+        from datacreek.models.qa import QAPair
+
+        verified: list[QAPair] = []
+        for p in pairs:
+            score = self.verify_answer(p.answer, max_hops=max_hops)
+            p.confidence = score
+            verified.append(p)
+        self._record_event(
+            "verify_qa_pairs",
+            "QA pairs verified",
+            count=len(verified),
+        )
+        return verified
+
+    def _update_edge_usage(self, path: Iterable[str]) -> None:
+        """Increment counters for edges appearing in ``path``."""
+
+        nodes = list(path)
+        for u, v in zip(nodes[:-1], nodes[1:]):
+            key = f"{u}->{v}"
+            self.edge_usage[key] = self.edge_usage.get(key, 0) + 1
+
+    def coverage_stats(self) -> Dict[str, float]:
+        """Return coverage statistics based on traversed edges."""
+
+        total = self.graph.graph.number_of_edges()
+        used_pairs = {tuple(k.split("->", 1)) for k in self.edge_usage}
+        sub = nx.Graph()
+        sub.add_nodes_from(self.graph.graph.nodes())
+        sub.add_edges_from(used_pairs)
+        betti_total = (
+            self.graph.graph.number_of_edges()
+            - self.graph.graph.number_of_nodes()
+            + nx.number_connected_components(self.graph.graph)
+        )
+        betti_sub = (
+            sub.number_of_edges()
+            - sub.number_of_nodes()
+            + nx.number_connected_components(sub)
+        )
+        edge_cov = len(used_pairs) / total if total else 0.0
+        betti_cov = betti_sub / betti_total if betti_total else 0.0
+        self._record_event(
+            "coverage_stats",
+            "Coverage computed",
+            edge_coverage=edge_cov,
+            betti_coverage=betti_cov,
+        )
+        return {"edge_coverage": edge_cov, "betti_coverage": betti_cov}
 
     def build_fractal_hierarchy(
         self, radii: Iterable[int], *, max_levels: int = 5
@@ -2460,6 +2609,26 @@ class DatasetBuilder:
                 redis_client=redis_client,
             )
 
+        if self.dataset_type == DatasetType.QA:
+            try:
+                from datacreek.models.results import CurationResult, QAGenerationResult
+                from datacreek.models.qa import QAPair
+
+                if isinstance(result, CurationResult):
+                    result.qa_pairs = self.verify_qa_pairs(result.qa_pairs)
+                    if result.rated_pairs:
+                        result.rated_pairs = self.verify_qa_pairs(result.rated_pairs)
+                elif isinstance(result, QAGenerationResult):
+                    result.qa_pairs = self.verify_qa_pairs(result.qa_pairs)
+                elif isinstance(result, dict) and "qa_pairs" in result:
+                    pairs = [
+                        QAPair(**p) if isinstance(p, dict) else p for p in result["qa_pairs"]
+                    ]
+                    verified = self.verify_qa_pairs(pairs)
+                    result["qa_pairs"] = [p.to_dict() for p in verified]
+            except Exception:
+                logger.exception("Failed to verify QA pairs")
+
         params = {
             "provider": provider,
             "profile": profile,
@@ -2536,15 +2705,19 @@ class DatasetBuilder:
             self.annotate_mdl_levels(radii, max_levels=max_levels)
 
         signature = self.graph.topological_signature(max_dim=1)
+        sig_hash = hashlib.md5(json.dumps(signature, sort_keys=True).encode()).hexdigest()
         data: List[Dict[str, Any]] = []
         for node, attrs in self.graph.graph.nodes(data=True):
             if attrs.get("type") != "chunk":
                 continue
+            prompt_text = attrs.get("text", "")
             record = {
-                "prompt": attrs.get("text", ""),
+                "prompt": prompt_text,
                 "fractal_level": attrs.get("fractal_level"),
                 "perception_id": attrs.get("perception_id"),
                 "topo_signature": signature,
+                "signature_hash": sig_hash,
+                "prompt_hash": hashlib.md5(prompt_text.encode()).hexdigest(),
             }
             data.append(record)
         self._record_event("export_prompts", "Prompt data exported")

--- a/datacreek/core/knowledge_graph.py
+++ b/datacreek/core/knowledge_graph.py
@@ -715,7 +715,9 @@ class KnowledgeGraph:
 
         seeds = self.search_hybrid(query, k)
         if fractal_level is not None:
-            seeds = [s for s in seeds if self.graph.nodes[s].get("fractal_level", 0) <= fractal_level]
+            seeds = [
+                s for s in seeds if self.graph.nodes[s].get("fractal_level", 0) <= fractal_level
+            ]
         seen = set(seeds)
         results = list(seeds)
         queue = [(cid, 0) for cid in seeds]
@@ -736,7 +738,10 @@ class KnowledgeGraph:
                     continue
                 if neighbor in seen:
                     continue
-                if fractal_level is not None and self.graph.nodes[neighbor].get("fractal_level", 0) > fractal_level:
+                if (
+                    fractal_level is not None
+                    and self.graph.nodes[neighbor].get("fractal_level", 0) > fractal_level
+                ):
                     continue
                 seen.add(neighbor)
                 results.append(neighbor)
@@ -761,7 +766,9 @@ class KnowledgeGraph:
 
         seeds = self.search_hybrid(query, k)
         if fractal_level is not None:
-            seeds = [s for s in seeds if self.graph.nodes[s].get("fractal_level", 0) <= fractal_level]
+            seeds = [
+                s for s in seeds if self.graph.nodes[s].get("fractal_level", 0) <= fractal_level
+            ]
         seen = set(seeds)
         queue: List[tuple[str, int, List[str]]] = [(cid, 0, [cid]) for cid in seeds]
         results: List[tuple[str, int, List[str]]] = queue.copy()
@@ -776,7 +783,10 @@ class KnowledgeGraph:
                     continue
                 if nb in seen:
                     continue
-                if fractal_level is not None and self.graph.nodes[nb].get("fractal_level", 0) > fractal_level:
+                if (
+                    fractal_level is not None
+                    and self.graph.nodes[nb].get("fractal_level", 0) > fractal_level
+                ):
                     continue
                 seen.add(nb)
                 new_path = path + [nb]
@@ -3265,10 +3275,7 @@ class KnowledgeGraph:
         confidence score. ``0.0`` is returned when no statements are supplied.
         """
 
-        scores = [
-            self.fact_confidence(s, p, o, max_hops=max_hops)
-            for s, p, o in statements
-        ]
+        scores = [self.fact_confidence(s, p, o, max_hops=max_hops) for s, p, o in statements]
         return float(sum(scores) / len(scores)) if scores else 0.0
 
     def to_dict(self) -> Dict[str, Any]:

--- a/datacreek/core/knowledge_graph.py
+++ b/datacreek/core/knowledge_graph.py
@@ -692,7 +692,14 @@ class KnowledgeGraph:
             records = session.run(cypher, ids=ids)
             return [dict(r) for r in records]
 
-    def search_with_links(self, query: str, k: int = 5, hops: int = 1) -> list[str]:
+    def search_with_links(
+        self,
+        query: str,
+        k: int = 5,
+        hops: int = 1,
+        *,
+        fractal_level: int | None = None,
+    ) -> list[str]:
         """Return chunk IDs related to a query and expand via graph links.
 
         Parameters
@@ -707,6 +714,8 @@ class KnowledgeGraph:
         """
 
         seeds = self.search_hybrid(query, k)
+        if fractal_level is not None:
+            seeds = [s for s in seeds if self.graph.nodes[s].get("fractal_level", 0) <= fractal_level]
         seen = set(seeds)
         results = list(seeds)
         queue = [(cid, 0) for cid in seeds]
@@ -727,13 +736,22 @@ class KnowledgeGraph:
                     continue
                 if neighbor in seen:
                     continue
+                if fractal_level is not None and self.graph.nodes[neighbor].get("fractal_level", 0) > fractal_level:
+                    continue
                 seen.add(neighbor)
                 results.append(neighbor)
                 queue.append((neighbor, depth + 1))
 
         return results
 
-    def search_with_links_data(self, query: str, k: int = 5, hops: int = 1) -> List[Dict[str, Any]]:
+    def search_with_links_data(
+        self,
+        query: str,
+        k: int = 5,
+        hops: int = 1,
+        *,
+        fractal_level: int | None = None,
+    ) -> List[Dict[str, Any]]:
         """Return enriched search results expanding through graph links.
 
         Each item contains the chunk ``id``, its ``text``, owning ``document``
@@ -742,6 +760,8 @@ class KnowledgeGraph:
         """
 
         seeds = self.search_hybrid(query, k)
+        if fractal_level is not None:
+            seeds = [s for s in seeds if self.graph.nodes[s].get("fractal_level", 0) <= fractal_level]
         seen = set(seeds)
         queue: List[tuple[str, int, List[str]]] = [(cid, 0, [cid]) for cid in seeds]
         results: List[tuple[str, int, List[str]]] = queue.copy()
@@ -755,6 +775,8 @@ class KnowledgeGraph:
                 if not rel or rel.get("relation") not in {"next_chunk", "similar_to"}:
                     continue
                 if nb in seen:
+                    continue
+                if fractal_level is not None and self.graph.nodes[nb].get("fractal_level", 0) > fractal_level:
                     continue
                 seen.add(nb)
                 new_path = path + [nb]
@@ -2097,6 +2119,27 @@ class KnowledgeGraph:
             "entropy": entropies,
         }
 
+    def betti_number(self, dimension: int = 1) -> int:
+        """Return Betti number of ``dimension`` for the graph."""
+
+        if dimension == 0:
+            return nx.number_connected_components(self.graph)
+        if dimension == 1:
+            return (
+                self.graph.number_of_edges()
+                - self.graph.number_of_nodes()
+                + nx.number_connected_components(self.graph)
+            )
+        # fallback to persistence diagrams for higher dimensions
+        try:
+            diags = self.persistence_diagrams(max_dim=dimension)
+            diag = diags.get(dimension)
+        except Exception:
+            diag = None
+        if diag is None:
+            return 0
+        return int(sum(np.isinf(diag[:, 1]) == False))
+
     def compute_fractal_features(self, radii: Iterable[int], *, max_dim: int = 1) -> Dict[str, Any]:
         """Return fractal dimension, optimal radius and topological signature."""
 
@@ -2149,6 +2192,21 @@ class KnowledgeGraph:
             max_dim=max_dim,
             dimension=dimension,
         )
+
+    def select_diverse_nodes(
+        self, candidates: Iterable[str], count: int, radii: Iterable[int]
+    ) -> list[str]:
+        """Return ``count`` nodes maximizing the diversification score."""
+
+        chosen: list[str] = []
+        for cand in candidates:
+            if len(chosen) >= count:
+                break
+            new_set = chosen + [cand]
+            score = self.diversification_score(new_set, radii)
+            if not chosen or score > self.diversification_score(chosen, radii):
+                chosen.append(cand)
+        return chosen
 
     def hyperbolic_neighbors(self, node_id: str, k: int = 5) -> List[tuple[str, float]]:
         """Return ``k`` nearest neighbors in hyperbolic space."""
@@ -3196,6 +3254,22 @@ class KnowledgeGraph:
             return 0.4
 
         return 0.4 if length <= max_hops else 0.0
+
+    def verify_statements(
+        self, statements: Iterable[tuple[str, str, str]], *, max_hops: int = 3
+    ) -> float:
+        """Return average confidence over ``statements``.
+
+        Each statement is a ``(subject, predicate, object)`` triple. The method
+        calls :meth:`fact_confidence` for every triple and returns the mean
+        confidence score. ``0.0`` is returned when no statements are supplied.
+        """
+
+        scores = [
+            self.fact_confidence(s, p, o, max_hops=max_hops)
+            for s, p, o in statements
+        ]
+        return float(sum(scores) / len(scores)) if scores else 0.0
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize the graph to a dictionary."""

--- a/datacreek/templates/__init__.py
+++ b/datacreek/templates/__init__.py
@@ -1,0 +1,1 @@
+from .library import PromptTemplate, get_template, validate_output

--- a/datacreek/templates/library.py
+++ b/datacreek/templates/library.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 """Prompt template library with validation utilities."""
 
-from dataclasses import dataclass
-from pathlib import Path
 import json
 import re
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, Optional
 
 import jsonschema
 
 # Template definitions live under ``specs/`` to avoid gitignore "data/" rules
 TEMPLATE_DIR = Path(__file__).resolve().parent / "specs"
+
 
 @dataclass
 class PromptTemplate:

--- a/datacreek/templates/library.py
+++ b/datacreek/templates/library.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Prompt template library with validation utilities."""
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import re
+from typing import Dict, Optional
+
+import jsonschema
+
+# Template definitions live under ``specs/`` to avoid gitignore "data/" rules
+TEMPLATE_DIR = Path(__file__).resolve().parent / "specs"
+
+@dataclass
+class PromptTemplate:
+    """Metadata describing a prompt/response format."""
+
+    name: str
+    schema: dict
+    max_length: int
+    regex: str
+
+    def validate(self, output: str) -> bool:
+        """Return ``True`` if ``output`` respects length and regex constraints."""
+        if len(output) > self.max_length:
+            return False
+        if self.regex and not re.fullmatch(self.regex, output.strip(), re.DOTALL):
+            return False
+        try:
+            jsonschema.validate(json.loads(output), self.schema)
+        except Exception:
+            return False
+        return True
+
+
+def load_templates() -> Dict[str, PromptTemplate]:
+    """Load templates from the ``data`` directory."""
+    templates: Dict[str, PromptTemplate] = {}
+    if not TEMPLATE_DIR.exists():
+        return templates
+    for path in TEMPLATE_DIR.glob("*.json"):
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        tmpl = PromptTemplate(
+            name=path.stem,
+            schema=data.get("schema", {}),
+            max_length=int(data.get("max_length", 4096)),
+            regex=data.get("regex", r".*"),
+        )
+        templates[tmpl.name] = tmpl
+    return templates
+
+
+TEMPLATES = load_templates()
+
+
+def get_template(name: str) -> PromptTemplate:
+    """Return template by ``name``."""
+    if name not in TEMPLATES:
+        raise KeyError(f"Unknown template: {name}")
+    return TEMPLATES[name]
+
+
+def validate_output(template_name: str, text: str) -> bool:
+    """Validate ``text`` using template constraints."""
+    tmpl = get_template(template_name)
+    return tmpl.validate(text)

--- a/datacreek/templates/specs/alpaca.json
+++ b/datacreek/templates/specs/alpaca.json
@@ -1,0 +1,13 @@
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "instruction": {"type": "string"},
+      "input": {"type": "string"},
+      "output": {"type": "string"}
+    },
+    "required": ["instruction", "output"]
+  },
+  "max_length": 4096,
+  "regex": "(?s)\\{.*\\}"
+}

--- a/datacreek/templates/specs/chatml.json
+++ b/datacreek/templates/specs/chatml.json
@@ -1,0 +1,12 @@
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "prompt": {"type": "string"},
+      "completion": {"type": "string"}
+    },
+    "required": ["prompt", "completion"]
+  },
+  "max_length": 4096,
+  "regex": "(?s)\\{.*\\}"
+}

--- a/datacreek/templates/specs/qa.json
+++ b/datacreek/templates/specs/qa.json
@@ -1,0 +1,12 @@
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "question": {"type": "string"},
+      "answer": {"type": "string"}
+    },
+    "required": ["question", "answer"]
+  },
+  "max_length": 1024,
+  "regex": "(?s)\\{.*\\}"
+}

--- a/datacreek/utils/__init__.py
+++ b/datacreek/utils/__init__.py
@@ -26,7 +26,7 @@ from .llm_processing import (
 from .progress import create_progress, progress_context
 from .redis_helpers import decode_hash
 from .text import clean_text, extract_json_from_text, normalize_units, split_into_chunks
-from .toolformer import insert_tool_calls
+from .toolformer import execute_tool_calls, insert_tool_calls
 
 
 def __getattr__(name: str):
@@ -74,4 +74,5 @@ __all__ = [
     "subgraph_to_text",
     "graph_to_text",
     "insert_tool_calls",
+    "execute_tool_calls",
 ]

--- a/datacreek/utils/self_instruct.py
+++ b/datacreek/utils/self_instruct.py
@@ -1,0 +1,59 @@
+"""Simple helpers implementing a Self-Instruct style loop."""
+from __future__ import annotations
+
+import logging
+import json
+from typing import Callable, Iterable
+
+from .llm_processing import parse_qa_pairs
+from ..templates.library import validate_output
+
+logger = logging.getLogger(__name__)
+
+
+def generate_with_self_instruct(
+    llm_call: Callable[[str], str],
+    instruction: str,
+    *,
+    template: str,
+    retries: int = 3,
+) -> str:
+    """Generate text repeatedly until it validates against ``template``.
+
+    The helper queries ``llm_call`` with ``instruction``. If the raw output
+    fails validation it falls back to ``parse_qa_pairs`` to reformat the text and
+    tries validating again. Up to ``retries`` attempts are made before raising an
+    error.
+    """
+
+    for attempt in range(retries):
+        raw = llm_call(instruction)
+        if validate_output(template, raw):
+            return raw
+        pairs = parse_qa_pairs(raw)
+        if pairs:
+            try:
+                serial = json.dumps([p.__dict__ for p in pairs])
+                if validate_output(template, serial):
+                    return serial
+            except Exception:
+                pass
+        logger.debug("Validation failed on attempt %d", attempt + 1)
+    raise RuntimeError("LLM output did not pass validation")
+
+
+def auto_tool_calls(
+    text: str,
+    tools: Iterable[tuple[str, str]],
+    insert_fn: Callable[[str, Iterable[tuple[str, str]]], str],
+) -> str:
+    """Insert tool-call examples in ``text``.
+
+    ``insert_fn`` receives the original text and a list of ``(name, example)``
+    tuples and should return the text augmented with tool-call markers. When it
+    returns ``None`` or an empty string the original text is preserved.
+    """
+    updated = insert_fn(text, tools)
+    if not updated:
+        return text
+    return updated

--- a/datacreek/utils/self_instruct.py
+++ b/datacreek/utils/self_instruct.py
@@ -1,4 +1,5 @@
 """Simple helpers implementing a Self-Instruct style loop."""
+
 from __future__ import annotations
 
 import json

--- a/datacreek/utils/self_instruct.py
+++ b/datacreek/utils/self_instruct.py
@@ -1,12 +1,12 @@
 """Simple helpers implementing a Self-Instruct style loop."""
 from __future__ import annotations
 
-import logging
 import json
+import logging
 from typing import Callable, Iterable
 
-from .llm_processing import parse_qa_pairs
 from ..templates.library import validate_output
+from .llm_processing import parse_qa_pairs
 
 logger = logging.getLogger(__name__)
 

--- a/datacreek/utils/toolformer.py
+++ b/datacreek/utils/toolformer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Lightweight helpers to insert API call placeholders."""
 
 import re
-from typing import Iterable, Tuple
+from typing import Callable, Dict, Iterable, Tuple
 
 
 def insert_tool_calls(text: str, tools: Iterable[Tuple[str, str]]) -> str:
@@ -33,3 +33,94 @@ def insert_tool_calls(text: str, tools: Iterable[Tuple[str, str]]) -> str:
 
         out = regex.sub(repl, out, count=1)
     return out
+
+
+def execute_tool_calls(text: str, tools: Dict[str, Callable[[str], str]]) -> str:
+    """Execute tool call placeholders in ``text`` and return updated output.
+
+    Parameters
+    ----------
+    text:
+        Input text containing ``[TOOL:name(args)]`` markers.
+    tools:
+        Mapping of tool ``name`` to a callable accepting the ``args`` string
+        and returning the replacement text. Unknown tool names are ignored.
+
+    Returns
+    -------
+    str
+        ``text`` with all placeholders replaced by the function outputs. If
+        a tool raises an exception its placeholder is left intact.
+    """
+
+    pattern = re.compile(r"\[TOOL:(\w+)\((.*?)\)\]")
+
+    def repl(match: re.Match) -> str:
+        name, arg = match.group(1), match.group(2)
+        func = tools.get(name)
+        if not func:
+            return match.group(0)
+        try:
+            return str(func(arg))
+        except Exception:
+            return match.group(0)
+
+    return pattern.sub(repl, text)
+
+
+def generate_with_tools(
+    llm_call: Callable[[str], str],
+    prompt: str,
+    tools: Dict[str, Callable[[str], str]],
+    *,
+    insert_patterns: Iterable[Tuple[str, str]] = (),
+    score_fn: Callable[[str], float] | None = None,
+    retries: int = 1,
+) -> str:
+    """Generate text using tool calls when it improves a quality score.
+
+    The helper applies :func:`insert_tool_calls` to ``prompt`` using
+    ``insert_patterns`` and queries ``llm_call``. If ``score_fn`` is provided
+    the output is only kept when ``score_fn`` yields a higher value than the
+    baseline prompt without tools. Placeholders are replaced by calling
+    ``execute_tool_calls``.
+
+    Parameters
+    ----------
+    llm_call:
+        Function invoking a language model with a string prompt.
+    prompt:
+        Base prompt sent to the model.
+    tools:
+        Mapping of tool names to callables executed on placeholder content.
+    insert_patterns:
+        ``(name, regex)`` pairs used to insert tool calls in ``prompt``.
+    score_fn:
+        Function evaluating text quality. When ``None`` the first tool assisted
+        output is returned.
+    retries:
+        Maximum attempts with the tool augmented prompt.
+
+    Returns
+    -------
+    str
+        Best model output according to ``score_fn`` or the tool assisted text
+        if no scoring is provided.
+    """
+
+    baseline = llm_call(prompt)
+    best = baseline
+    best_score = score_fn(baseline) if score_fn else None
+
+    tool_prompt = insert_tool_calls(prompt, insert_patterns)
+    for _ in range(retries):
+        raw = llm_call(tool_prompt)
+        executed = execute_tool_calls(raw, tools)
+        if score_fn is None:
+            return executed
+        score = score_fn(executed)
+        if best_score is None or score > best_score:
+            best = executed
+            best_score = score
+
+    return best

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "gudhi>=3.9.0",
     "fakeredis>=2.30.0",
     "beautifulsoup4>=4.12.2",
+    "jsonschema>=4.0.0",
 ]
 
 # These fields appear in pip show

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -11,9 +11,9 @@ from datacreek.analysis import bottleneck_distance
 from datacreek.core import dataset
 from datacreek.core.dataset import DatasetBuilder
 from datacreek.core.ingest import IngestOptions
+from datacreek.models.qa import QAPair
 from datacreek.models.stage import DatasetStage
 from datacreek.pipelines import DatasetType, PipelineStep
-from datacreek.models.qa import QAPair
 
 
 def test_dataset_has_its_own_graph():

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -13,6 +13,7 @@ from datacreek.core.dataset import DatasetBuilder
 from datacreek.core.ingest import IngestOptions
 from datacreek.models.stage import DatasetStage
 from datacreek.pipelines import DatasetType, PipelineStep
+from datacreek.models.qa import QAPair
 
 
 def test_dataset_has_its_own_graph():
@@ -1816,3 +1817,26 @@ def test_hyperbolic_multi_curvature_reasoning_wrapper():
     path = ds.hyperbolic_multi_curvature_reasoning("a", "c", curvatures=[-1, -0.5], max_steps=3)
     assert path[0] == "a" and path[-1] == "c"
     assert any(e.operation == "hyperbolic_multi_curvature_reasoning" for e in ds.events)
+
+
+def test_verify_answer_and_pairs():
+    ds = DatasetBuilder(DatasetType.QA)
+    ds.graph.add_fact("Paris", "is", "capital of France", fact_id="f1")
+    score = ds.verify_answer("Paris is the capital of France.")
+    assert score == 1.0
+    pair = QAPair(question="q", answer="Paris is the capital of France.")
+    verified = ds.verify_qa_pairs([pair])
+    assert verified[0].confidence == 1.0
+    assert any(e.operation == "verify_qa_pairs" for e in ds.events)
+
+
+def test_sample_diverse_chunks():
+    ds = DatasetBuilder(DatasetType.TEXT)
+    ds.add_document("d", source="s")
+    for i in range(3):
+        ds.add_chunk("d", f"c{i}", str(i))
+    ds.graph.graph.add_edge("c0", "c1")
+    ds.graph.graph.add_edge("c1", "c2")
+    result = ds.sample_diverse_chunks(2, [1])
+    assert len(result) >= 1
+    assert any(e.operation == "sample_diverse_chunks" for e in ds.events)

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -7,7 +7,11 @@ from datacreek.analysis.generation import (
     generate_graph_rnn_stateful,
 )
 from datacreek.utils.graph_text import graph_to_text, neighborhood_to_sentence, subgraph_to_text
-from datacreek.utils.toolformer import insert_tool_calls
+from datacreek.utils.toolformer import (
+    execute_tool_calls,
+    generate_with_tools,
+    insert_tool_calls,
+)
 
 
 def test_generate_graph_rnn_like():
@@ -70,6 +74,35 @@ def test_insert_tool_calls():
     )
     assert out.count("[TOOL:search") == 1
     assert "[TOOL:filter" in out
+
+
+def test_execute_tool_calls():
+    text = "[TOOL:echo(hi)] and [TOOL:upper(world)]"
+
+    def echo(x: str) -> str:
+        return x
+
+    def upper(x: str) -> str:
+        return x.upper()
+
+    out = execute_tool_calls(text, {"echo": echo, "upper": upper})
+    assert out == "hi and WORLD"
+
+
+def test_generate_with_tools():
+    def llm_call(prompt: str) -> str:
+        return prompt
+
+    def echo(arg: str) -> str:
+        return arg
+
+    result = generate_with_tools(
+        llm_call,
+        "say hello",
+        {"echo": echo},
+        insert_patterns=[("echo", r"hello")],
+    )
+    assert result == "say hello"
 
 
 def test_subgraph_to_text():

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -7,11 +7,7 @@ from datacreek.analysis.generation import (
     generate_graph_rnn_stateful,
 )
 from datacreek.utils.graph_text import graph_to_text, neighborhood_to_sentence, subgraph_to_text
-from datacreek.utils.toolformer import (
-    execute_tool_calls,
-    generate_with_tools,
-    insert_tool_calls,
-)
+from datacreek.utils.toolformer import execute_tool_calls, generate_with_tools, insert_tool_calls
 
 
 def test_generate_graph_rnn_like():


### PR DESCRIPTION
## Summary
- provide JSON template specs for ChatML, Alpaca and QA
- track traversed edges and Betti coverage during queries
- expose betti_number and coverage_stats in the main package
- enhance self-instruct helper to reformat model output
- document coverage stats in pipeline overview
- verify QA answers against graph facts and select diverse prompts
- improve graph neighborhood description and add tool-call execution helper
- add toolformer-like helper `generate_with_tools`
- expose template helpers

## Testing
- `pytest tests/test_generation.py::test_generate_with_tools tests/test_generation.py::test_execute_tool_calls tests/test_generation.py::test_neighborhood_to_sentence tests/test_dataset_builder.py -k "verify_answer_and_pairs or sample_diverse_chunks" -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4d04ed34832f9436c7b2088eabdf