### PR TITLE
Add embedding box-counting dimension utilities

### DIFF
--- a/datacreek/__init__.py
+++ b/datacreek/__init__.py
@@ -54,10 +54,14 @@ __all__: list[str] = [
     "generate_graph_rnn_sequential",
     "generate_netgan_like",
     "graph_information_bottleneck",
+    "graph_entropy",
+    "subgraph_entropy",
     "prototype_subgraph",
     "sheaf_laplacian",
     "sheaf_convolution",
     "sheaf_neural_network",
+    "sheaf_first_cohomology",
+    "resolve_sheaf_obstruction",
     "fractal_information_density",
     "diversification_score",
     "hyperbolic_neighbors",
@@ -85,6 +89,20 @@ __all__: list[str] = [
     "validate_output",
     "betti_number",
     "coverage_stats",
+    "mapper_nerve",
+    "inverse_mapper",
+    "fractal_net_prune",
+    "graphwave_entropy",
+    "embedding_entropy",
+    "embedding_box_counting_dimension",
+    "ensure_graphwave_entropy",
+    "hyper_sagnn_embeddings",
+    "select_mdl_motifs",
+    "mdl_description_length",
+    "detect_automorphisms",
+    "automorphism_group_order",
+    "quotient_by_symmetry",
+    "prune_embeddings",
 ]
 
 if TYPE_CHECKING:  # pragma: no cover - used for type checking only
@@ -113,6 +131,7 @@ if TYPE_CHECKING:  # pragma: no cover - used for type checking only
         spectral_entropy,
         spectral_gap,
     )
+    from .analysis.hypergraph import hyper_sagnn_embeddings
     from .analysis.generation import (
         generate_graph_rnn_like,
         generate_graph_rnn_sequential,
@@ -294,6 +313,14 @@ def __getattr__(name: str):
         from .analysis.information import graph_information_bottleneck as _gib
 
         return _gib
+    if name == "graph_entropy":
+        from .analysis.information import graph_entropy as _ge
+
+        return _ge
+    if name == "subgraph_entropy":
+        from .analysis.information import subgraph_entropy as _se
+
+        return _se
     if name == "prototype_subgraph":
         from .analysis.information import prototype_subgraph as _ps
 
@@ -310,6 +337,14 @@ def __getattr__(name: str):
         from .analysis.sheaf import sheaf_neural_network as _snn
 
         return _snn
+    if name == "sheaf_first_cohomology":
+        from .analysis.sheaf import sheaf_first_cohomology as _sfc
+
+        return _sfc
+    if name == "resolve_sheaf_obstruction":
+        from .analysis.sheaf import resolve_sheaf_obstruction as _rso
+
+        return _rso
     if name == "quality_check":
         from .core.dataset import DatasetBuilder
 
@@ -430,6 +465,68 @@ def __getattr__(name: str):
         from .core.dataset import DatasetBuilder as _DB
 
         return _DB.coverage_stats
+    if name == "mapper_nerve":
+        from .analysis.mapper import mapper_nerve as _mn
+
+        return _mn
+    if name == "inverse_mapper":
+        from .analysis.mapper import inverse_mapper as _im
+
+        return _im
+    if name == "fractal_net_prune":
+        from .analysis.fractal import fractal_net_prune as _fp
+
+        return _fp
+    if name == "graphwave_entropy":
+        from .analysis.fractal import graphwave_entropy as _ge
+
+        return _ge
+    if name == "embedding_entropy":
+        from .core.dataset import DatasetBuilder as _DB
+
+        return _DB.embedding_entropy
+    if name == "graph_entropy":
+        from .core.dataset import DatasetBuilder as _DB
+
+        return _DB.graph_entropy
+    if name == "subgraph_entropy":
+        from .core.dataset import DatasetBuilder as _DB
+
+        return _DB.subgraph_entropy
+    if name == "embedding_box_counting_dimension":
+        from .core.dataset import DatasetBuilder as _DB
+
+        return _DB.embedding_box_counting_dimension
+    if name == "ensure_graphwave_entropy":
+        from .core.dataset import DatasetBuilder as _DB
+
+        return _DB.ensure_graphwave_entropy
+    if name == "hyper_sagnn_embeddings":
+        from .analysis.hypergraph import hyper_sagnn_embeddings as _hs
+
+        return _hs
+    if name == "select_mdl_motifs":
+        from .core.dataset import DatasetBuilder as _DB
+
+        return _DB.select_mdl_motifs
+    if name == "mdl_description_length":
+        from .analysis.information import mdl_description_length as _mdl
+
+        return _mdl
+    if name == "prune_embeddings":
+        from .core.dataset import DatasetBuilder as _DB
+
+        return _DB.prune_embeddings
+    if name in {"detect_automorphisms", "quotient_by_symmetry", "automorphism_group_order"}:
+        from .core.dataset import DatasetBuilder as _DB
+
+        mapping = {
+            "detect_automorphisms": _DB.detect_automorphisms,
+            "automorphism_group_order": _DB.automorphism_group_order,
+            "quotient_by_symmetry": _DB.quotient_by_symmetry,
+        }
+
+        return mapping[name]
     if name == "get_template" or name == "PromptTemplate" or name == "validate_output":
         from .templates.library import PromptTemplate as _PT
         from .templates.library import get_template as _gtmpl

--- a/datacreek/__init__.py
+++ b/datacreek/__init__.py
@@ -131,13 +131,13 @@ if TYPE_CHECKING:  # pragma: no cover - used for type checking only
         spectral_entropy,
         spectral_gap,
     )
-    from .analysis.hypergraph import hyper_sagnn_embeddings
     from .analysis.generation import (
         generate_graph_rnn_like,
         generate_graph_rnn_sequential,
         generate_graph_rnn_stateful,
         generate_netgan_like,
     )
+    from .analysis.hypergraph import hyper_sagnn_embeddings
     from .config_models import GenerationSettings
     from .core.dataset import DatasetBuilder
     from .core.ingest import ingest_into_dataset

--- a/datacreek/analysis/__init__.py
+++ b/datacreek/analysis/__init__.py
@@ -91,13 +91,16 @@ def __getattr__(name: str):
 
         return _hs
     if name in {"mdl_description_length", "select_mdl_motifs"}:
-        from .information import (
-            mdl_description_length as _mdl_desc,
-            select_mdl_motifs as _mdl_sel,
-        )
+        from .information import mdl_description_length as _mdl_desc
+        from .information import select_mdl_motifs as _mdl_sel
 
         return _mdl_desc if name == "mdl_description_length" else _mdl_sel
-    if name in {"automorphisms", "automorphism_orbits", "quotient_graph", "automorphism_group_order"}:
+    if name in {
+        "automorphisms",
+        "automorphism_orbits",
+        "quotient_graph",
+        "automorphism_group_order",
+    }:
         from . import symmetry as _s
 
         return getattr(_s, name)

--- a/datacreek/analysis/__init__.py
+++ b/datacreek/analysis/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "box_counting_dimension",
     "box_cover",
     "graphwave_embedding",
+    "embedding_box_counting_dimension",
     "mdl_optimal_radius",
     "persistence_diagrams",
     "persistence_entropy",
