### PR TITLE
Add LakeFS schema registry, training ETA metric, safety filter, dynamic SNR gating, hypergraph power iteration, fractal dimension callback, checkpoint pruning, alias-aware reward, paraphrase contradiction filter, and tokenizer snapshot

### DIFF
--- a/.lakefs/schema.yaml
+++ b/.lakefs/schema.yaml
@@ -1,0 +1,8 @@
+version: 1
+fields:
+  - name: id
+    type: string
+  - name: prompt
+    type: string
+  - name: completion
+    type: string

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,3 +54,9 @@ repos:
         language: python
         additional_dependencies: ["radon"]
         pass_filenames: false
+      - id: lakefs-schema
+        name: lakefs schema compatibility
+        entry: python scripts/check_schema_break.py
+        language: python
+        files: "^\\.lakefs/schema\\.yaml$"
+        additional_dependencies: ["pyyaml"]

--- a/datacreek/analysis/__init__.py
+++ b/datacreek/analysis/__init__.py
@@ -267,7 +267,13 @@ def __getattr__(name: str):  # pragma: no cover - dynamic lazy imports
         from . import symmetry as _s
 
         return getattr(_s, name)
-    if name in {"mapper_nerve", "inverse_mapper", "mapper_full", "mapper_to_json", "autotune_mapper_overlap"}:
+    if name in {
+        "mapper_nerve",
+        "inverse_mapper",
+        "mapper_full",
+        "mapper_to_json",
+        "autotune_mapper_overlap",
+    }:
         from . import mapper as _m
 
         return getattr(_m, name)
@@ -401,10 +407,8 @@ def __getattr__(name: str):  # pragma: no cover - dynamic lazy imports
         from .hybrid_ann import search_hnsw_pq as _hpq
         from .hypergraph_conv import chebyshev_conv as _cc
         from .hypergraph_conv import hypergraph_laplacian as _hl
-        from .sheaf_hyper_bridge import (
-            sheaf_hyper_bridge_score as _shb,
-            top_k_incoherent as _tki,
-        )
+        from .sheaf_hyper_bridge import sheaf_hyper_bridge_score as _shb
+        from .sheaf_hyper_bridge import top_k_incoherent as _tki
         from .tda_fast import fast_persistence_diagrams as _fpd
         from .tda_vectorize import augment_embeddings_with_persistence as _ap
         from .tda_vectorize import betti_curve as _bc

--- a/datacreek/analysis/__init__.py
+++ b/datacreek/analysis/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "graphwave_embedding",
     "embedding_box_counting_dimension",
     "latent_box_dimension",
+    "fractal_dim_embedding",
     "colour_box_dimension",
     "mdl_optimal_radius",
     "persistence_diagrams",
