### PR TITLE
Fix config k_min and persist fractal metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Tasks Checklist
+
+- [ ] Add `cleanup.k_min` to configs and code; ensure `gds_quality_check` uses this setting.
+- [ ] Update `cleanup.hub_deg` default to 1000 in configuration.
+- [ ] Write `fractal_dim` and `fractal_sigma` to Neo4j after running `bootstrap_db`.
+
+## Notes
+- Tests should cover new behaviour for saving fractal metrics with a driver.
+- Remember to run `pytest -q` before committing.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -6,10 +6,10 @@ ingest:
 cleanup:
   tau: 5           # triangle threshold
   sigma: 0.95      # node similarity threshold
-  k: 4             # min component size
+  k_min: 5         # min component size
   lp_sigma: 0.3    # Hyper-AA score threshold
   lp_topk: 5
-  hub_deg: 500     # hub tagging degree threshold
+  hub_deg: 1000    # hub tagging degree threshold
 tpl:
   eps_w1: 0.05     # Wasserstein-1 cutoff
   rnn_size: 128    # GraphRNN-Lite subgraph size

--- a/datacreek/core/dataset.py
+++ b/datacreek/core/dataset.py
@@ -3366,7 +3366,9 @@ class DatasetBuilder:
             Whether to rely on Neo4j. ``None`` means auto-detect based on
             ``neo4j_driver``.
         min_component_size:
-            Components smaller than this size are removed.
+            Components smaller than this size are removed. ``None`` loads the
+            default from ``configs/default.yaml`` (``cleanup.k_min``) so
+            autotuning can adjust the parameter.
         similarity_threshold:
             Duplicate nodes above this value are merged.
         triangle_threshold:
@@ -4228,7 +4230,7 @@ class DatasetBuilder:
 
         cfg = load_config()
         cleanup_cfg = cfg.get("cleanup", {})
-        min_component_size = cleanup_cfg.get("k", min_component_size)
+        min_component_size = cleanup_cfg.get("k_min", min_component_size)
         similarity_threshold = cleanup_cfg.get("sigma", similarity_threshold)
         triangle_threshold = cleanup_cfg.get("tau", triangle_threshold)
 

--- a/datacreek/core/knowledge_graph.py
+++ b/datacreek/core/knowledge_graph.py
@@ -4926,7 +4926,7 @@ class KnowledgeGraph:
             Optional dataset label used to filter nodes.
         min_component_size:
             Components smaller than this size are removed. ``None`` loads the
-            default from ``configs/default.yaml`` (``cleanup.k``) so autotuning
+            default from ``configs/default.yaml`` (``cleanup.k_min``) so autotuning
             can adapt it.
         similarity_threshold:
             Cosine similarity above which nodes are flagged as duplicates.
@@ -4958,7 +4958,7 @@ class KnowledgeGraph:
             cfg = load_config()
             cleanup_cfg = cfg.get("cleanup", {})
             if min_component_size is None:
-                min_component_size = int(cleanup_cfg.get("k", 2))
+                min_component_size = int(cleanup_cfg.get("k_min", 2))
             if similarity_threshold is None:
                 similarity_threshold = float(cleanup_cfg.get("sigma", 0.95))
             if triangle_threshold is None:

--- a/tests/test_bootstrap_db.py
+++ b/tests/test_bootstrap_db.py
@@ -11,3 +11,38 @@ def test_bootstrap_db_records_properties():
     assert len(dims) == 3
     assert "fractal_dim" in kg.graph.graph
     assert "fractal_sigma" in kg.graph.graph
+
+
+class DummySession:
+    def __init__(self, log):
+        self.log = log
+
+    def run(self, query, **params):
+        self.log.append(query)
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummyDriver:
+    def __init__(self):
+        self.log = []
+
+    def session(self):
+        return DummySession(self.log)
+
+
+def test_bootstrap_db_writes_neo4j(monkeypatch):
+    kg = KnowledgeGraph()
+    kg.graph.add_edge("a", "b")
+    monkeypatch.setattr(kg, "to_neo4j", lambda *a, **k: None)
+    driver = DummyDriver()
+    monkeypatch.setattr(
+        "datacreek.core.fractal.colour_box_dimension", lambda g, r: (1.0, None)
+    )
+    bootstrap_db(kg, n=2, ratio=0.5, driver=driver, dataset="tmp")
+    assert any("GraphMeta" in q for q in driver.log)


### PR DESCRIPTION
## Summary
- add agent instructions
- support `k_min` and update `hub_deg` in default config
- load `cleanup.k_min` in dataset and knowledge graph
- write fractal metrics to Neo4j in `bootstrap_db`
- test Neo4j persistence for bootstrap_db

## Testing
- `pre-commit run --files configs/default.yaml datacreek/core/knowledge_graph.py datacreek/core/dataset.py datacreek/core/fractal.py AGENTS.md tests/test_bootstrap_db.py tests/test_bootstrap_sigma.py`
- `PYTHONPATH=$PWD pytest tests/test_bootstrap_db.py tests/test_bootstrap_sigma.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f62e7630832fa8268c80cebbe8c5