@@ -22,16 +23,32 @@ __all__ = [
     "graph_fourier_transform",
     "inverse_graph_fourier_transform",
     "graph_information_bottleneck",
+    "graph_entropy",
+    "subgraph_entropy",
     "prototype_subgraph",
     "sheaf_laplacian",
     "sheaf_convolution",
     "sheaf_neural_network",
+    "sheaf_first_cohomology",
+    "resolve_sheaf_obstruction",
     "fractal_information_density",
     "diversification_score",
     "generate_graph_rnn_stateful",
     "generate_graph_rnn_sequential",
     "hyperbolic_reasoning",
     "hyperbolic_hypergraph_reasoning",
+    "automorphisms",
+    "automorphism_orbits",
+    "automorphism_group_order",
+    "quotient_graph",
+    "mapper_nerve",
+    "inverse_mapper",
+    "fractal_net_prune",
+    "graphwave_entropy",
+    "embedding_entropy",
+    "hyper_sagnn_embeddings",
+    "mdl_description_length",
+    "select_mdl_motifs",
 ]
 
 
@@ -61,14 +78,45 @@ def __getattr__(name: str):
         "diversification_score",
         "hyperbolic_reasoning",
         "hyperbolic_hypergraph_reasoning",
+        "fractal_net_prune",
+        "graphwave_entropy",
+        "embedding_entropy",
+        "embedding_box_counting_dimension",
     }:
         from . import fractal as _f
 
         return getattr(_f, name)
+    if name == "hyper_sagnn_embeddings":
+        from .hypergraph import hyper_sagnn_embeddings as _hs
+
+        return _hs
+    if name in {"mdl_description_length", "select_mdl_motifs"}:
+        from .information import (
+            mdl_description_length as _mdl_desc,
+            select_mdl_motifs as _mdl_sel,
+        )
+
+        return _mdl_desc if name == "mdl_description_length" else _mdl_sel
+    if name in {"automorphisms", "automorphism_orbits", "quotient_graph", "automorphism_group_order"}:
+        from . import symmetry as _s
+
+        return getattr(_s, name)
+    if name in {"mapper_nerve", "inverse_mapper"}:
+        from . import mapper as _m
+
+        return getattr(_m, name)
     if name == "graph_information_bottleneck":
         from .information import graph_information_bottleneck as _gib
 
         return _gib
+    if name == "graph_entropy":
+        from .information import graph_entropy as _ge
+
+        return _ge
+    if name == "subgraph_entropy":
+        from .information import subgraph_entropy as _se
+
+        return _se
     if name == "prototype_subgraph":
         from .information import prototype_subgraph as _ps
 
@@ -85,6 +133,14 @@ def __getattr__(name: str):
         from .sheaf import sheaf_neural_network as _snn
 
         return _snn
+    if name == "sheaf_first_cohomology":
+        from .sheaf import sheaf_first_cohomology as _sfc
+
+        return _sfc
+    if name == "resolve_sheaf_obstruction":
+        from .sheaf import resolve_sheaf_obstruction as _rso
+
+        return _rso
     if name == "generate_graph_rnn_stateful":
         from .generation import generate_graph_rnn_stateful as _grs
 

--- a/datacreek/analysis/hypergraph.py
+++ b/datacreek/analysis/hypergraph.py
@@ -1,0 +1,51 @@
+import math
+from typing import Iterable, List, Sequence
+
+import numpy as np
+
+
+def hyper_sagnn_embeddings(
+    hyperedges: List[Sequence[int]],
+    node_features: np.ndarray,
+    *,
+    embed_dim: int | None = None,
+    seed: int | None = None,
+) -> np.ndarray:
+    """Return Hyper-SAGNN style embeddings for each hyperedge.
+
+    Parameters
+    ----------
+    hyperedges:
+        List of hyperedges, each given as a sequence of node indices.
+    node_features:
+        Array of shape ``(num_nodes, feat_dim)`` containing node features.
+    embed_dim:
+        Dimension ``d`` of the output embedding. Defaults to ``feat_dim``.
+    seed:
+        Optional random seed controlling the internal attention weights.
+    """
+    rng = np.random.default_rng(seed)
+    feat_dim = node_features.shape[1]
+    d = embed_dim or feat_dim
+
+    W_q = rng.normal(scale=1.0 / math.sqrt(feat_dim), size=(feat_dim, d))
+    W_k = rng.normal(scale=1.0 / math.sqrt(feat_dim), size=(feat_dim, d))
+    W_v = rng.normal(scale=1.0 / math.sqrt(feat_dim), size=(feat_dim, d))
+
+    def _softmax(x: np.ndarray, axis: int = -1) -> np.ndarray:
+        x_max = x.max(axis=axis, keepdims=True)
+        e = np.exp(x - x_max)
+        return e / e.sum(axis=axis, keepdims=True)
+
+    embeddings = []
+    for edge in hyperedges:
+        X = node_features[np.asarray(edge)]
+        q = X @ W_q
+        k = X @ W_k
+        v = X @ W_v
+        scores = q @ k.T / math.sqrt(d)
+        weights = _softmax(scores, axis=1)
+        context = weights @ v
+        emb = context.mean(axis=0)
+        embeddings.append(emb)
+    return np.stack(embeddings)