@@ -55,6 +56,7 @@ __all__ = [
     "inverse_mapper",
     "mapper_full",
     "mapper_to_json",
+    "autotune_mapper_overlap",
     "bootstrap_db",
     "bootstrap_sigma_db",
     "fractal_net_prune",
@@ -70,6 +72,7 @@ __all__ = [
     "fp8_quantize",
     "fp8_dequantize",
     "online_pca_reduce",
+    "reduce_pca",
     "fractal_encoder",
     "mdl_description_length",
     "select_mdl_motifs",
@@ -120,6 +123,7 @@ __all__ = [
     "chebyshev_heat_kernel_gpu",
     "fast_persistence_diagrams",
     "sheaf_hyper_bridge_score",
+    "top_k_incoherent",
     "explain_to_svg",
 ]
 
@@ -160,6 +164,7 @@ def __getattr__(name: str):  # pragma: no cover - dynamic lazy imports
         "embedding_entropy",
         "embedding_box_counting_dimension",
         "latent_box_dimension",
+        "fractal_dim_embedding",
         "colour_box_dimension",
         "bootstrap_db",
         "bootstrap_sigma_db",
@@ -262,7 +267,7 @@ def __getattr__(name: str):  # pragma: no cover - dynamic lazy imports
         from . import symmetry as _s
 
         return getattr(_s, name)
-    if name in {"mapper_nerve", "inverse_mapper", "mapper_full", "mapper_to_json"}:
+    if name in {"mapper_nerve", "inverse_mapper", "mapper_full", "mapper_to_json", "autotune_mapper_overlap"}:
         from . import mapper as _m
 
         return getattr(_m, name)
@@ -380,11 +385,13 @@ def __getattr__(name: str):  # pragma: no cover - dynamic lazy imports
         "betti_curve",
         "diagram_entropy",
         "augment_embeddings_with_persistence",
+        "reduce_pca",
         "hypergraph_laplacian",
         "chebyshev_conv",
         "chebyshev_heat_kernel_gpu",
         "fast_persistence_diagrams",
         "sheaf_hyper_bridge_score",
+        "top_k_incoherent",
     }:
         from .chebyshev_diag import chebyshev_diag_hutchpp as _cdh
         from .graphwave_bandwidth import estimate_lambda_max as _el
@@ -394,7 +401,10 @@ def __getattr__(name: str):  # pragma: no cover - dynamic lazy imports
         from .hybrid_ann import search_hnsw_pq as _hpq
         from .hypergraph_conv import chebyshev_conv as _cc
         from .hypergraph_conv import hypergraph_laplacian as _hl
-        from .sheaf_hyper_bridge import sheaf_hyper_bridge_score as _shb
+        from .sheaf_hyper_bridge import (
+            sheaf_hyper_bridge_score as _shb,
+            top_k_incoherent as _tki,
+        )
         from .tda_fast import fast_persistence_diagrams as _fpd
         from .tda_vectorize import augment_embeddings_with_persistence as _ap
         from .tda_vectorize import betti_curve as _bc
@@ -402,6 +412,7 @@ def __getattr__(name: str):  # pragma: no cover - dynamic lazy imports
         from .tda_vectorize import persistence_image as _pi
         from .tda_vectorize import persistence_landscape as _pl
         from .tda_vectorize import persistence_silhouette as _ps
+        from .tda_vectorize import reduce_pca as _rp
 
         return {
             "estimate_lambda_max": _el,
@@ -415,11 +426,13 @@ def __getattr__(name: str):  # pragma: no cover - dynamic lazy imports
             "betti_curve": _bc,
             "diagram_entropy": _de,
             "augment_embeddings_with_persistence": _ap,
+            "reduce_pca": _rp,
             "hypergraph_laplacian": _hl,
             "chebyshev_conv": _cc,
             "chebyshev_heat_kernel_gpu": _gwk,
             "fast_persistence_diagrams": _fpd,
             "sheaf_hyper_bridge_score": _shb,
+            "top_k_incoherent": _tki,
         }[name]
     if name == "learn_hyperbolic_projection":
         from .hyp_embed import learn_hyperbolic_projection as _lh

--- a/datacreek/analysis/fractal.py
+++ b/datacreek/analysis/fractal.py
@@ -1032,6 +1032,42 @@ def latent_box_dimension(
     return float(slope), counts
 
 
+def fractal_dim_embedding(
+    coords: Mapping[object, Iterable[float]],
+    radii: Iterable[float],
+    *,
+    sample: int = 512,
+) -> float:
+    """Estimate the fractal dimension of embedding coordinates.
+
+    The function applies a box-counting procedure to the embedding vectors and
+    returns the slope of ``\log N_B`` versus ``-\log r`` where ``N_B`` is the
+    number of boxes of radius ``r`` covering the points:
+
+    .. math::
+
+        D_f = \frac{\log N_B(r)}{-\log r}
+
+    Parameters
+    ----------
+    coords:
+        Mapping of node identifiers to embedding vectors.
+    radii:
+        Iterable of cover radii used for the box-counting estimate.
+    sample:
+        Optional number of points to subsample before counting. Defaults to
+        ``512``.
+
+    Returns
+    -------
+    float
+        Estimated fractal dimension of the embedding space.
+    """
+
+    dim, _ = latent_box_dimension(coords, radii, sample=sample)
+    return dim
+
+
 def laplacian_spectrum(
     graph: nx.Graph, *, normed: bool = True
 ) -> np.ndarray:  # pragma: no cover - heavy computation

--- a/datacreek/analysis/hypergraph_conv.py
+++ b/datacreek/analysis/hypergraph_conv.py
@@ -41,6 +41,45 @@ def hypergraph_laplacian(B: np.ndarray, w: Iterable[float] | None = None) -> np.
     return np.eye(num_nodes) - dv_inv_sqrt @ B @ W @ de_inv @ B.T @ dv_inv_sqrt
 
 
+def estimate_lambda_max(Delta: np.ndarray, it: int = 3) -> float:
+    r"""Estimate the largest eigenvalue :math:`\lambda_{\max}` of ``Delta``.
+
+    A lightweight power iteration is used to avoid the costly dense
+    eigendecomposition required by :func:`numpy.linalg.eigvalsh`. Starting from a
+    random vector ``v`` the iteration ``v_{k+1} = \Delta v_k / \|\Delta v_k\|``
+    converges to the dominant eigenvector. The corresponding Rayleigh quotient
+    provides an approximation of ``\lambda_{\max}``.
+
+    Parameters
+    ----------
+    Delta:
+        Symmetric hypergraph Laplacian ``\Delta``.
+    it:
+        Number of power iterations. A small value (``it=3``) already yields a
+        good estimate in practice.
+
+    Returns
+    -------
+    float
+        Estimated largest eigenvalue ``\lambda_{\max}``.
+    """
+    Delta = np.asarray(Delta, dtype=float)
+    if Delta.ndim != 2 or Delta.shape[0] != Delta.shape[1]:
+        raise ValueError("Delta must be a square matrix")
+
+    # Start from a random but deterministic vector for reproducibility.
+    rng = np.random.default_rng(0)
+    v = rng.standard_normal(Delta.shape[0])
+    v /= np.linalg.norm(v) + 1e-12
+    for _ in range(it):
+        v = Delta @ v
+        norm = np.linalg.norm(v)
+        if norm == 0.0:
+            return 0.0
+        v /= norm
+    return float(v @ (Delta @ v))
+
+
 def chebyshev_conv(
     X: np.ndarray, Delta: np.ndarray, K: int, theta: Iterable[float] | None = None
 ) -> np.ndarray:
@@ -70,7 +109,7 @@ def chebyshev_conv(
     if theta.shape[0] != K:
         raise ValueError("theta length must equal K")
 
-    lamb_max = float(np.linalg.eigvalsh(Delta).max())
+    lamb_max = estimate_lambda_max(Delta)
     if lamb_max == 0.0:
         lamb_max = 1.0
     Delta_tilde = (2.0 / lamb_max) * Delta - np.eye(Delta.shape[0])

--- a/datacreek/analysis/mapper.py
+++ b/datacreek/analysis/mapper.py
@@ -159,6 +159,114 @@ def mapper_to_json(
     return json.dumps(data)
 
 
+def _cover_silhouette(
+    lens_vals: dict[object, float], cover_sets: Iterable[set[object]]
+) -> float:
+    """Return the silhouette coefficient of ``cover_sets`` w.r.t ``lens_vals``.
+
+    Parameters
+    ----------
+    lens_vals:
+        Mapping of node to lens value.
+    cover_sets:
+        Clusters produced by :func:`mapper_full`.
+
+    Notes
+    -----
+    The silhouette coefficient compares mean intra-cluster distances with the
+    smallest mean distance to points in other clusters. For the 1-D lens values
+    used here this simplifies to differences along that axis. If scikit-learn
+    is unavailable or less than two clusters exist, ``0.0`` is returned.
+    """
+
+    try:  # optional dependency, pragma: no cover for failure path
+        from sklearn.metrics import silhouette_score  # type: ignore
+    except Exception:  # pragma: no cover - sklearn missing
+        silhouette_score = None  # type: ignore
+
+    nodes = list(lens_vals.keys())
+    labels = [-1] * len(nodes)
+    for idx, cluster in enumerate(cover_sets):
+        for n in cluster:
+            i = nodes.index(n)
+            if labels[i] == -1:
+                labels[i] = idx  # assign node to first cluster encountered
+    if len(set(labels)) <= 1 or -1 in labels:
+        return 0.0
+
+    X = [[lens_vals[n]] for n in nodes]
+    if silhouette_score is not None:
+        try:
+            return float(silhouette_score(X, labels))
+        except Exception:  # pragma: no cover - numerical issues
+            return 0.0
+
+    # Fallback: manual silhouette computation for 1-D lens values
+    import numpy as np
+
+    X = np.array(X, dtype=float).reshape(-1)
+    labels_arr = np.array(labels)
+    unique = np.unique(labels_arr)
+    sils = []
+    for i, x in enumerate(X):
+        same = X[labels_arr == labels_arr[i]]
+        other = [X[labels_arr == u] for u in unique if u != labels_arr[i]]
+        a = float(np.mean(np.abs(same - x))) if len(same) > 1 else 0.0
+        b = min(float(np.mean(np.abs(o - x))) for o in other) if other else 0.0
+        sils.append((b - a) / max(a, b) if max(a, b) else 0.0)
+    return float(np.mean(sils))
+
+
+def autotune_mapper_overlap(
+    graph: nx.Graph,
+    *,
+    overlaps: Iterable[float] = (0.2, 0.3, 0.4, 0.5),
+    n_intervals: int = 10,
+    lens: Callable[[nx.Graph], dict[object, float]] | None = None,
+    clusterer: str = "dbscan",
+) -> tuple[nx.Graph, list[set[object]], float, float]:
+    """Grid-search the Mapper overlap maximizing the silhouette score.
+
+    The function evaluates :func:`mapper_full` for each candidate overlap and
+    selects the configuration whose clustering of nodes (cover sets) yields the
+    highest silhouette coefficient. The silhouette coefficient ``s`` for an
+    overlap ``\omega`` is computed as
+
+    .. math::
+
+        s(\omega) = \frac{b - a}{\max(a, b)}
+
+    where ``a`` is the mean intra-cluster distance and ``b`` the minimum mean
+    distance to points of other clusters. A higher value indicates better
+    separated clusters.
+
+    Returns
+    -------
+    nerve, cover, best_overlap, best_score
+        The Mapper nerve and cover with the best overlap along with the
+        optimal overlap value and corresponding silhouette coefficient.
+    """
+
+    if lens is None:
+        lens_vals = default_lens(graph)
+    else:
+        lens_vals = lens(graph)
+    if not lens_vals:
+        return nx.Graph(), [], 0.5, 0.0
+
+    best_score = -1.0
+    best_result = (nx.Graph(), [], 0.5, 0.0)
+    for ov in overlaps:
+        nerve, cover_sets = mapper_full(
+            graph, lens=lambda _g: lens_vals, cover=(n_intervals, ov), clusterer=clusterer
+        )
+        score = _cover_silhouette(lens_vals, cover_sets)
+        if score > best_score:
+            best_score = score
+            best_result = (nerve, cover_sets, ov, score)
+    return best_result
+
+
 import os
 import pickle  # nosec B403
 import threading

--- a/datacreek/analysis/mapper.py
+++ b/datacreek/analysis/mapper.py
@@ -258,7 +258,10 @@ def autotune_mapper_overlap(
     best_result = (nx.Graph(), [], 0.5, 0.0)
     for ov in overlaps:
         nerve, cover_sets = mapper_full(
-            graph, lens=lambda _g: lens_vals, cover=(n_intervals, ov), clusterer=clusterer
+            graph,
+            lens=lambda _g: lens_vals,
+            cover=(n_intervals, ov),
+            clusterer=clusterer,
         )
         score = _cover_silhouette(lens_vals, cover_sets)
         if score > best_score:

--- a/datacreek/analysis/sheaf_hyper_bridge.py
+++ b/datacreek/analysis/sheaf_hyper_bridge.py
@@ -97,9 +97,7 @@ def top_k_incoherent(
         return []
     L_s = sheaf_laplacian(graph, edge_attr=edge_attr)
     L_h = B @ B.T
-    base = float(
-        np.sum(np.abs(np.linalg.eigvalsh(L_s) - np.linalg.eigvalsh(L_h)))
-    )
+    base = float(np.sum(np.abs(np.linalg.eigvalsh(L_s) - np.linalg.eigvalsh(L_h))))
 
     incoherent: list[tuple[tuple[int, int], float]] = []
     for u, v in graph.edges():
@@ -111,12 +109,7 @@ def top_k_incoherent(
         L_s2 = sheaf_laplacian(g2, edge_attr=edge_attr)
         L_h2 = B2 @ B2.T
         diff = float(
-            np.sum(
-                np.abs(
-                    np.linalg.eigvalsh(L_s2)
-                    - np.linalg.eigvalsh(L_h2)
-                )
-            )
+            np.sum(np.abs(np.linalg.eigvalsh(L_s2) - np.linalg.eigvalsh(L_h2)))
         )
         delta = abs(diff - base)
         if delta > tau:

--- a/datacreek/analysis/sheaf_hyper_bridge.py
+++ b/datacreek/analysis/sheaf_hyper_bridge.py
@@ -59,3 +59,68 @@ def sheaf_hyper_bridge_score(
     except Exception:
         pass  # metric or monitoring not available
     return score
+
+
+def top_k_incoherent(
+    graph: nx.Graph,
+    k: int,
+    tau: float,
+    *,
+    edge_attr: str = "sheaf_sign",
+) -> list[tuple[tuple[int, int], float]]:
+    """Return ``k`` edges whose removal increases spectral mismatch.
+
+    For each edge we remove it and recompute eigenvalues of the sheaf and
+    hypergraph Laplacians. The change in total absolute eigenvalue difference
+    defines ``Δλ_e``. Edges with ``Δλ_e > τ`` are considered incoherent and
+    returned sorted by this value.
+
+    Parameters
+    ----------
+    graph:
+        Input graph with sheaf sign information.
+    k:
+        Maximum number of edges to return.
+    tau:
+        Minimum eigenvalue difference ``Δλ_e`` to include an edge.
+    edge_attr:
+        Name of the edge attribute storing the sheaf sign.
+
+    Returns
+    -------
+    list of ((int, int), float)
+        Edge tuples with their ``Δλ_e`` value sorted descending.
+    """
+
+    B = sheaf_incidence_matrix(graph, edge_attr=edge_attr)
+    if B.size == 0:
+        return []
+    L_s = sheaf_laplacian(graph, edge_attr=edge_attr)
+    L_h = B @ B.T
+    base = float(
+        np.sum(np.abs(np.linalg.eigvalsh(L_s) - np.linalg.eigvalsh(L_h)))
+    )
+
+    incoherent: list[tuple[tuple[int, int], float]] = []
+    for u, v in graph.edges():
+        g2 = graph.copy()
+        g2.remove_edge(u, v)
+        B2 = sheaf_incidence_matrix(g2, edge_attr=edge_attr)
+        if B2.size == 0:
+            continue
+        L_s2 = sheaf_laplacian(g2, edge_attr=edge_attr)
+        L_h2 = B2 @ B2.T
+        diff = float(
+            np.sum(
+                np.abs(
+                    np.linalg.eigvalsh(L_s2)
+                    - np.linalg.eigvalsh(L_h2)
+                )
+            )
+        )
+        delta = abs(diff - base)
+        if delta > tau:
+            incoherent.append(((u, v), delta))
+
+    incoherent.sort(key=lambda x: x[1], reverse=True)
+    return incoherent[:k]

--- a/datacreek/utils/__init__.py
+++ b/datacreek/utils/__init__.py
@@ -44,6 +44,7 @@ except Exception:  # pragma: no cover - fallback when heavy deps missing
 from .crypto import decrypt_pii_fields, encrypt_pii_fields, xor_decrypt, xor_encrypt
 from .dataset_cleanup import deduplicate_pairs
 from .delta_export import delta_optimize, delta_vacuum, export_delta, lakefs_commit
+from .dataset_export import snapshot_tokenizer
 from .gitinfo import get_commit_hash
 from .kafka_queue import enqueue_ingest
 from .rate_limit import consume_token
@@ -189,4 +190,5 @@ __all__ = [
     "propose_merge_split",
     "record_feedback",
     "fine_tune_from_feedback",
+    "snapshot_tokenizer",
 ]

--- a/datacreek/utils/__init__.py
+++ b/datacreek/utils/__init__.py
@@ -43,8 +43,8 @@ except Exception:  # pragma: no cover - fallback when heavy deps missing
     ) = _missing  # type: ignore
 from .crypto import decrypt_pii_fields, encrypt_pii_fields, xor_decrypt, xor_encrypt
 from .dataset_cleanup import deduplicate_pairs
-from .delta_export import delta_optimize, delta_vacuum, export_delta, lakefs_commit
 from .dataset_export import snapshot_tokenizer
+from .delta_export import delta_optimize, delta_vacuum, export_delta, lakefs_commit
 from .gitinfo import get_commit_hash
 from .kafka_queue import enqueue_ingest
 from .rate_limit import consume_token

--- a/datacreek/utils/dataset_export.py
+++ b/datacreek/utils/dataset_export.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Helpers to snapshot tokenizers alongside dataset exports.
+
+The snapshot is saved as ``tokenizer.json`` within the given LakeFS branch
+working copy so that the exact tokenizer used for the dataset can be
+reproduced. The file is committed using ``lakefs commit`` to ensure it shares
+the same commit as the exported dataset.
+"""
+
+from hashlib import sha256
+from pathlib import Path
+from typing import Tuple
+
+from .delta_export import lakefs_commit
+
+__all__ = ["snapshot_tokenizer"]
+
+
+def snapshot_tokenizer(tokenizer, *, path: str | Path, repo: str) -> Tuple[Path, str]:
+    """Persist ``tokenizer`` to ``path`` and return its SHA256 digest.
+
+    Parameters
+    ----------
+    tokenizer:
+        Any object providing either ``save_pretrained`` (Hugging Face style)
+        or a ``backend_tokenizer.save`` method.
+    path:
+        Directory representing the LakeFS branch working copy where the
+        tokenizer should be stored. The file will be named ``tokenizer.json``.
+    repo:
+        Name of the LakeFS repository to commit to. The commit is best-effort;
+        failures are logged but do not raise.
+
+    Returns
+    -------
+    Tuple[Path, str]
+        The path to the written ``tokenizer.json`` and its SHA256 hex digest.
+    """
+
+    dir_path = Path(path)
+    dir_path.mkdir(parents=True, exist_ok=True)
+    json_path = dir_path / "tokenizer.json"
+
+    # Hugging Face tokenizers expose ``save_pretrained`` while ``tokenizers``
+    # library exposes ``backend_tokenizer.save``. Support both to keep the
+    # utility generic.
+    if hasattr(tokenizer, "save_pretrained"):
+        tokenizer.save_pretrained(dir_path)
+    elif hasattr(getattr(tokenizer, "backend_tokenizer", None), "save"):
+        tokenizer.backend_tokenizer.save(str(json_path))  # type: ignore[union-attr]
+    else:  # pragma: no cover - defensive branch
+        raise TypeError("Tokenizer does not implement a known save method")
+
+    data = json_path.read_bytes()
+    digest = sha256(data).hexdigest()
+    # Commit the snapshot so that it is versioned with the dataset. The digest
+    # allows callers to assert that downstream tokenizers match this snapshot.
+    lakefs_commit(dir_path, repo)
+    return json_path, digest

--- a/examples/fine_tune_QA.ipynb
+++ b/examples/fine_tune_QA.ipynb
@@ -1,0 +1,137 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Fine-tune QA example\n",
+        "This notebook demonstrates how to fine-tune a question answering model using the `datacreek` toolkit. The workflow covers dataset ingestion with the semantic safety filter, training with Hugging Face `Trainer`, and running inference on the fine-tuned model.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Install dependencies\n",
+        "# In a Colab environment this cell installs required packages.\n",
+        "import sys\n",
+        "\n",
+        "if 'google.colab' in sys.modules:\n",
+        "    !pip install -q datasets transformers accelerate datacreek\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\"\"\"Load the SQuAD dataset and apply the semantic safety filter.\n\n",
+        "The safety filter uses a tiny toxicity model and NSFW regex heuristics to drop unsafe samples before training.\n\n",
+        "Variables\n",
+        "    dataset: Raw SQuAD dataset split dictionary\n",
+        "    safe_dataset: Dataset after filtering\n\"\"\"\n",
+        "from datasets import load_dataset\n",
+        "from ingest.safety_filter import SafetyFilter\n",
+        "\n",
+        "dataset = load_dataset('squad')\n",
+        "filter = SafetyFilter()\n",
+        "\n",
+        "def is_safe(example):\n",
+        "    text = example['question'] + ' ' + example['context']\n",
+        "    return filter(text)\n",
+        "\n",
+        "safe_dataset = dataset.filter(is_safe)\n",
+        "safe_dataset\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\"\"\"Tokenize the dataset for the QA task.\n\n",
+        "This cell leverages the pretrained tokenizer associated with the chosen model.\n",
+        "Variables\n",
+        "    tokenizer: Hugging Face tokenizer\n",
+        "    tokenized: tokenized dataset ready for training\n\"\"\"\n",
+        "from transformers import AutoTokenizer\n",
+        "\n",
+        "model_name = 'distilbert-base-uncased'\n",
+        "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+        "\n",
+        "def preprocess(example):\n",
+        "    return tokenizer(example['question'], example['context'], truncation=True)\n",
+        "\n",
+        "tokenized = safe_dataset.map(preprocess, batched=True)\n",
+        "tokenized\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\"\"\"Fine-tune the model using Hugging Face Trainer.\n\n",
+        "TrainingArguments set a small number of epochs for demonstration. On Colab with a GPU this cell completes within minutes.\n",
+        "Variables\n",
+        "    model: pretrained transformer model for QA\n",
+        "    trainer: Hugging Face Trainer instance\n\"\"\"\n",
+        "from transformers import AutoModelForQuestionAnswering, TrainingArguments, Trainer\n",
+        "\n",
+        "model = AutoModelForQuestionAnswering.from_pretrained(model_name)\n",
+        "args = TrainingArguments(\n",
+        "    output_dir='qa-model',\n",
+        "    per_device_train_batch_size=8,\n",
+        "    learning_rate=3e-5,\n",
+        "    num_train_epochs=1,\n",
+        "    weight_decay=0.01,\n",
+        "    logging_steps=50,\n",
+        ")\n",
+        "\n",
+        "trainer = Trainer(model=model, args=args, train_dataset=tokenized['train'])\n",
+        "trainer.train()\n",
+        "trainer.save_model()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\"\"\"Run inference with the fine-tuned model.\n\n",
+        "Given a question and context from the validation set, the model predicts the answer span.\n\n",
+        "Variables\n",
+        "    question: sample question from dataset\n",
+        "    context: corresponding context passage\n",
+        "    answer: text span predicted by the model\n\"\"\"\n",
+        "from transformers import pipeline\n",
+        "\n",
+        "qa_pipeline = pipeline('question-answering', model='qa-model')\n",
+        "sample = safe_dataset['validation'][0]\n",
+        "question = sample['question']\n",
+        "context = sample['context']\n",
+        "answer = qa_pipeline(question=question, context=context)\n",
+        "answer\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": ""
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/ingest/safety_filter.py
+++ b/ingest/safety_filter.py
@@ -1,0 +1,84 @@
+"""Safety filter for incoming text, blocking toxic/NSFW payloads."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+try:  # optional dependency
+    from transformers import pipeline
+except Exception:  # pragma: no cover - dependency missing
+    pipeline = None  # type: ignore
+
+try:  # optional Prometheus metric
+    from prometheus_client import CollectorRegistry, Counter
+except Exception:  # pragma: no cover - metrics disabled
+    CollectorRegistry = Counter = None  # type: ignore
+
+# Tiny HF toxicity model
+_MODEL_ID = "unitary/toxic-roberta"
+
+# Regex heuristics for NSFW content (simple demo set)
+_NSFW_RE = re.compile(r"\b(?:porn|xxx|sex)\b", re.I)
+
+# Prometheus counter for blocked payloads
+INGEST_TOXIC_BLOCKS: Optional[Counter]
+if Counter is not None:
+    _REGISTRY = CollectorRegistry(auto_describe=True)
+    INGEST_TOXIC_BLOCKS = Counter(
+        "ingest_toxic_blocks_total",
+        "Total number of toxic payloads blocked during ingestion",
+        registry=_REGISTRY,
+    )
+else:  # pragma: no cover - metrics disabled
+    INGEST_TOXIC_BLOCKS = None
+
+# Lazily loaded classification pipeline
+_TOXICITY_PIPE = None
+
+
+def _load_pipeline() -> None:
+    """Load the Hugging Face pipeline if not already loaded."""
+    global _TOXICITY_PIPE
+    if _TOXICITY_PIPE is None and pipeline is not None:
+        _TOXICITY_PIPE = pipeline("text-classification", model=_MODEL_ID)
+
+
+def _toxicity_score(text: str) -> float:
+    """Return probability of toxicity from the model if available."""
+    _load_pipeline()
+    if _TOXICITY_PIPE is None:  # pragma: no cover - model missing
+        return 0.0
+    try:
+        res = _TOXICITY_PIPE(text)[0]
+    except Exception:  # pragma: no cover - inference failure
+        return 0.0
+    label = res.get("label", "").lower()
+    score = float(res.get("score", 0.0))
+    # Some models use LABEL_1 for toxic class
+    if "toxic" in label or label == "label_1":
+        return score
+    return 1 - score
+
+
+def filter_text(text: str, threshold: float = 0.7) -> Optional[str]:
+    """Return text if safe, otherwise ``None``.
+
+    The global score :math:`s` combines model toxicity :math:`s_{tox}` and
+    regex heuristic :math:`s_{nsfw}` using
+
+    .. math::
+
+        s = 0.5 (s_{tox} + s_{nsfw})
+
+    Blocking occurs when ``s > threshold`` (default 0.7). The Prometheus
+    counter ``ingest_toxic_blocks_total`` is incremented when a text is blocked.
+    """
+    s_tox = _toxicity_score(text)
+    s_nsfw = 1.0 if _NSFW_RE.search(text) else 0.0
+    s = 0.5 * (s_tox + s_nsfw)
+    if s > threshold:
+        if INGEST_TOXIC_BLOCKS is not None:  # pragma: no branch - metric optional
+            INGEST_TOXIC_BLOCKS.inc()
+        return None
+    return text

--- a/scripts/check_schema_break.py
+++ b/scripts/check_schema_break.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Git hook preventing breaking changes to the LakeFS schema.
+
+The script compares the current ``.lakefs/schema.yaml`` against the version
+committed in ``HEAD``. Removing existing fields or changing their type is
+considered a breaking change and will abort the commit.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+import yaml
+
+SCHEMA_PATH = Path(".lakefs/schema.yaml")
+
+
+def load_schema(path: Path) -> Dict[str, Any]:
+    """Load a YAML schema from ``path`` returning an empty dict if missing."""
+    with path.open() as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def load_previous_schema(path: Path) -> Optional[Dict[str, Any]]:
+    """Return the schema tracked in ``HEAD`` or ``None`` if it does not exist."""
+    try:
+        res = subprocess.run(
+            ["git", "show", f"HEAD:{path.as_posix()}"] ,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    return yaml.safe_load(res.stdout) or {}
+
+
+def is_breaking_change(curr: Dict[str, Any], prev: Optional[Dict[str, Any]]) -> bool:
+    """Return ``True`` if removing fields or changing types in ``curr``."""
+    if not prev:
+        return False
+    prev_fields = {f["name"]: f["type"] for f in prev.get("fields", [])}
+    curr_fields = {f["name"]: f["type"] for f in curr.get("fields", [])}
+    for name, typ in prev_fields.items():
+        if name not in curr_fields:
+            return True
+        if curr_fields[name] != typ:
+            return True
+    return False
+
+
+def main() -> int:
+    """Entry point for the pre-commit hook."""
+    curr = load_schema(SCHEMA_PATH)
+    prev = load_previous_schema(SCHEMA_PATH)
+    if is_breaking_change(curr, prev):
+        print(
+            "Breaking schema change detected: remove or modification of existing fields.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_schema_break.py
+++ b/scripts/check_schema_break.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 import yaml
 
@@ -28,7 +28,7 @@ def load_previous_schema(path: Path) -> Optional[Dict[str, Any]]:
     """Return the schema tracked in ``HEAD`` or ``None`` if it does not exist."""
     try:
         res = subprocess.run(
-            ["git", "show", f"HEAD:{path.as_posix()}"] ,
+            ["git", "show", f"HEAD:{path.as_posix()}"],
             check=True,
             capture_output=True,
             text=True,

--- a/tests/property/test_reward_fn_properties.py
+++ b/tests/property/test_reward_fn_properties.py
@@ -1,0 +1,35 @@
+"""Property-based tests for the alias-aware reward."""
+
+pytest = __import__("pytest")
+pytest.importorskip("hypothesis")
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+from training.reward_fn import build_alias_reward_fn
+
+# Strategies generating valid triplet strings compatible with ``extract_triplets``
+subjects = st.sampled_from(["alice", "bob", "paris", "london"])
+predicates = st.sampled_from(["is", "likes", "has", "knows", "located_in", "capital_of"])
+objects = st.sampled_from(["apples", "carol", "france", "uk", "usa"])
+triplets = st.builds(lambda s, p, o: f"{s} {p} {o}", subjects, predicates, objects)
+
+
+@given(triplets)
+@settings(max_examples=30)
+def test_reward_is_one_when_truthful(fact: str) -> None:
+    """If the response exactly matches the fact, reward should be 1."""
+    s, p, o = fact.split()
+    graph = {(s, p): {o}}
+    reward_fn = build_alias_reward_fn(graph, None)
+    assert reward_fn(fact) == 1.0
+
+
+@given(triplets)
+@settings(max_examples=30)
+def test_reward_zero_when_response_empty(fact: str) -> None:
+    """Empty responses should yield zero reward regardless of the fact."""
+    s, p, o = fact.split()
+    graph = {(s, p): {o}}
+    reward_fn = build_alias_reward_fn(graph, None)
+    assert reward_fn("") == 0.0

--- a/tests/property/test_reward_fn_properties.py
+++ b/tests/property/test_reward_fn_properties.py
@@ -10,7 +10,9 @@ from training.reward_fn import build_alias_reward_fn
 
 # Strategies generating valid triplet strings compatible with ``extract_triplets``
 subjects = st.sampled_from(["alice", "bob", "paris", "london"])
-predicates = st.sampled_from(["is", "likes", "has", "knows", "located_in", "capital_of"])
+predicates = st.sampled_from(
+    ["is", "likes", "has", "knows", "located_in", "capital_of"]
+)
 objects = st.sampled_from(["apples", "carol", "france", "uk", "usa"])
 triplets = st.builds(lambda s, p, o: f"{s} {p} {o}", subjects, predicates, objects)
 

--- a/tests/unit/test_augmenter.py
+++ b/tests/unit/test_augmenter.py
@@ -3,6 +3,24 @@
 from training.augmenter import ActiveLearningAugmenter
 
 
+def test_contradictory_paraphrases_are_dropped(monkeypatch):
+    samples = ["sky is blue"]
+    losses = [1.0]
+    synonyms = {"blue": ["green"]}
+
+    # Mock contradiction detector to flag the paraphrase as contradictory.
+    def fake_contradiction(orig: str, para: str) -> bool:
+        return para.endswith("green")
+
+    monkeypatch.setattr(
+        "training.augmenter._is_contradiction", fake_contradiction
+    )
+    augmenter = ActiveLearningAugmenter(synonyms, k=1, percentile=0, interval=1)
+    augmented = augmenter.augment(samples, losses, epoch=1)
+
+    assert augmented == samples  # variant filtered out
+
+
 def _recall(dataset, val_set):
     return sum(1 for s in val_set if s in dataset) / len(val_set)
 

--- a/tests/unit/test_augmenter.py
+++ b/tests/unit/test_augmenter.py
@@ -12,9 +12,7 @@ def test_contradictory_paraphrases_are_dropped(monkeypatch):
     def fake_contradiction(orig: str, para: str) -> bool:
         return para.endswith("green")
 
-    monkeypatch.setattr(
-        "training.augmenter._is_contradiction", fake_contradiction
-    )
+    monkeypatch.setattr("training.augmenter._is_contradiction", fake_contradiction)
     augmenter = ActiveLearningAugmenter(synonyms, k=1, percentile=0, interval=1)
     augmented = augmenter.augment(samples, losses, epoch=1)
 

--- a/tests/unit/test_checkpoint_pruner.py
+++ b/tests/unit/test_checkpoint_pruner.py
@@ -1,0 +1,26 @@
+from training.monitoring import CheckpointPruner
+
+
+def test_pruner_keeps_top_k(tmp_path):
+    pruner = CheckpointPruner(k=2, mode="max")
+    scores = [0.1, 0.4, 0.3]
+    for i, s in enumerate(scores):
+        d = tmp_path / f"ckpt{i}"
+        d.mkdir()
+        # simulate saving some file inside checkpoint
+        (d / "weights.bin").write_text("x")
+        pruner.step(str(d), s)
+    remaining = {p.name for p in tmp_path.iterdir()}
+    assert remaining == {"ckpt1", "ckpt2"}
+
+
+def test_pruner_min_mode(tmp_path):
+    pruner = CheckpointPruner(k=2, mode="min")
+    scores = [0.4, 0.1, 0.3]
+    for i, s in enumerate(scores):
+        d = tmp_path / f"ckpt{i}"
+        d.mkdir()
+        (d / "weights.bin").write_text("x")
+        pruner.step(str(d), s)
+    remaining = {p.name for p in tmp_path.iterdir()}
+    assert remaining == {"ckpt1", "ckpt2"}

--- a/tests/unit/test_dataset_export.py
+++ b/tests/unit/test_dataset_export.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from hashlib import sha256
+from pathlib import Path
+
+from datacreek.utils import snapshot_tokenizer
+
+
+class DummyTokenizer:
+    """Minimal tokenizer stub writing deterministic JSON."""
+
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+
+    def save_pretrained(self, path: str | Path) -> None:  # pragma: no cover - trivial
+        out = Path(path) / "tokenizer.json"
+        with open(out, "w", encoding="utf-8") as fh:
+            json.dump(self.payload, fh, ensure_ascii=False, sort_keys=True)
+
+
+def test_snapshot_tokenizer(tmp_path, monkeypatch):
+    tok = DummyTokenizer({"hello": 1})
+
+    called = {}
+
+    def fake_commit(path, repo):  # record arguments
+        called["path"] = Path(path)
+        called["repo"] = repo
+        return "id"
+
+    monkeypatch.setattr(
+        "datacreek.utils.dataset_export.lakefs_commit", fake_commit
+    )
+
+    path, digest1 = snapshot_tokenizer(tok, path=tmp_path, repo="foo")
+    assert path == tmp_path / "tokenizer.json"
+    data = path.read_bytes()
+    assert digest1 == sha256(data).hexdigest()
+    assert called["repo"] == "foo" and called["path"] == tmp_path
+
+    # Second snapshot should yield the same hash (stable export)
+    _, digest2 = snapshot_tokenizer(tok, path=tmp_path, repo="foo")
+    assert digest2 == digest1

--- a/tests/unit/test_dataset_export.py
+++ b/tests/unit/test_dataset_export.py
@@ -29,9 +29,7 @@ def test_snapshot_tokenizer(tmp_path, monkeypatch):
         called["repo"] = repo
         return "id"
 
-    monkeypatch.setattr(
-        "datacreek.utils.dataset_export.lakefs_commit", fake_commit
-    )
+    monkeypatch.setattr("datacreek.utils.dataset_export.lakefs_commit", fake_commit)
 
     path, digest1 = snapshot_tokenizer(tok, path=tmp_path, repo="foo")
     assert path == tmp_path / "tokenizer.json"

--- a/tests/unit/test_explain_router.py
+++ b/tests/unit/test_explain_router.py
@@ -4,7 +4,6 @@ import json
 import types
 
 import networkx as nx
-
 import pytest
 from fastapi import HTTPException
 

--- a/tests/unit/test_fractal_dim_embedding.py
+++ b/tests/unit/test_fractal_dim_embedding.py
@@ -1,0 +1,8 @@
+import datacreek.analysis.fractal as fractal
+from datacreek.analysis import fractal_dim_embedding
+
+
+def test_fractal_dim_embedding(monkeypatch):
+    monkeypatch.setattr(fractal, "latent_box_dimension", lambda c, r, sample=512: (2.0, []))
+    dim = fractal_dim_embedding({1: [0.0]}, [1.0])
+    assert dim == 2.0

--- a/tests/unit/test_fractal_dim_embedding.py
+++ b/tests/unit/test_fractal_dim_embedding.py
@@ -3,6 +3,8 @@ from datacreek.analysis import fractal_dim_embedding
 
 
 def test_fractal_dim_embedding(monkeypatch):
-    monkeypatch.setattr(fractal, "latent_box_dimension", lambda c, r, sample=512: (2.0, []))
+    monkeypatch.setattr(
+        fractal, "latent_box_dimension", lambda c, r, sample=512: (2.0, [])
+    )
     dim = fractal_dim_embedding({1: [0.0]}, [1.0])
     assert dim == 2.0

--- a/tests/unit/test_hypergraph_conv.py
+++ b/tests/unit/test_hypergraph_conv.py
@@ -1,10 +1,7 @@
 import numpy as np
 import pytest
 
-from datacreek.analysis.hypergraph_conv import (
-    hypergraph_laplacian,
-    estimate_lambda_max,
-)
+from datacreek.analysis.hypergraph_conv import estimate_lambda_max, hypergraph_laplacian
 
 
 def build_simple_laplacian():

--- a/tests/unit/test_hypergraph_conv.py
+++ b/tests/unit/test_hypergraph_conv.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+from datacreek.analysis.hypergraph_conv import (
+    hypergraph_laplacian,
+    estimate_lambda_max,
+)
+
+
+def build_simple_laplacian():
+    """Construct a small hypergraph Laplacian for testing."""
+    # Incidence matrix for 3 nodes and 2 hyperedges
+    # Edge e0 connects v0 and v1; e1 connects all three nodes
+    B = np.array(
+        [
+            [1, 1],
+            [1, 1],
+            [0, 1],
+        ],
+        dtype=float,
+    )
+    return hypergraph_laplacian(B)
+
+
+def test_power_iteration_estimate_close_to_true():
+    """Power iteration should approximate the dominant eigenvalue within 5%."""
+    Delta = build_simple_laplacian()
+    true = np.linalg.eigvalsh(Delta).max()
+    est = estimate_lambda_max(Delta, it=10)
+    assert est == pytest.approx(true, rel=0.05)
+
+
+def test_zero_matrix_returns_zero():
+    """Zero Laplacian should yield an eigenvalue estimate of zero."""
+    Delta = np.zeros((3, 3))
+    assert estimate_lambda_max(Delta) == pytest.approx(0.0)

--- a/tests/unit/test_mapper.py
+++ b/tests/unit/test_mapper.py
@@ -32,6 +32,21 @@ def test_inverse_mapper_cross_edges():
         assert recon.has_edge(u, v)
 
 
+def test_autotune_mapper_overlap_increases_silhouette():
+    """Grid-searching overlap should yield higher silhouette score."""
+
+    g = nx.path_graph(6)
+    lens = lambda graph: {n: float(n) for n in graph.nodes()}
+
+    nerve, cover, ov, score = mapper.autotune_mapper_overlap(
+        g, overlaps=[0.2, 0.3, 0.4, 0.5], n_intervals=2, lens=lens
+    )
+    _, base_cover = mapper.mapper_full(g, lens=lens, cover=(2, 0.5))
+    base_score = mapper._cover_silhouette(lens(g), base_cover)
+    assert score - base_score >= 0.03
+    assert ov in {0.2, 0.3}
+
+
 def test_cache_mapper_nerve_with_redis_and_lmdb(tmp_path):
     """Ensure caching uses Redis and LMDB layers."""
     g = nx.path_graph(4)

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -5,6 +5,13 @@ from importlib import reload
 import pytest
 
 
+def test_eta_callback_export():
+    """Ensure EtaCallback is re-exported at package level."""
+    from training import EtaCallback
+
+    assert hasattr(EtaCallback, "update")
+
+
 def test_init_wandb(monkeypatch):
     dummy = types.SimpleNamespace(
         init=lambda **kwargs: types.SimpleNamespace(kwargs=kwargs)
@@ -34,11 +41,20 @@ def test_prometheus_logger(monkeypatch):
 
     reload(monitoring)
     logger = monitoring.PrometheusLogger()
-    logger.log(training_loss=0.5, val_metric=0.4, gpu_vram_bytes=1.0, reward_avg=0.7)
+    logger.log(
+        training_loss=0.5,
+        val_metric=0.4,
+        gpu_vram_bytes=1.0,
+        reward_avg=0.7,
+        training_eta_seconds=9.0,
+        fractal_loss=0.1,
+    )
     assert logger.training_loss.value == 0.5
     assert logger.val_metric.value == 0.4
     assert logger.gpu_vram_bytes.value == 1.0
     assert logger.reward_avg.value == 0.7
+    assert logger.training_eta_seconds.value == 9.0
+    assert logger.fractal_loss.value == 0.1
 
 
 def test_early_stopping():
@@ -48,3 +64,36 @@ def test_early_stopping():
     assert not stopper.step(1.0)
     assert not stopper.step(1.1)
     assert stopper.step(1.2)
+
+
+def test_eta_callback(monkeypatch):
+    dummy = types.SimpleNamespace(Gauge=DummyGauge, start_http_server=lambda port: None)
+    monkeypatch.setitem(sys.modules, "prometheus_client", dummy)
+    from training import monitoring
+
+    reload(monitoring)
+    logger = monitoring.PrometheusLogger()
+    times = iter([0.0, 10.0])
+    monkeypatch.setattr(monitoring.time, "perf_counter", lambda: next(times))
+    cb = monitoring.EtaCallback(steps_total=100, logger=logger)
+    eta = cb.update(step_done=50)
+    assert eta == 10.0
+    assert logger.training_eta_seconds.value == 10.0
+
+
+def test_fractal_dim_callback(monkeypatch):
+    dummy = types.SimpleNamespace(Gauge=DummyGauge, start_http_server=lambda port: None)
+    monkeypatch.setitem(sys.modules, "prometheus_client", dummy)
+    from training import monitoring
+
+    reload(monitoring)
+    logger = monitoring.PrometheusLogger()
+    # Patch fractal_dim_embedding to return a fixed dimension
+    monkeypatch.setattr(monitoring, "fractal_dim_embedding", lambda e, r: 1.5)
+    cb = monitoring.FractalDimCallback(target_dim=1.0, beta=2.0, logger=logger)
+    # First epoch: no computation
+    assert cb.update({1: [0.0]}) is None
+    # Second epoch: dimension computed, loss logged
+    dim = cb.update({1: [0.0]})
+    assert dim == 1.5
+    assert logger.fractal_loss.value == 1.0

--- a/tests/unit/test_quality_metrics.py
+++ b/tests/unit/test_quality_metrics.py
@@ -7,7 +7,10 @@ from datacreek.utils.quality_metrics import (
     audio_metrics,
     audio_snr,
     blur_score,
+    dynamic_snr_threshold,
     image_dimensions,
+    snr_soft_gate,
+    snr_std,
     text_entropy,
 )
 
@@ -70,3 +73,13 @@ def test_audio_metrics(tmp_path):
     assert sr_out == sr
     assert math.isclose(dur, 1.0, rel_tol=1e-3)
     assert snr > 10.0
+
+
+def test_dynamic_snr_threshold_and_gate():
+    history = [10.0, 12.0, 11.0, 9.0, 10.0]
+    sigma = snr_std(history)
+    assert math.isclose(sigma, 1.0198039, rel_tol=1e-5)
+    thr = dynamic_snr_threshold(history)
+    assert math.isclose(thr, 6 + 0.5 * sigma, rel_tol=1e-5)
+    assert snr_soft_gate(thr + 0.1, history)
+    assert not snr_soft_gate(thr - 0.1, history)

--- a/tests/unit/test_reward_fn.py
+++ b/tests/unit/test_reward_fn.py
@@ -1,0 +1,50 @@
+"""Unit tests for alias-aware reward function."""
+
+from training.reward_fn import build_alias_reward_fn
+
+
+class DummySession:
+    """Minimal in-memory stand-in for a Neo4j session."""
+
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def run(self, query, n):  # pragma: no cover - trivial passthrough
+        canonical = self.mapping.get(n)
+        return [{"canonical": canonical}] if canonical else []
+
+    def __enter__(self):  # pragma: no cover - context manager protocol
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # pragma: no cover
+        return False
+
+
+class DummyDriver:
+    """Neo4j driver stub returning ``DummySession`` objects."""
+
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def session(self):  # pragma: no cover
+        return DummySession(self.mapping)
+
+
+def test_alias_resolution_counts_as_valid_fact():
+    """Facts matching only after alias canonicalisation should be rewarded."""
+    graph = {("new_york_city", "located_in"): {"usa"}}
+    driver = DummyDriver({"nyc": "new_york_city"})
+    reward_fn = build_alias_reward_fn(graph, driver)
+    assert reward_fn("NYC located_in USA") == 1.0
+
+
+def test_ratio_accounts_for_invalid_facts():
+    """Unverified facts reduce the overall reward proportionally."""
+    graph = {
+        ("new_york_city", "located_in"): {"usa"},
+        ("paris", "located_in"): {"france"},
+    }
+    driver = DummyDriver({"nyc": "new_york_city"})
+    text = "NYC located_in USA. Paris located_in France. Berlin located_in Mars."
+    reward_fn = build_alias_reward_fn(graph, driver)
+    assert reward_fn(text) == 2 / 3

--- a/tests/unit/test_safety_filter.py
+++ b/tests/unit/test_safety_filter.py
@@ -1,0 +1,43 @@
+import importlib
+
+import pytest
+
+
+def _setup_module(monkeypatch, score):
+    """Reload module and patch pipeline/counter."""
+    module = importlib.reload(importlib.import_module("ingest.safety_filter"))
+
+    class DummyPipe:
+        def __call__(self, text):
+            return [{"label": "toxic", "score": score}]
+
+    class DummyCounter:
+        def __init__(self):
+            self.n = 0
+
+        def inc(self):
+            self.n += 1
+
+    monkeypatch.setattr(module, "pipeline", lambda *a, **k: DummyPipe())
+    monkeypatch.setattr(module, "_TOXICITY_PIPE", None)
+    counter = DummyCounter()
+    monkeypatch.setattr(module, "INGEST_TOXIC_BLOCKS", counter)
+    return module, counter
+
+
+def test_blocks_when_regex_and_score_high(monkeypatch):
+    module, counter = _setup_module(monkeypatch, 0.9)
+    assert module.filter_text("this is porn") is None
+    assert counter.n == 1
+
+
+def test_allows_safe_text(monkeypatch):
+    module, counter = _setup_module(monkeypatch, 0.1)
+    assert module.filter_text("hello world") == "hello world"
+    assert counter.n == 0
+
+
+def test_regex_low_score_not_blocked(monkeypatch):
+    module, counter = _setup_module(monkeypatch, 0.1)
+    assert module.filter_text("sex education content") == "sex education content"
+    assert counter.n == 0

--- a/tests/unit/test_schema_guard.py
+++ b/tests/unit/test_schema_guard.py
@@ -1,0 +1,29 @@
+"""Tests for the LakeFS schema compatibility hook."""
+
+from scripts.check_schema_break import is_breaking_change
+
+
+def test_addition_is_allowed():
+    """Adding new fields should not be considered breaking."""
+    prev = {"fields": [{"name": "id", "type": "string"}]}
+    curr = {"fields": prev["fields"] + [{"name": "extra", "type": "int"}]}
+    assert not is_breaking_change(curr, prev)
+
+
+def test_removal_is_breaking():
+    """Removing a field must trigger a breaking change."""
+    prev = {
+        "fields": [
+            {"name": "id", "type": "string"},
+            {"name": "value", "type": "int"},
+        ]
+    }
+    curr = {"fields": [{"name": "id", "type": "string"}]}
+    assert is_breaking_change(curr, prev)
+
+
+def test_type_change_is_breaking():
+    """Changing the type of a field is breaking."""
+    prev = {"fields": [{"name": "id", "type": "string"}]}
+    curr = {"fields": [{"name": "id", "type": "int"}]}
+    assert is_breaking_change(curr, prev)

--- a/tests/unit/test_sheaf_hyper_bridge.py
+++ b/tests/unit/test_sheaf_hyper_bridge.py
@@ -1,6 +1,10 @@
 import networkx as nx
+import pytest
 
-from datacreek.analysis.sheaf_hyper_bridge import sheaf_hyper_bridge_score
+from datacreek.analysis.sheaf_hyper_bridge import (
+    sheaf_hyper_bridge_score,
+    top_k_incoherent,
+)
 
 
 def test_sheaf_hyper_bridge_score_dense():
@@ -10,3 +14,13 @@ def test_sheaf_hyper_bridge_score_dense():
     score = sheaf_hyper_bridge_score(g)
     assert 0.0 <= score <= 1.0
     assert score > 0.7
+
+
+def test_top_k_incoherent_edges():
+    g = nx.Graph()
+    g.add_edge(0, 1, sheaf_sign=1)
+    g.add_edge(1, 2, sheaf_sign=2)  # different sign to induce mismatch
+    out = top_k_incoherent(g, k=2, tau=0.1)
+    assert out == [((1, 2), pytest.approx(3.0))]
+    # High threshold filters the edge
+    assert top_k_incoherent(g, k=2, tau=10.0) == []

--- a/tests/unit/test_tda_vectorize.py
+++ b/tests/unit/test_tda_vectorize.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 from datacreek.analysis import reduce_pca
 
 

--- a/tests/unit/test_tda_vectorize.py
+++ b/tests/unit/test_tda_vectorize.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+from datacreek.analysis import reduce_pca
+
+
+def test_reduce_pca_deterministic_and_matches_sklearn():
+    """Shape is reduced and, if available, matches scikit-learn's IPCA."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(40, 20))
+    Y1 = reduce_pca(X, n=5, batch_size=10)
+    Y2 = reduce_pca(X, n=5, batch_size=10)
+    assert Y1.shape == (40, 5)
+    np.testing.assert_allclose(Y1, Y2)
+
+    try:
+        from sklearn.decomposition import IncrementalPCA
+    except Exception:
+        pytest.skip("scikit-learn not available")
+    ipca = IncrementalPCA(n_components=5)
+    for start in range(0, X.shape[0], 10):
+        ipca.partial_fit(X[start : start + 10])
+    Y_ref = ipca.transform(X)
+    np.testing.assert_allclose(Y1, Y_ref, rtol=1e-5, atol=1e-8)

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -3,7 +3,8 @@
 from .augmenter import ActiveLearningAugmenter
 from .auto_feedback import build_reward_fn, extract_triplets
 from .curriculum_dataloader import CurriculumDataLoader, compute_difficulty
-from .monitoring import EarlyStopping, PrometheusLogger, init_wandb
+from .monitoring import EarlyStopping, EtaCallback, PrometheusLogger, init_wandb
+from .reward_fn import build_alias_reward_fn
 from .task_detector import detect_task, format_classif, format_rlhf, format_sft
 from .trainer_factory import build_trainer
 from .unsloth_loader import add_lora, load_model
@@ -18,10 +19,12 @@ __all__ = [
     "format_rlhf",
     "extract_triplets",
     "build_reward_fn",
+    "build_alias_reward_fn",
     "compute_difficulty",
     "CurriculumDataLoader",
     "ActiveLearningAugmenter",
     "init_wandb",
     "PrometheusLogger",
+    "EtaCallback",
     "EarlyStopping",
 ]

--- a/training/monitoring.py
+++ b/training/monitoring.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 """Monitoring utilities for training metrics and callbacks."""
 
-from dataclasses import dataclass
-from typing import Iterable, Mapping, Optional
-import time
-from pathlib import Path
 import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Optional
 
 from datacreek.analysis import fractal_dim_embedding
 
@@ -163,9 +163,7 @@ class FractalDimCallback:
         self.logger = logger
         self._epoch = 0
 
-    def update(
-        self, embeddings: Mapping[object, Iterable[float]]
-    ) -> Optional[float]:
+    def update(self, embeddings: Mapping[object, Iterable[float]]) -> Optional[float]:
         """Update the estimate and log the fractal loss.
 
         Parameters
@@ -254,6 +252,6 @@ class CheckpointPruner:
         # Sort according to metric quality.
         self._checkpoints.sort(key=lambda x: x[0], reverse=self.mode == "max")
         # Remove checkpoints beyond the top-k.
-        for _, obsolete in self._checkpoints[self.k:]:
+        for _, obsolete in self._checkpoints[self.k :]:
             shutil.rmtree(obsolete, ignore_errors=True)
         self._checkpoints = self._checkpoints[: self.k]

--- a/training/monitoring.py
+++ b/training/monitoring.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 """Monitoring utilities for training metrics and callbacks."""
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Iterable, Mapping, Optional
+import time
+from pathlib import Path
+import shutil
+
+from datacreek.analysis import fractal_dim_embedding
 
 try:
     import wandb
@@ -45,6 +50,12 @@ class PrometheusLogger:
         self.val_metric = Gauge("val_metric", "Validation metric")
         self.gpu_vram_bytes = Gauge("gpu_vram_bytes", "GPU VRAM usage in bytes")
         self.reward_avg = Gauge("reward_avg", "Average reward value")
+        # Estimated time remaining for the training run (seconds).
+        self.training_eta_seconds = Gauge(
+            "training_eta_seconds", "Estimated time remaining in seconds"
+        )
+        # Fractal loss indicating deviation from target dimension.
+        self.fractal_loss = Gauge("fractal_loss", "Fractal dimension loss")
         if self.port is not None and start_http_server:
             start_http_server(self.port)
 
@@ -54,6 +65,8 @@ class PrometheusLogger:
         val_metric: Optional[float] = None,
         gpu_vram_bytes: Optional[float] = None,
         reward_avg: Optional[float] = None,
+        training_eta_seconds: Optional[float] = None,
+        fractal_loss: Optional[float] = None,
     ) -> None:
         """Update metric gauges with new values."""
         if training_loss is not None:
@@ -64,6 +77,116 @@ class PrometheusLogger:
             self.gpu_vram_bytes.set(gpu_vram_bytes)
         if reward_avg is not None:
             self.reward_avg.set(reward_avg)
+        if training_eta_seconds is not None:
+            self.training_eta_seconds.set(training_eta_seconds)
+        if fractal_loss is not None:
+            self.fractal_loss.set(fractal_loss)
+
+
+class EtaCallback:
+    """Compute and log an estimate of remaining training time.
+
+    Parameters
+    ----------
+    steps_total:
+        Total number of optimization steps expected for the run.
+    logger:
+        Optional :class:`PrometheusLogger` to record the metric.
+
+    Notes
+    -----
+    The estimate is based on the average step rate since the callback
+    creation:
+
+    .. math::
+
+        \text{ETA} = \frac{\text{steps}_\text{total} - \text{step}_\text{done}}
+        {\text{steps}_\text{per\_sec}}
+
+    where ``steps_per_sec = step_done / elapsed_time``.
+    """
+
+    def __init__(self, steps_total: int, logger: Optional[PrometheusLogger] = None):
+        self.steps_total = steps_total
+        self.logger = logger
+        # Reference time used to compute steps per second.
+        self._start_time = time.perf_counter()
+
+    def update(self, step_done: int) -> float:
+        """Update the ETA based on completed steps.
+
+        Parameters
+        ----------
+        step_done:
+            Number of steps completed so far.
+
+        Returns
+        -------
+        float
+            Estimated remaining time in seconds.
+        """
+        elapsed = time.perf_counter() - self._start_time
+        # Avoid division by zero for the initial call.
+        steps_per_sec = (
+            step_done / elapsed if step_done > 0 and elapsed > 0 else float("inf")
+        )
+        eta = (
+            (self.steps_total - step_done) / steps_per_sec
+            if steps_per_sec > 0
+            else float("inf")
+        )
+        if self.logger is not None:
+            self.logger.log(training_eta_seconds=eta)
+        return eta
+
+
+class FractalDimCallback:
+    """Estimate embedding fractal dimension every two epochs.
+
+    The callback computes the dimension using :func:`fractal_dim_embedding` and
+    logs the corresponding loss
+
+    .. math:: \mathcal{L}_{frac} = \beta |\hat D_f - D_f^{target}|.
+    """
+
+    def __init__(
+        self,
+        target_dim: float,
+        *,
+        beta: float = 1.0,
+        radii: Iterable[float] = (1.0, 2.0),
+        logger: Optional[PrometheusLogger] = None,
+    ) -> None:
+        self.target_dim = target_dim
+        self.beta = beta
+        self.radii = tuple(radii)
+        self.logger = logger
+        self._epoch = 0
+
+    def update(
+        self, embeddings: Mapping[object, Iterable[float]]
+    ) -> Optional[float]:
+        """Update the estimate and log the fractal loss.
+
+        Parameters
+        ----------
+        embeddings:
+            Mapping of node identifiers to embedding vectors.
+
+        Returns
+        -------
+        float | None
+            Dimension estimate when computed, otherwise ``None``.
+        """
+
+        self._epoch += 1
+        if self._epoch % 2:
+            return None
+        dim = fractal_dim_embedding(embeddings, self.radii)
+        loss = self.beta * abs(dim - self.target_dim)
+        if self.logger is not None:
+            self.logger.log(fractal_loss=loss)
+        return dim
 
 
 class EarlyStopping:
@@ -87,3 +210,50 @@ class EarlyStopping:
         else:
             self.bad_epochs += 1
         return self.bad_epochs >= self.patience
+
+
+class CheckpointPruner:
+    """Keep only the best ``k`` checkpoints based on a validation metric.
+
+    Parameters
+    ----------
+    k:
+        Number of checkpoints to retain. Defaults to ``2``.
+    mode:
+        Whether a larger (``"max"``) or smaller (``"min"``) metric value is
+        considered better.
+
+    Notes
+    -----
+    After saving a checkpoint, call :meth:`step` with its path and associated
+    validation metric :math:`m`. The pruner keeps the checkpoints with the
+    top-:math:`k` metric values and removes the others to limit disk usage.
+    """
+
+    def __init__(self, k: int = 2, mode: str = "max") -> None:
+        if mode not in {"max", "min"}:
+            raise ValueError("mode must be 'max' or 'min'")
+        self.k = k
+        self.mode = mode
+        # Store pairs of (metric, path) for existing checkpoints.
+        self._checkpoints: list[tuple[float, Path]] = []
+
+    def step(self, path: str, metric: float) -> None:
+        """Register a new checkpoint and prune excess ones.
+
+        Parameters
+        ----------
+        path:
+            Filesystem path where the checkpoint was saved.
+        metric:
+            Validation metric associated with this checkpoint.
+        """
+
+        p = Path(path)
+        self._checkpoints.append((metric, p))
+        # Sort according to metric quality.
+        self._checkpoints.sort(key=lambda x: x[0], reverse=self.mode == "max")
+        # Remove checkpoints beyond the top-k.
+        for _, obsolete in self._checkpoints[self.k:]:
+            shutil.rmtree(obsolete, ignore_errors=True)
+        self._checkpoints = self._checkpoints[: self.k]

--- a/training/reward_fn.py
+++ b/training/reward_fn.py
@@ -1,0 +1,119 @@
+"""Alias-aware fact-check reward utilities.
+
+This module extends the basic graph-based reward function by resolving
+entity aliases through a Neo4j full-text index. The reward is computed as
+
+.. math::
+
+    R = \frac{N_\text{facts} + N_\text{alias}}{N_\text{facts}}
+
+where :math:`N_\text{facts}` counts exact matches between extracted
+triplets and the knowledge graph while :math:`N_\text{alias}` counts
+matches found after alias canonicalisation via ``apoc.text.clean``.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Iterable, Set, Tuple
+
+from neo4j import Driver
+
+from .auto_feedback import extract_triplets
+
+# Type aliases mirroring ``auto_feedback`` for clarity.
+Triplet = Tuple[str, str, str]
+HyperGraph = Dict[Tuple[str, str], Set[str]]
+
+
+def _resolve_alias(driver: Driver | None, name: str) -> Set[str]:
+    """Return canonical entity names for ``name`` using Neo4j aliases.
+
+    Parameters
+    ----------
+    driver:
+        Active Neo4j driver. When ``None`` the function falls back to the
+        identity mapping which keeps the entity unchanged. This allows the
+        reward function to operate without Neo4j during tests.
+    name:
+        Raw entity name possibly containing punctuation or casing
+        variations.
+
+    Returns
+    -------
+    set of str
+        Set of canonical names obtained through ``apoc.text.clean`` and a
+        full-text index named ``alias``. If no mapping is found the original
+        name is returned.
+    """
+
+    if driver is None:
+        return {name}
+
+    query = (
+        "WITH apoc.text.clean($n) AS cleaned "
+        "CALL db.index.fulltext.queryNodes('alias', cleaned) YIELD node "
+        "RETURN node.canonical AS canonical"
+    )
+
+    with driver.session() as session:
+        records = session.run(query, n=name)
+        resolved = {r["canonical"] for r in records}  # type: ignore[index]
+    return resolved or {name}
+
+
+def build_alias_reward_fn(graph: HyperGraph, driver: Driver | None) -> Callable[[str], float]:
+    """Create an alias-aware reward function.
+
+    The returned callable extracts triplets from a model ``response`` and
+    verifies them against ``graph``. When a triplet is not found directly,
+    the subjects and objects are canonicalised through Neo4j to discover
+    alias matches. The reward is the ratio of validated facts—either exact
+    or via alias—over the number of extracted facts.
+
+    Parameters
+    ----------
+    graph:
+        Knowledge graph mapping ``(subject, predicate)`` pairs to a set of
+        accepted objects.
+    driver:
+        Neo4j driver providing access to the alias index. ``None`` skips alias
+        resolution, useful for offline tests.
+
+    Returns
+    -------
+    callable
+        Function taking a text ``response`` and returning the reward in
+        ``[0, 1]``.
+    """
+
+    def reward_fn(response: str) -> float:
+        triplets = extract_triplets(response)
+        if not triplets:
+            return 0.0
+
+        validated = 0
+        alias_validated = 0
+
+        for subj, pred, obj in triplets:
+            # Exact match
+            objects = graph.get((subj, pred), set())
+            if obj in objects:
+                validated += 1
+                continue
+
+            # Alias-based match
+            subj_aliases = _resolve_alias(driver, subj)
+            obj_aliases = _resolve_alias(driver, obj)
+            if any(
+                alias_obj in graph.get((alias_subj, pred), set())
+                for alias_subj in subj_aliases
+                for alias_obj in obj_aliases
+            ):
+                alias_validated += 1
+
+        return (validated + alias_validated) / len(triplets)
+
+    return reward_fn
+
+
+__all__ = ["build_alias_reward_fn", "_resolve_alias"]

--- a/training/reward_fn.py
+++ b/training/reward_fn.py
@@ -61,7 +61,9 @@ def _resolve_alias(driver: Driver | None, name: str) -> Set[str]:
     return resolved or {name}
 
 
-def build_alias_reward_fn(graph: HyperGraph, driver: Driver | None) -> Callable[[str], float]:
+def build_alias_reward_fn(
+    graph: HyperGraph, driver: Driver | None
+) -> Callable[[str], float]:
     """Create an alias-aware reward function.
 
     The returned callable extracts triplets from a model ``response`` and


### PR DESCRIPTION
## Summary
- reset AGENTS for Hardening Qualité / Perf / Gouvernance v2.1 checklist
- add Prometheus gauge and callback for `training_eta_seconds`
- expose `EtaCallback` at package level and cover with unit test
- implement semantic safety filter with HF toxicity model, NSFW regex, and Prometheus counter
- add dynamic SNR soft-gating utilities with adaptive threshold
- estimate hypergraph Laplacian spectral radius via lightweight power iteration
- surface sheaf/hypergraph spectral incoherence with `top_k_incoherent` utility and `/explain/sheaf_diff` route
- compress persistence image vectors via new incremental PCA reducer
- log fractal dimension drift with a periodic `FractalDimCallback` and Prometheus `fractal_loss` gauge
- prune stale checkpoints to retain the top 2 based on validation metric
- auto-tune Mapper overlap via silhouette grid search with a manual fallback metric
- introduce alias-aware fact-check reward backed by Neo4j alias resolution and property tests
- filter contradictory paraphrases in `ActiveLearningAugmenter` using a bart-large-mnli entailment check
- snapshot tokenizer.json to a LakeFS branch with SHA256 digest for reproducible dataset exports
- register LakeFS schema in `.lakefs/schema.yaml` and add a pre-commit guard that blocks breaking schema changes
- add end-to-end fine-tuning QA notebook example
- verify all checklist implementations by rerunning targeted unit tests

## Testing
- `pre-commit run --files AGENTS.md`
- `PYTHONPATH=$PWD pytest tests/unit/test_safety_filter.py tests/unit/test_quality_metrics.py tests/unit/test_hypergraph_conv.py tests/unit/test_sheaf_hyper_bridge.py tests/unit/test_explain_router.py tests/unit/test_tda_vectorize.py tests/unit/test_fractal_dim_embedding.py tests/unit/test_mapper.py tests/unit/test_schema_guard.py tests/unit/test_dataset_export.py tests/unit/test_reward_fn.py tests/property/test_reward_fn_properties.py tests/unit/test_augmenter.py tests/unit/test_monitoring.py tests/unit/test_checkpoint_pruner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e054754b0832f8260ae9a09f915d2