### PR TITLE
Add pipeline orchestrator

### DIFF
--- a/datacreek/__init__.py
+++ b/datacreek/__init__.py
@@ -11,6 +11,7 @@ __version__ = "0.0.2"
 __all__: list[str] = [
     "__version__",
     "DatasetBuilder",
+    "Atom",
     "DatasetType",
     "GenerationPipeline",
     "TrainingGoal",
@@ -89,6 +90,7 @@ __all__: list[str] = [
     "validate_output",
     "betti_number",
     "coverage_stats",
+    "invariants_dashboard",
     "mapper_nerve",
     "inverse_mapper",
     "fractal_net_prune",
@@ -103,6 +105,16 @@ __all__: list[str] = [
     "automorphism_group_order",
     "quotient_by_symmetry",
     "prune_embeddings",
+    "ingestion_layer",
+    "quality_layer",
+    "fractal_layer",
+    "embedding_layer",
+    "generation_layer",
+    "compression_layer",
+    "topological_perception_layer",
+    "information_layer",
+    "export_layer",
+    "orchestrator",
 ]
 
 if TYPE_CHECKING:  # pragma: no cover - used for type checking only
@@ -166,6 +178,10 @@ def __getattr__(name: str):
         from .core.dataset import DatasetBuilder as _DB
 
         return _DB
+    if name == "Atom":
+        from .core.dataset import Atom as _Atom
+
+        return _Atom
     if name in {"ingest_file", "to_kg", "ingest_into_dataset"}:
         from .core.ingest import ingest_into_dataset as _ingest_into_dataset
         from .core.ingest import process_file as _ingest_file
@@ -361,6 +377,42 @@ def __getattr__(name: str):
         from .core.dataset import DatasetBuilder
 
         return DatasetBuilder.optimize_topology_iterative
+    if name == "quality_layer":
+        from .core.dataset import DatasetBuilder
+
+        return DatasetBuilder.run_quality_layer
+    if name == "fractal_layer":
+        from .core.dataset import DatasetBuilder
+
+        return DatasetBuilder.run_fractal_layer
+    if name == "embedding_layer":
+        from .core.dataset import DatasetBuilder
+
+        return DatasetBuilder.run_embedding_layer
+    if name == "generation_layer":
+        from .core.dataset import DatasetBuilder
+
+        return DatasetBuilder.run_generation_layer
+    if name == "topological_perception_layer":
+        from .core.dataset import DatasetBuilder
+
+        return DatasetBuilder.run_topological_perception_layer
+    if name == "compression_layer":
+        from .core.dataset import DatasetBuilder
+
+        return DatasetBuilder.run_compression_layer
+    if name == "information_layer":
+        from .core.dataset import DatasetBuilder
+
+        return DatasetBuilder.run_information_layer
+    if name == "export_layer":
+        from .core.dataset import DatasetBuilder
+
+        return DatasetBuilder.run_export_layer
+    if name == "orchestrator":
+        from .core.dataset import DatasetBuilder
+
+        return DatasetBuilder.run_orchestrator
     if name == "poincare_embedding":
         from .analysis.fractal import poincare_embedding as _peb
 
@@ -465,6 +517,10 @@ def __getattr__(name: str):
         from .core.dataset import DatasetBuilder as _DB
 
         return _DB.coverage_stats
+    if name == "invariants_dashboard":
+        from .core.dataset import DatasetBuilder as _DB
+
+        return _DB.invariants_dashboard
     if name == "mapper_nerve":
         from .analysis.mapper import mapper_nerve as _mn
 
@@ -517,6 +573,10 @@ def __getattr__(name: str):
         from .core.dataset import DatasetBuilder as _DB
 
         return _DB.prune_embeddings
+    if name == "ingestion_layer":
+        from .core.dataset import DatasetBuilder
+
+        return DatasetBuilder.run_ingestion_layer
     if name in {"detect_automorphisms", "quotient_by_symmetry", "automorphism_group_order"}:
         from .core.dataset import DatasetBuilder as _DB
 

--- a/datacreek/analysis/information.py
+++ b/datacreek/analysis/information.py
@@ -71,6 +71,8 @@ def prototype_subgraph(
     X = np.stack([features[n] for n in nodes])
     y = np.array([labels[n] for n in nodes])
 
+    from sklearn.linear_model import LogisticRegression
+
     model = LogisticRegression(max_iter=1000, n_jobs=1)
     model.fit(X, y)
     probs = model.predict_proba(X)

--- a/datacreek/core/knowledge_graph.py
+++ b/datacreek/core/knowledge_graph.py
@@ -10,6 +10,7 @@ import networkx as nx
 import numpy as np
 import requests
 from dateutil import parser
+from datetime import datetime, timezone
 
 try:
     from neo4j import Driver, GraphDatabase
@@ -377,6 +378,8 @@ class KnowledgeGraph:
         source: str | None = None,
         *,
         page: int | None = None,
+        lang: str | None = None,
+        timestamp: datetime | None = None,
         emotion: str | None = None,
         modality: str | None = None,
         entities: list[str] | None = None,
@@ -400,6 +403,8 @@ class KnowledgeGraph:
             element_type=element_type,
             source=source,
             page=page,
+            lang=lang,
+            timestamp=(timestamp or datetime.now(timezone.utc)).isoformat(),
         )
         if emotion:
             self.graph.nodes[atom_id]["emotion"] = emotion


### PR DESCRIPTION
## Summary
- implement a simple `run_orchestrator` method to execute all pipeline layers in sequence
- expose the orchestrator via the package API
- test orchestrator end-to-end
- fix LogisticRegression import in prototype subgraph

## Testing
- `PYTHONPATH=$PWD pytest tests/test_dataset_builder.py::test_run_orchestrator_wrapper -q`
- `PYTHONPATH=$PWD pytest tests/test_dataset_builder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e17470d74832f8e6263823c92be4b