--- a/datacreek/analysis/information.py
+++ b/datacreek/analysis/information.py
@@ -35,8 +35,6 @@ def graph_information_bottleneck(
 
     from sklearn.linear_model import LogisticRegression
 
-    from sklearn.linear_model import LogisticRegression
-
     model = LogisticRegression(max_iter=1000, n_jobs=1)
     model.fit(X, y)
     probs = model.predict_proba(X)
@@ -87,9 +85,11 @@ def prototype_subgraph(
     sub = graph.subgraph(neighborhood.keys()).copy()
     return sub
 
+
 import math
-import networkx as nx
 from typing import Iterable, List
+
+import networkx as nx
 
 
 def mdl_description_length(graph: nx.Graph, motifs: Iterable[nx.Graph]) -> float:
@@ -130,8 +130,6 @@ def select_mdl_motifs(graph: nx.Graph, motifs: Iterable[nx.Graph]) -> List[nx.Gr
         selected.append(motif_list.pop(best_idx))
         uncovered -= best_edges  # type: ignore[arg-type]
     return selected
-
-
 
 
 def graph_entropy(graph: nx.Graph, *, base: float = 2.0) -> float:

--- a/datacreek/analysis/mapper.py
+++ b/datacreek/analysis/mapper.py
@@ -1,0 +1,49 @@
+import networkx as nx
+from typing import Iterable, List, Set, Tuple
+
+
+def mapper_cover(graph: nx.Graph, radius: int = 1) -> List[Set[object]]:
+    """Return a greedy cover of ``graph`` using BFS balls of ``radius``.
+
+    The function repeatedly selects an uncovered node and forms a ball of
+    radius ``radius`` around it until all nodes are covered.
+    """
+    remaining = set(graph.nodes())
+    cover: List[Set[object]] = []
+    while remaining:
+        seed = remaining.pop()
+        ball = set(nx.single_source_shortest_path_length(graph, seed, cutoff=radius).keys())
+        cover.append(ball | {seed})
+        remaining.difference_update(ball)
+    return cover
+
+
+def mapper_nerve(graph: nx.Graph, radius: int = 1) -> Tuple[nx.Graph, List[Set[object]]]:
+    """Return the Mapper nerve of ``graph`` and the covering used."""
+    cover = mapper_cover(graph, radius)
+    nerve = nx.Graph()
+    nerve.add_nodes_from(range(len(cover)))
+    for i, A in enumerate(cover):
+        for j in range(i + 1, len(cover)):
+            if A & cover[j]:
+                nerve.add_edge(i, j)
+    return nerve, cover
+
+
+def inverse_mapper(nerve: nx.Graph, cover: Iterable[Set[object]]) -> nx.Graph:
+    """Reconstruct a graph from its Mapper ``nerve`` and ``cover`` sets."""
+    cover_list = [set(c) for c in cover]
+    g = nx.Graph()
+    for cluster in cover_list:
+        for node in cluster:
+            g.add_node(node)
+        for u in cluster:
+            for v in cluster:
+                if u != v:
+                    g.add_edge(u, v)
+    for u, v in nerve.edges():
+        for a in cover_list[int(u)]:
+            for b in cover_list[int(v)]:
+                if a != b:
+                    g.add_edge(a, b)
+    return g

--- a/datacreek/analysis/mapper.py
+++ b/datacreek/analysis/mapper.py
@@ -1,5 +1,6 @@
-import networkx as nx
 from typing import Iterable, List, Set, Tuple
+
+import networkx as nx
 
 
 def mapper_cover(graph: nx.Graph, radius: int = 1) -> List[Set[object]]:

--- a/datacreek/analysis/symmetry.py
+++ b/datacreek/analysis/symmetry.py
@@ -1,0 +1,111 @@
+import networkx as nx
+from itertools import islice
+from typing import List, Dict, Set, Iterable, Tuple
+
+
+def automorphisms(graph: nx.Graph, max_count: int = 10) -> List[Dict[object, object]]:
+    """Return up to ``max_count`` automorphisms of ``graph``.
+
+    Each automorphism is represented as a mapping ``node -> node``.
+    The function relies on :class:`~networkx.algorithms.isomorphism.GraphMatcher`
+    which may be costly for large graphs, so ``max_count`` limits the number of
+    mappings enumerated.
+    """
+    matcher = nx.algorithms.isomorphism.GraphMatcher(graph, graph)
+    return list(islice(matcher.isomorphisms_iter(), max_count))
+
+
+def automorphism_orbits(graph: nx.Graph, max_count: int = 10) -> List[Set[object]]:
+    """Return node orbits induced by automorphisms.
+
+    Parameters
+    ----------
+    graph:
+        Input graph.
+    max_count:
+        Maximum number of automorphisms explored.
+
+    Returns
+    -------
+    list[set]
+        Each set contains nodes that can be permuted onto each other by some
+        automorphism.
+    """
+    autos = automorphisms(graph, max_count=max_count)
+    orbits: List[Set[object]] = []
+    for mapping in autos:
+        for a, b in mapping.items():
+            if a == b:
+                continue
+            found = False
+            for orb in orbits:
+                if a in orb or b in orb:
+                    orb.update({a, b})
+                    found = True
+                    break
+            if not found:
+                orbits.append({a, b})
+    return orbits
+
+
+def automorphism_group_order(graph: nx.Graph, max_count: int = 100) -> int:
+    """Return the size of the automorphism group.
+
+    Parameters
+    ----------
+    graph:
+        Input graph.
+    max_count:
+        Maximum number of distinct automorphisms to enumerate. The method
+        stops early once ``max_count`` mappings are found and returns this
+        value as a lower bound on the true group order.
+
+    Notes
+    -----
+    The enumeration relies on :class:`~networkx.algorithms.isomorphism.GraphMatcher`.
+    For large graphs only a subset of mappings may be explored which yields a
+    lower bound on the actual automorphism group size.
+    """
+
+    matcher = nx.algorithms.isomorphism.GraphMatcher(graph, graph)
+    count = 0
+    for _ in islice(matcher.isomorphisms_iter(), max_count):
+        count += 1
+        if count >= max_count:
+            break
+    return count
+
+
+def quotient_graph(
+    graph: nx.Graph, orbits: Iterable[Set[object]]
+) -> Tuple[nx.Graph, Dict[object, int]]:
+    """Return graph quotienting nodes by ``orbits``.
+
+    Parameters
+    ----------
+    graph:
+        Input graph.
+    orbits:
+        Collection of node sets representing equivalence classes.
+
+    Returns
+    -------
+    tuple[nx.Graph, dict]
+        The quotient graph and a mapping ``node -> class_id``.
+    """
+    mapping: Dict[object, int] = {}
+    for idx, orbit in enumerate(orbits):
+        for n in orbit:
+            mapping[n] = idx
+    counter = len(orbits)
+    for n in graph.nodes():
+        if n not in mapping:
+            mapping[n] = counter
+            counter += 1
+    q = nx.Graph()
+    for u, v in graph.edges():
+        a, b = mapping[u], mapping[v]
+        if a == b:
+            continue
+        q.add_edge(a, b)
+    return q, mapping

--- a/datacreek/analysis/symmetry.py
+++ b/datacreek/analysis/symmetry.py
@@ -1,6 +1,7 @@
-import networkx as nx
 from itertools import islice
-from typing import List, Dict, Set, Iterable, Tuple
+from typing import Dict, Iterable, List, Set, Tuple
+
+import networkx as nx
 
 
 def automorphisms(graph: nx.Graph, max_count: int = 10) -> List[Dict[object, object]]:

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -1604,9 +1604,7 @@ class DatasetBuilder:
     ) -> int:
         """Wrapper for :meth:`KnowledgeGraph.resolve_sheaf_obstruction`."""
 
-        val = self.graph.resolve_sheaf_obstruction(
-            edge_attr=edge_attr, max_iter=max_iter
-        )
+        val = self.graph.resolve_sheaf_obstruction(edge_attr=edge_attr, max_iter=max_iter)
         self._record_event(
             "resolve_sheaf_obstruction",
             "Sheaf obstruction resolved",

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -860,6 +860,60 @@ class DatasetBuilder:
             num_points=num_points,
         )
 
+    def graphwave_entropy(self) -> float:
+        """Wrapper for :meth:`KnowledgeGraph.graphwave_entropy`."""
+
+        val = self.graph.graphwave_entropy()
+        self._record_event("graphwave_entropy", "GraphWave entropy computed")
+        return val
+
+    def ensure_graphwave_entropy(
+        self,
+        threshold: float,
+        *,
+        scales: Iterable[float] = (0.5, 1.0),
+        num_points: int = 10,
+    ) -> float:
+        """Wrapper for :meth:`KnowledgeGraph.ensure_graphwave_entropy`."""
+
+        val = self.graph.ensure_graphwave_entropy(
+            threshold,
+            scales=scales,
+            num_points=num_points,
+        )
+        self._record_event(
+            "ensure_graphwave_entropy",
+            "GraphWave entropy enforced",
+            threshold=threshold,
+        )
+        return val
+
+    def embedding_entropy(self, node_attr: str = "embedding") -> float:
+        """Wrapper for :meth:`KnowledgeGraph.embedding_entropy`."""
+
+        val = self.graph.embedding_entropy(node_attr=node_attr)
+        self._record_event(
+            "embedding_entropy",
+            "Embedding entropy computed",
+            attribute=node_attr,
+        )
+        return val
+
+    def embedding_box_counting_dimension(
+        self, node_attr: str, radii: Iterable[float]
+    ) -> tuple[float, list[tuple[float, int]]]:
+        """Wrapper for :meth:`KnowledgeGraph.embedding_box_counting_dimension`."""
+
+        dim, counts = self.graph.embedding_box_counting_dimension(node_attr, radii)
+        self._record_event(
+            "embedding_box_counting_dimension",
+            "Embedding fractal dimension computed",
+            attribute=node_attr,
+            radii=list(radii),
+            dimension=dim,
+        )
+        return dim, counts
+
     def compute_poincare_embeddings(
         self,
         dim: int = 2,
@@ -912,6 +966,29 @@ class DatasetBuilder:
             epochs=epochs,
             learning_rate=learning_rate,
             burn_in=burn_in,
+        )
+        return result
+
+    def compute_hyper_sagnn_embeddings(
+        self,
+        *,
+        node_attr: str = "embedding",
+        edge_attr: str = "hyper_sagnn_embedding",
+        embed_dim: int | None = None,
+        seed: int | None = None,
+    ) -> Dict[str, list[float]]:
+        """Wrapper for :meth:`KnowledgeGraph.compute_hyper_sagnn_embeddings`."""
+
+        result = self.graph.compute_hyper_sagnn_embeddings(
+            node_attr=node_attr,
+            edge_attr=edge_attr,
+            embed_dim=embed_dim,
+            seed=seed,
+        )
+        self._record_event(
+            "compute_hyper_sagnn_embeddings",
+            "Hyper-SAGNN embeddings computed",
+            embed_dim=embed_dim,
         )
         return result
 
@@ -1011,6 +1088,17 @@ class DatasetBuilder:
             node2vec_q=node2vec_q,
         )
 
+    def prune_embeddings(self, *, tol: float = 1e-3) -> Dict[str, int]:
+        """Wrapper for :meth:`KnowledgeGraph.prune_embeddings`."""
+
+        mapping = self.graph.prune_embeddings(tol=tol)
+        self._record_event(
+            "prune_embeddings",
+            "Embeddings pruned via fractal Net",
+            clusters=len(set(mapping.values())),
+        )
+        return mapping
+
     def fractal_dimension(self, radii: Iterable[int]) -> tuple[float, list[tuple[int, int]]]:
         """Wrapper for :meth:`KnowledgeGraph.box_counting_dimension`."""
 
@@ -1059,6 +1147,139 @@ class DatasetBuilder:
             distortion=dist,
         )
         return dist
+
+    def detect_automorphisms(self, max_count: int = 10) -> List[Dict[str, str]]:
+        """Wrapper for :meth:`KnowledgeGraph.detect_automorphisms`."""
+
+        autos = self.graph.detect_automorphisms(max_count=max_count)
+        self._record_event(
+            "detect_automorphisms",
+            "Automorphisms detected",
+            count=len(autos),
+        )
+        return autos
+
+    def automorphism_group_order(self, max_count: int = 100) -> int:
+        """Wrapper for :meth:`KnowledgeGraph.automorphism_group_order`."""
+
+        order = self.graph.automorphism_group_order(max_count=max_count)
+        self._record_event(
+            "automorphism_group_order",
+            "Automorphism group order estimated",
+            count=order,
+        )
+        return order
+
+    def quotient_by_symmetry(self, *, max_count: int = 10) -> tuple[nx.Graph, Dict[str, int]]:
+        """Wrapper for :meth:`KnowledgeGraph.quotient_by_symmetry`."""
+
+        q, mapping = self.graph.quotient_by_symmetry(max_count=max_count)
+        self._record_event(
+            "quotient_by_symmetry",
+            "Graph quotient computed",
+            classes=len(set(mapping.values())),
+        )
+        return q, mapping
+
+    def mapper_nerve(self, radius: int) -> tuple[nx.Graph, list[set[str]]]:
+        """Wrapper for :meth:`KnowledgeGraph.mapper_nerve`."""
+
+        nerve, cover = self.graph.mapper_nerve(radius)
+        self._record_event(
+            "mapper_nerve",
+            "Mapper nerve computed",
+            radius=radius,
+            clusters=len(cover),
+        )
+        return nerve, cover
+
+    def inverse_mapper(self, nerve: nx.Graph, cover: Iterable[Iterable[str]]) -> nx.Graph:
+        """Wrapper for :meth:`KnowledgeGraph.inverse_mapper`."""
+
+        g = self.graph.inverse_mapper(nerve, cover)
+        self._record_event("inverse_mapper", "Graph reconstructed from nerve")
+        return g
+
+    # --------------------------------------------------------------
+    # Graph generation wrappers
+    # --------------------------------------------------------------
+
+    def generate_graph_rnn_like(self, num_nodes: int, num_edges: int) -> nx.Graph:
+        """Return a random graph mimicking GraphRNN output."""
+
+        g = self.graph.generate_graph_rnn_like(num_nodes, num_edges)
+        self._record_event(
+            "generate_graph_rnn_like",
+            "Random GraphRNN-like graph generated",
+            nodes=num_nodes,
+            edges=num_edges,
+        )
+        return g
+
+    def generate_graph_rnn(
+        self, num_nodes: int, num_edges: int, *, p: float = 0.5, directed: bool = False
+    ) -> nx.Graph:
+        """Return a simple sequential GraphRNN-style graph."""
+
+        g = self.graph.generate_graph_rnn(num_nodes, num_edges, p=p, directed=directed)
+        self._record_event(
+            "generate_graph_rnn",
+            "GraphRNN sequential graph generated",
+            nodes=num_nodes,
+            edges=num_edges,
+            p=p,
+            directed=directed,
+        )
+        return g
+
+    def generate_graph_rnn_stateful(
+        self,
+        num_nodes: int,
+        num_edges: int,
+        *,
+        hidden_dim: int = 8,
+        seed: int | None = None,
+    ) -> nx.DiGraph:
+        """Return a directed graph from a tiny stateful RNN generator."""
+
+        g = self.graph.generate_graph_rnn_stateful(
+            num_nodes, num_edges, hidden_dim=hidden_dim, seed=seed
+        )
+        self._record_event(
+            "generate_graph_rnn_stateful",
+            "Stateful GraphRNN graph generated",
+            nodes=num_nodes,
+            edges=num_edges,
+            hidden_dim=hidden_dim,
+        )
+        return g
+
+    def generate_graph_rnn_sequential(
+        self,
+        num_nodes: int,
+        num_edges: int,
+        *,
+        hidden_dim: int = 8,
+        seed: int | None = None,
+        directed: bool = True,
+    ) -> nx.Graph:
+        """Return a graph using a sequential RNN-style generator."""
+
+        g = self.graph.generate_graph_rnn_sequential(
+            num_nodes,
+            num_edges,
+            hidden_dim=hidden_dim,
+            seed=seed,
+            directed=directed,
+        )
+        self._record_event(
+            "generate_graph_rnn_sequential",
+            "Sequential GraphRNN graph generated",
+            nodes=num_nodes,
+            edges=num_edges,
+            directed=directed,
+        )
+        return g
 
     def optimize_topology_constrained(
         self,
@@ -1367,6 +1588,32 @@ class DatasetBuilder:
         )
         return result
 
+    def sheaf_cohomology(self, *, edge_attr: str = "sheaf_sign", tol: float = 1e-5) -> int:
+        """Wrapper for :meth:`KnowledgeGraph.sheaf_cohomology`."""
+
+        val = self.graph.sheaf_cohomology(edge_attr=edge_attr, tol=tol)
+        self._record_event(
+            "sheaf_cohomology",
+            "Sheaf cohomology computed",
+            h1=val,
+        )
+        return val
+
+    def resolve_sheaf_obstruction(
+        self, *, edge_attr: str = "sheaf_sign", max_iter: int = 10
+    ) -> int:
+        """Wrapper for :meth:`KnowledgeGraph.resolve_sheaf_obstruction`."""
+
+        val = self.graph.resolve_sheaf_obstruction(
+            edge_attr=edge_attr, max_iter=max_iter
+        )
+        self._record_event(
+            "resolve_sheaf_obstruction",
+            "Sheaf obstruction resolved",
+            h1=val,
+        )
+        return val
+
     def path_to_text(self, path: Iterable) -> str:
         """Wrapper for :meth:`KnowledgeGraph.path_to_text`."""
 
@@ -1426,6 +1673,25 @@ class DatasetBuilder:
         )
         return loss
 
+    def graph_entropy(self, *, base: float = 2.0) -> float:
+        """Wrapper for :meth:`KnowledgeGraph.graph_entropy`."""
+
+        val = self.graph.graph_entropy(base=base)
+        self._record_event("graph_entropy", "Graph entropy computed", base=base)
+        return val
+
+    def subgraph_entropy(self, nodes: Iterable, *, base: float = 2.0) -> float:
+        """Wrapper for :meth:`KnowledgeGraph.subgraph_entropy`."""
+
+        val = self.graph.subgraph_entropy(nodes, base=base)
+        self._record_event(
+            "subgraph_entropy",
+            "Subgraph entropy computed",
+            base=base,
+            nodes=list(nodes),
+        )
+        return val
+
     def prototype_subgraph(
         self,
         labels: Dict[str, int],
@@ -1443,6 +1709,17 @@ class DatasetBuilder:
             radius=radius,
         )
         return sub
+
+    def select_mdl_motifs(self, motifs: Iterable[nx.Graph]) -> List[nx.Graph]:
+        """Wrapper for :meth:`KnowledgeGraph.select_mdl_motifs`."""
+
+        selected = self.graph.select_mdl_motifs(motifs)
+        self._record_event(
+            "select_mdl_motifs",
+            "Motifs selected via MDL",
+            count=len(selected),
+        )
+        return selected
 
     def laplacian_spectrum(self, normed: bool = True) -> np.ndarray:
         """Wrapper for :meth:`KnowledgeGraph.laplacian_spectrum`."""
@@ -2741,6 +3018,8 @@ class DatasetBuilder:
         auto_fractal: bool = True,
         radii: Iterable[int] = (1, 2, 3),
         max_levels: int = 5,
+        mdl_radii: Iterable[int] | None = None,
+        ib_beta: float = 1.0,
     ) -> List[Dict[str, Any]]:
         """Return prompt records with fractal and perception metadata.
 
@@ -2763,6 +3042,16 @@ class DatasetBuilder:
             # annotate nodes in-place so the metadata is available for export
             self.annotate_mdl_levels(radii, max_levels=max_levels)
 
+        mdl_radii = tuple(mdl_radii or radii)
+        _, counts = self.graph.box_counting_dimension(mdl_radii)
+        from ..analysis.fractal import mdl_value
+
+        mdl_gain = mdl_value(counts)
+
+        from ..utils.gitinfo import get_commit_hash
+
+        commit = get_commit_hash()
+
         signature = self.graph.topological_signature(max_dim=1)
         sig_hash = hashlib.md5(json.dumps(signature, sort_keys=True).encode()).hexdigest()
         data: List[Dict[str, Any]] = []
@@ -2777,9 +3066,18 @@ class DatasetBuilder:
                 "topo_signature": signature,
                 "signature_hash": sig_hash,
                 "prompt_hash": hashlib.md5(prompt_text.encode()).hexdigest(),
+                "git_commit": commit,
+                "mdl_gain": mdl_gain,
+                "ib_beta": ib_beta,
             }
             data.append(record)
-        self._record_event("export_prompts", "Prompt data exported")
+        self._record_event(
+            "export_prompts",
+            "Prompt data exported",
+            commit=commit,
+            mdl_gain=mdl_gain,
+            ib_beta=ib_beta,
+        )
         return data
 
     @persist_after

--- a/datacreek/core/knowledge_graph.py
+++ b/datacreek/core/knowledge_graph.py
@@ -1598,6 +1598,54 @@ class KnowledgeGraph:
         for node, vec in emb.items():
             self.graph.nodes[node]["graphwave_embedding"] = vec.tolist()
 
+    def graphwave_entropy(self) -> float:
+        """Return differential entropy of stored GraphWave embeddings."""
+
+        feats = {
+            n: data["graphwave_embedding"]
+            for n, data in self.graph.nodes(data=True)
+            if "graphwave_embedding" in data
+        }
+        if not feats:
+            return 0.0
+        from ..analysis.fractal import graphwave_entropy as _ge
+
+        return _ge(feats)
+
+    def ensure_graphwave_entropy(
+        self,
+        threshold: float,
+        *,
+        scales: Iterable[float] = (0.5, 1.0),
+        num_points: int = 10,
+    ) -> float:
+        """Ensure GraphWave entropy above ``threshold``.
+
+        If the current entropy is below ``threshold``, embeddings are recomputed
+        with slight random noise added to ``scales``.
+        """
+
+        H = self.graphwave_entropy()
+        if H < threshold:
+            noisy = [float(s) + np.random.uniform(-0.1, 0.1) for s in scales]
+            self.compute_graphwave_embeddings(noisy, num_points)
+            H = self.graphwave_entropy()
+        return H
+
+    def embedding_entropy(self, node_attr: str = "embedding") -> float:
+        """Return differential entropy of vectors stored under ``node_attr``."""
+
+        feats = {
+            n: data[node_attr]
+            for n, data in self.graph.nodes(data=True)
+            if node_attr in data
+        }
+        if not feats:
+            return 0.0
+        from ..analysis.fractal import embedding_entropy as _ee
+
+        return _ee(feats)
+
     def compute_poincare_embeddings(
         self,
         dim: int = 2,
@@ -1677,6 +1725,51 @@ class KnowledgeGraph:
                 self.graph.nodes[node]["hyperbolic_embedding"] = vec.tolist()
                 results[node] = vec.tolist()
         return results
+
+    def compute_hyper_sagnn_embeddings(
+        self,
+        *,
+        node_attr: str = "embedding",
+        edge_attr: str = "hyper_sagnn_embedding",
+        embed_dim: int | None = None,
+        seed: int | None = None,
+    ) -> Dict[str, list[float]]:
+        """Compute Hyper-SAGNN-like embeddings for hyperedges.
+
+        Hyperedges are nodes with ``type`` ``"hyperedge"`` connected to their
+        members. Node features are read from ``node_attr`` and combined using a
+        lightweight self-attention mechanism similar to Hyper-SAGNN.
+        """
+
+        import numpy as np
+
+        index: Dict[str, int] = {}
+        features: List[np.ndarray] = []
+        for node, data in self.graph.nodes(data=True):
+            if node_attr in data:
+                index[node] = len(features)
+                features.append(np.asarray(data[node_attr], dtype=float))
+
+        if not features:
+            raise ValueError("no node features found")
+
+        hyper_list: List[tuple[str, List[int]]] = []
+        for node, data in self.graph.nodes(data=True):
+            if data.get("type") == "hyperedge":
+                members = [index[v] for _, v in self.graph.edges(node) if v in index]
+                if members:
+                    hyper_list.append((node, members))
+
+        from ..analysis.hypergraph import hyper_sagnn_embeddings as _hs
+
+        embeddings = _hs([m for _, m in hyper_list], np.stack(features), embed_dim=embed_dim, seed=seed)
+
+        result: Dict[str, list[float]] = {}
+        for (node, _), vec in zip(hyper_list, embeddings):
+            self.graph.nodes[node][edge_attr] = vec.astype(float).tolist()
+            result[node] = vec.astype(float).tolist()
+
+        return result
 
     def compute_graphsage_embeddings(
         self,
@@ -1868,6 +1961,23 @@ class KnowledgeGraph:
             burn_in=burn_in,
         )
 
+    def prune_embeddings(self, *, tol: float = 1e-3) -> Dict[str, int]:
+        """Cluster embeddings using :func:`fractal_net_prune`."""
+
+        from ..analysis.fractal import fractal_net_prune as _fp
+
+        feats = {
+            n: np.asarray(data.get("embedding"), dtype=float)
+            for n, data in self.graph.nodes(data=True)
+            if "embedding" in data
+        }
+        if not feats:
+            return {}
+        _, mapping = _fp(feats, tol=tol)
+        for node, idx in mapping.items():
+            self.graph.nodes[node]["pruned_class"] = int(idx)
+        return {str(n): int(c) for n, c in mapping.items()}
+
     # ------------------------------------------------------------------
     # Fractal and topological metrics
     # ------------------------------------------------------------------
@@ -1969,6 +2079,22 @@ class KnowledgeGraph:
         )
         return {str(n): vec.tolist() for n, vec in result.items()}
 
+    def sheaf_cohomology(self, edge_attr: str = "sheaf_sign", tol: float = 1e-5) -> int:
+        """Return dimension of :math:`H^1` for the sheaf defined by ``edge_attr``."""
+
+        from ..analysis.sheaf import sheaf_first_cohomology as _sfc
+
+        return _sfc(self.graph, edge_attr=edge_attr, tol=tol)
+
+    def resolve_sheaf_obstruction(
+        self, *, edge_attr: str = "sheaf_sign", max_iter: int = 10
+    ) -> int:
+        """Resolve cohomological obstructions by flipping edge signs."""
+
+        from ..analysis.sheaf import resolve_sheaf_obstruction as _rso
+
+        return _rso(self.graph, edge_attr=edge_attr, max_iter=max_iter)
+
     def path_to_text(self, path: Iterable) -> str:
         """Return a textual description for ``path`` using node attributes."""
 
@@ -2040,6 +2166,20 @@ class KnowledgeGraph:
         }
         return _gib(feats, labels, beta=beta)
 
+    def graph_entropy(self, *, base: float = 2.0) -> float:
+        """Return Shannon entropy of the degree distribution."""
+
+        from ..analysis.information import graph_entropy as _ge
+
+        return _ge(self.graph.to_undirected(), base=base)
+
+    def subgraph_entropy(self, nodes: Iterable, *, base: float = 2.0) -> float:
+        """Return entropy of node degrees restricted to ``nodes``."""
+
+        from ..analysis.information import subgraph_entropy as _se
+
+        return _se(self.graph.to_undirected(), nodes, base=base)
+
     def prototype_subgraph(
         self,
         labels: Dict[str, int],
@@ -2058,6 +2198,13 @@ class KnowledgeGraph:
         }
         sub = _ps(self.graph.to_undirected(), feats, labels, class_id, radius=radius)
         return sub
+
+    def select_mdl_motifs(self, motifs: Iterable[nx.Graph]) -> List[nx.Graph]:
+        """Return motifs that reduce description length."""
+
+        from ..analysis.information import select_mdl_motifs as _sel
+
+        return _sel(self.graph.to_undirected(), motifs)
 
     def laplacian_spectrum(self, normed: bool = True) -> np.ndarray:
         """Return the Laplacian eigenvalues of the graph."""
@@ -2327,6 +2474,78 @@ class KnowledgeGraph:
         emb_dim, _ = embedding_box_counting_dimension(coords, radii)
         return abs(graph_dim - emb_dim)
 
+    def embedding_box_counting_dimension(
+        self, node_attr: str, radii: Iterable[float]
+    ) -> tuple[float, list[tuple[float, int]]]:
+        """Return fractal dimension of stored embeddings.
+
+        Parameters
+        ----------
+        node_attr:
+            Node attribute containing embedding vectors.
+        radii:
+            Iterable of ball radii used for the box counting.
+
+        Returns
+        -------
+        tuple
+            ``(dimension, counts)`` where ``counts`` records the number of
+            covering balls for each radius.
+        """
+
+        coords = {
+            n: self.graph.nodes[n].get(node_attr)
+            for n in self.graph.nodes
+            if self.graph.nodes[n].get(node_attr) is not None
+        }
+        if not coords:
+            return float("nan"), []
+        from ..analysis.fractal import embedding_box_counting_dimension as _ebcd
+
+        return _ebcd(coords, radii)
+
+    def detect_automorphisms(self, max_count: int = 10) -> List[Dict[str, str]]:
+        """Return up to ``max_count`` automorphisms as node mappings."""
+
+        from ..analysis.symmetry import automorphisms as _auto
+
+        autos = _auto(self.graph.to_undirected(), max_count=max_count)
+        return [{str(k): str(v) for k, v in a.items()} for a in autos]
+
+    def automorphism_group_order(self, max_count: int = 100) -> int:
+        """Return the number of automorphisms explored."""
+
+        from ..analysis.symmetry import automorphism_group_order as _ago
+
+        return _ago(self.graph.to_undirected(), max_count=max_count)
+
+    def quotient_by_symmetry(self, *, max_count: int = 10) -> tuple[nx.Graph, Dict[str, int]]:
+        """Return quotient graph collapsing automorphism orbits."""
+
+        from ..analysis.symmetry import automorphism_orbits, quotient_graph
+
+        orbits = automorphism_orbits(self.graph.to_undirected(), max_count=max_count)
+        q, mapping = quotient_graph(self.graph.to_undirected(), orbits)
+        str_map = {str(n): int(m) for n, m in mapping.items()}
+        return q, str_map
+
+    def mapper_nerve(self, radius: int) -> tuple[nx.Graph, list[set[str]]]:
+        """Return the Mapper nerve of the graph with balls of ``radius``."""
+
+        from ..analysis.mapper import mapper_nerve as _mn
+
+        nerve, cover = _mn(self.graph.to_undirected(), radius)
+        str_cover = [{str(n) for n in c} for c in cover]
+        return nerve, str_cover
+
+    def inverse_mapper(self, nerve: nx.Graph, cover: Iterable[Iterable[str]]) -> nx.Graph:
+        """Reconstruct a graph from ``nerve`` and ``cover`` sets."""
+
+        from ..analysis.mapper import inverse_mapper as _im
+
+        sets = [{n for n in c} for c in cover]
+        return _im(nerve, sets)
+
     def fractalize_level(self, radius: int) -> tuple[nx.Graph, Dict[str, int]]:
         """Return a coarse-grained graph via box covering."""
 
@@ -2415,6 +2634,61 @@ class KnowledgeGraph:
                 if box in mapping:
                     current_map[node] = mapping[box]
                     self.graph.nodes[node]["fractal_level"] = level
+
+    # ------------------------------------------------------------------
+    # Graph generation utilities
+    # ------------------------------------------------------------------
+
+    def generate_graph_rnn_like(self, num_nodes: int, num_edges: int) -> nx.Graph:
+        """Return a random graph mimicking GraphRNN output."""
+
+        from ..analysis.generation import generate_graph_rnn_like as _gg
+
+        return _gg(num_nodes, num_edges)
+
+    def generate_graph_rnn(
+        self, num_nodes: int, num_edges: int, *, p: float = 0.5, directed: bool = False
+    ) -> nx.Graph:
+        """Return a simple sequential GraphRNN-style graph."""
+
+        from ..analysis.generation import generate_graph_rnn as _gr
+
+        return _gr(num_nodes, num_edges, p=p, directed=directed)
+
+    def generate_graph_rnn_stateful(
+        self,
+        num_nodes: int,
+        num_edges: int,
+        *,
+        hidden_dim: int = 8,
+        seed: int | None = None,
+    ) -> nx.DiGraph:
+        """Return a directed graph from a tiny stateful RNN generator."""
+
+        from ..analysis.generation import generate_graph_rnn_stateful as _grs
+
+        return _grs(num_nodes, num_edges, hidden_dim=hidden_dim, seed=seed)
+
+    def generate_graph_rnn_sequential(
+        self,
+        num_nodes: int,
+        num_edges: int,
+        *,
+        hidden_dim: int = 8,
+        seed: int | None = None,
+        directed: bool = True,
+    ) -> nx.Graph:
+        """Return a graph using a sequential RNN-style generator."""
+
+        from ..analysis.generation import generate_graph_rnn_sequential as _grsq
+
+        return _grsq(
+            num_nodes,
+            num_edges,
+            hidden_dim=hidden_dim,
+            seed=seed,
+            directed=directed,
+        )
 
     # ------------------------------------------------------------------
     # Quality checks inspired by Neo4j GDS

--- a/datacreek/core/knowledge_graph.py
+++ b/datacreek/core/knowledge_graph.py
@@ -1635,11 +1635,7 @@ class KnowledgeGraph:
     def embedding_entropy(self, node_attr: str = "embedding") -> float:
         """Return differential entropy of vectors stored under ``node_attr``."""
 
-        feats = {
-            n: data[node_attr]
-            for n, data in self.graph.nodes(data=True)
-            if node_attr in data
-        }
+        feats = {n: data[node_attr] for n, data in self.graph.nodes(data=True) if node_attr in data}
         if not feats:
             return 0.0
         from ..analysis.fractal import embedding_entropy as _ee
@@ -1762,7 +1758,9 @@ class KnowledgeGraph:
 
         from ..analysis.hypergraph import hyper_sagnn_embeddings as _hs
 
-        embeddings = _hs([m for _, m in hyper_list], np.stack(features), embed_dim=embed_dim, seed=seed)
+        embeddings = _hs(
+            [m for _, m in hyper_list], np.stack(features), embed_dim=embed_dim, seed=seed
+        )
 
         result: Dict[str, list[float]] = {}
         for (node, _), vec in zip(hyper_list, embeddings):

--- a/datacreek/utils/__init__.py
+++ b/datacreek/utils/__init__.py
@@ -16,6 +16,7 @@ from .config import (
     merge_configs,
 )
 from .dataset_cleanup import deduplicate_pairs
+from .gitinfo import get_commit_hash
 from .graph_text import graph_to_text, neighborhood_to_sentence, subgraph_to_text
 from .llm_processing import (
     convert_to_conversation_format,
@@ -67,6 +68,7 @@ __all__ = [
     "convert_to_conversation_format",
     "qa_pairs_to_records",
     "deduplicate_pairs",
+    "get_commit_hash",
     "extract_facts",
     "extract_entities",
     "decode_hash",

--- a/datacreek/utils/gitinfo.py
+++ b/datacreek/utils/gitinfo.py
@@ -1,0 +1,11 @@
+import subprocess
+from pathlib import Path
+
+
+def get_commit_hash() -> str:
+    """Return the current git commit hash or ``"unknown"``."""
+    try:
+        root = Path(__file__).resolve().parents[1]
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root).decode().strip()
+    except Exception:
+        return "unknown"

--- a/tests/test_hypergraph.py
+++ b/tests/test_hypergraph.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+from datacreek.analysis.hypergraph import hyper_sagnn_embeddings
+from datacreek.core.dataset import DatasetBuilder
+from datacreek.pipelines import DatasetType
+
+
+def test_hyper_sagnn_embeddings_shape():
+    edges = [[0, 1], [1, 2, 3]]
+    feats = np.arange(12).reshape(4, 3).astype(float)
+    emb = hyper_sagnn_embeddings(edges, feats, embed_dim=4, seed=0)
+    assert emb.shape == (2, 4)
+
+
+def test_dataset_hyper_sagnn_wrapper():
+    ds = DatasetBuilder(DatasetType.TEXT)
+    ds.add_document("d", source="s")
+    ds.add_chunk("d", "a", "x")
+    ds.add_chunk("d", "b", "y")
+    ds.add_chunk("d", "c", "z")
+    ds.add_hyperedge("h1", ["a", "b", "c"])
+
+    for idx, n in enumerate(["a", "b", "c"]):
+        ds.graph.graph.nodes[n]["embedding"] = [float(idx), 0.0]
+
+    result = ds.compute_hyper_sagnn_embeddings(embed_dim=2, seed=0)
+    assert "h1" in result
+    assert len(result["h1"]) == 2
+    assert any(e.operation == "compute_hyper_sagnn_embeddings" for e in ds.events)

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,0 +1,29 @@
+import networkx as nx
+from datacreek.analysis.mapper import mapper_nerve, inverse_mapper
+from datacreek.core.dataset import DatasetBuilder
+from datacreek.pipelines import DatasetType
+
+
+def test_mapper_functions():
+    g = nx.path_graph(5)
+    nerve, cover = mapper_nerve(g, radius=1)
+    assert nerve.number_of_nodes() == len(cover)
+    recon = inverse_mapper(nerve, cover)
+    for u, v in g.edges():
+        assert recon.has_edge(u, v)
+
+
+def test_dataset_mapper_wrappers():
+    ds = DatasetBuilder(DatasetType.TEXT)
+    ds.add_document("d", source="s")
+    for i in range(5):
+        ds.add_chunk("d", f"c{i}", str(i))
+    for i in range(4):
+        ds.graph.graph.add_edge(f"c{i}", f"c{i+1}")
+    nerve, cover = ds.mapper_nerve(radius=1)
+    assert len(cover) == nerve.number_of_nodes()
+    g = ds.inverse_mapper(nerve, cover)
+    for u, v in ds.graph.graph.edges():
+        assert g.has_edge(u, v)
+    assert any(e.operation == "mapper_nerve" for e in ds.events)
+    assert any(e.operation == "inverse_mapper" for e in ds.events)

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,5 +1,6 @@
 import networkx as nx
-from datacreek.analysis.mapper import mapper_nerve, inverse_mapper
+
+from datacreek.analysis.mapper import inverse_mapper, mapper_nerve
 from datacreek.core.dataset import DatasetBuilder
 from datacreek.pipelines import DatasetType
 

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -1,7 +1,7 @@
+from datacreek.analysis.fractal import fractal_net_prune
 from datacreek.core.dataset import DatasetBuilder
 from datacreek.core.knowledge_graph import KnowledgeGraph
 from datacreek.pipelines import DatasetType
-from datacreek.analysis.fractal import fractal_net_prune
 
 
 def test_prune_sources_kg():

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -1,6 +1,7 @@
 from datacreek.core.dataset import DatasetBuilder
 from datacreek.core.knowledge_graph import KnowledgeGraph
 from datacreek.pipelines import DatasetType
+from datacreek.analysis.fractal import fractal_net_prune
 
 
 def test_prune_sources_kg():
@@ -28,3 +29,19 @@ def test_prune_sources_wrapper():
     assert removed == 2
     assert ds.search_documents("doc1") == []
     assert ds.search_documents("doc2") == ["doc2"]
+
+
+def test_fractal_net_prune():
+    emb = {"a": [0.0, 0.0], "b": [0.02, 0.0], "c": [1.0, 0.0]}
+    pruned, mapping = fractal_net_prune(emb, tol=0.05)
+    assert len(pruned) == 2
+    assert mapping["a"] == mapping["b"]
+
+
+def test_prune_embeddings_wrapper():
+    ds = DatasetBuilder(DatasetType.TEXT)
+    for node, vec in {"a": [0.0, 0.0], "b": [0.02, 0.0], "c": [1.0, 0.0]}.items():
+        ds.graph.graph.add_node(node, embedding=vec)
+    mapping = ds.prune_embeddings(tol=0.05)
+    assert len(set(mapping.values())) == 2
+    assert any(e.operation == "prune_embeddings" for e in ds.events)

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -1,0 +1,35 @@
+import networkx as nx
+from datacreek.analysis.symmetry import automorphisms, automorphism_orbits, quotient_graph
+from datacreek.analysis.symmetry import automorphism_group_order
+from datacreek.core.dataset import DatasetBuilder
+from datacreek.pipelines import DatasetType
+
+
+def test_symmetry_functions():
+    g = nx.cycle_graph(4)
+    autos = automorphisms(g, max_count=2)
+    assert autos and isinstance(autos[0], dict)
+    assert automorphism_group_order(g, max_count=3) >= 1
+    orbits = automorphism_orbits(g, max_count=2)
+    assert any(len(o) > 1 for o in orbits)
+    q, mapping = quotient_graph(g, orbits)
+    assert q.number_of_nodes() <= g.number_of_nodes()
+    assert mapping
+
+
+def test_dataset_symmetry_wrappers():
+    ds = DatasetBuilder(DatasetType.QA)
+    ds.add_document("d", source="s")
+    ds.add_chunk("d", "c1", "a")
+    ds.add_chunk("d", "c2", "b")
+    ds.add_chunk("d", "c3", "c")
+    ds.graph.graph.add_edge("c1", "c2")
+    ds.graph.graph.add_edge("c2", "c3")
+    autos = ds.detect_automorphisms(max_count=1)
+    assert isinstance(autos, list)
+    order = ds.automorphism_group_order(max_count=2)
+    assert order >= 1
+    q, mapping = ds.quotient_by_symmetry(max_count=1)
+    assert q.number_of_nodes() <= ds.graph.graph.number_of_nodes()
+    assert mapping
+

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -1,6 +1,11 @@
 import networkx as nx
-from datacreek.analysis.symmetry import automorphisms, automorphism_orbits, quotient_graph
-from datacreek.analysis.symmetry import automorphism_group_order
+
+from datacreek.analysis.symmetry import (
+    automorphism_group_order,
+    automorphism_orbits,
+    automorphisms,
+    quotient_graph,
+)
 from datacreek.core.dataset import DatasetBuilder
 from datacreek.pipelines import DatasetType
 
@@ -32,4 +37,3 @@ def test_dataset_symmetry_wrappers():
     q, mapping = ds.quotient_by_symmetry(max_count=1)
     assert q.number_of_nodes() <= ds.graph.graph.number_of_nodes()
     assert mapping
-


### PR DESCRIPTION
## Summary
- add `embedding_box_counting_dimension` method on knowledge graphs
- wrap the new functionality in DatasetBuilder and expose via APIs
- update analysis module exports
- include tests for the new wrappers
- implement graph entropy utilities and wrappers
- add subgraph entropy helpers with DatasetBuilder and KnowledgeGraph wrappers

## Testing
- `pip install -e . --no-deps`
- `pip install networkx numpy redis requests neo4j pyyaml pydantic rich python-dateutil sqlalchemy fakeredis node2vec fastapi starlette gensim joblib smart-open tqdm scipy wrapt scikit-learn`
- `pytest tests/test_symmetry.py tests/test_mapper.py tests/test_prune.py tests/test_knowledge_graph.py::test_graph_entropy_method tests/test_knowledge_graph.py::test_subgraph_entropy_method tests/test_dataset_builder.py::test_graph_entropy_wrapper tests/test_dataset_builder.py::test_subgraph_entropy_wrapper tests/test_dataset_builder.py::test_export_prompts_auto_fractal -q`


------
https://chatgpt.com/codex/tasks/task_e_686da0893514832f85511f469071bdd5