### PR TITLE
feat: add mapper overlap tuning, dynamic snr gate, tokenizer snapshot, and training ETA metric

### DIFF
--- a/datacreek/analysis/__init__.py
+++ b/datacreek/analysis/__init__.py
@@ -57,6 +57,7 @@ __all__ = [
     "mapper_full",
     "mapper_to_json",
     "autotune_mapper_overlap",
+    "tune_overlap",
     "bootstrap_db",
     "bootstrap_sigma_db",
     "fractal_net_prune",

--- a/datacreek/analysis/monitoring.py
+++ b/datacreek/analysis/monitoring.py
@@ -32,6 +32,7 @@ if Gauge is not None:
     sheaf_score_g = _metric(Gauge, "sheaf_score", "Sheaf consistency score")
     sheaf_hyper_score_g = _metric(Gauge, "sheaf_hyper_score", "Sheaf-hyper coherence")
     gw_entropy = _metric(Gauge, "gw_entropy", "GraphWave entropy")
+    snr_dynamic_thr = _metric(Gauge, "snr_dynamic_thr", "Adaptive SNR threshold in dB")
     autotune_cost_g = _metric(Gauge, "autotune_cost", "Current J(theta)")
     bias_wasserstein_last = _metric(
         Gauge, "bias_wasserstein_last", "Latest Wasserstein distance used"
@@ -143,6 +144,7 @@ else:  # pragma: no cover - optional dependency missing
     sheaf_score_g = None
     sheaf_hyper_score_g = None
     gw_entropy = None
+    snr_dynamic_thr = None  # type: ignore
     autotune_cost_g = None
     bias_wasserstein_last = None
     haa_edges_total = None
@@ -176,9 +178,11 @@ _METRICS = {
     "sheaf_score": sheaf_score_g,
     "sheaf_hyper_score": sheaf_hyper_score_g,
     "gw_entropy": gw_entropy,
+    "snr_dynamic_thr": snr_dynamic_thr,
     "tpl_w1": tpl_w1_g,
     "j_cost": j_cost,
     "autotune_cost": autotune_cost_g,
+    "mapper_overlap_opt": None,
     "bias_wasserstein_last": bias_wasserstein_last,
     "haa_edges_total": haa_edges_total,
     "gp_jitter_restarts_total": gp_jitter_restarts_total,

--- a/datacreek/utils/__init__.py
+++ b/datacreek/utils/__init__.py
@@ -101,6 +101,7 @@ except Exception:  # pragma: no cover - fallback when rich is missing
         yield None, 0
 
 
+from .audio_validator import AudioValidator
 from .redis_helpers import decode_hash
 from .redis_pid import get_current_ttl, start_pid_controller
 from .text import clean_text, extract_json_from_text, normalize_units, split_into_chunks
@@ -191,4 +192,5 @@ __all__ = [
     "record_feedback",
     "fine_tune_from_feedback",
     "snapshot_tokenizer",
+    "AudioValidator",
 ]

--- a/datacreek/utils/audio_validator.py
+++ b/datacreek/utils/audio_validator.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Audio validator with adaptive SNR threshold."""
+
+from collections import deque
+from typing import Deque
+
+from datacreek.analysis import monitoring
+
+from .quality_metrics import audio_snr, dynamic_snr_threshold
+
+__all__ = ["AudioValidator"]
+
+
+class AudioValidator:
+    r"""Validate audio clips using a dynamic SNR gate.
+
+    The validator maintains a rolling window of the last :math:`N` signal-to-noise
+    ratio (SNR) measurements.  The adaptive threshold is computed as
+
+    .. math::
+        \mathrm{thr} = 6 + 0.5\,\sigma_{SNR},
+
+    where :math:`\sigma_{SNR}` is the standard deviation of the collected SNR
+    values.  A higher variance thus raises the bar for accepting new audio
+    clips.
+
+    Parameters
+    ----------
+    window:
+        Maximum number of recent SNR values to keep in the history (default
+        500).
+    """
+
+    def __init__(self, window: int = 500) -> None:
+        self.history: Deque[float] = deque(maxlen=window)
+
+    def validate(self, pcm: bytes) -> bool:
+        """Return ``True`` if ``pcm`` passes the dynamic SNR threshold.
+
+        The current threshold is exported via the Prometheus metric
+        ``snr_dynamic_thr`` when the monitoring subsystem is available.
+        ``pcm`` is expected to contain 16-bit mono PCM samples.
+        """
+
+        snr = audio_snr(pcm)
+        threshold = dynamic_snr_threshold(self.history)
+        try:  # optional Prometheus metric
+            monitoring.update_metric("snr_dynamic_thr", threshold)
+        except Exception:  # pragma: no cover - metrics optional
+            pass
+        passed = snr >= threshold
+        self.history.append(snr)
+        return passed

--- a/tests/integration/test_mapper_full.py
+++ b/tests/integration/test_mapper_full.py
@@ -12,7 +12,9 @@ def test_mapper_full_and_json():
     nerve, cover = mapper.mapper_full(g, cover=(3, 0.5), clusterer="single")
     assert nerve.number_of_nodes() == len(cover)
 
-    data = json.loads(mapper.mapper_to_json(g, cover=(3, 0.5), clusterer="single"))
+    data = json.loads(
+        mapper.mapper_to_json(g, cover=(3, 0.5), clusterer="single", autotune=False)
+    )
     assert len(data["nodes"]) == len(cover)
     assert len(data["links"]) == nerve.number_of_edges()
 

--- a/tests/unit/test_audio_validator.py
+++ b/tests/unit/test_audio_validator.py
@@ -1,0 +1,42 @@
+import math
+
+import numpy as np
+
+from datacreek.analysis import monitoring
+from datacreek.utils.audio_validator import AudioValidator
+
+
+def _noise(duration=1600):
+    return (np.random.randn(duration).astype(np.int16)).tobytes()
+
+
+def _tone(duration=1600, snr_db=20.0, sr=1600):
+    signal = np.ones(duration) * 10000
+    noise = (10 ** (-snr_db / 20.0)) * np.random.randn(duration) * 10000
+    pcm = signal + noise
+    return np.asarray(pcm, dtype=np.int16).tobytes()
+
+
+def test_audio_validator_updates_metric(monkeypatch):
+    called = {}
+
+    def fake_update(name, value, labels=None):
+        called["name"] = name
+        called["value"] = value
+
+    monkeypatch.setattr(monitoring, "update_metric", fake_update)
+    v = AudioValidator(window=10)
+    pcm = _tone()
+    assert v.validate(pcm)
+    assert called["name"] == "snr_dynamic_thr"
+    assert math.isclose(called["value"], 6.0, rel_tol=1e-5)
+
+
+def test_audio_validator_rejects_noise():
+    v = AudioValidator(window=50)
+    false_pos = 0
+    for _ in range(100):
+        pcm = _noise()
+        if v.validate(pcm):
+            false_pos += 1
+    assert false_pos < 2

--- a/tests/unit/test_callbacks.py
+++ b/tests/unit/test_callbacks.py
@@ -1,0 +1,30 @@
+import sys
+import types
+from importlib import reload
+
+
+def test_prometheus_eta_callback_updates_gauge(monkeypatch):
+    class DummyGauge:
+        def __init__(self, name, desc):
+            self.name = name
+            self.desc = desc
+            self.value = None
+
+        def set(self, value):
+            self.value = value
+
+    dummy = types.SimpleNamespace(Gauge=DummyGauge)
+    monkeypatch.setitem(sys.modules, "prometheus_client", dummy)
+    from training import callbacks
+
+    reload(callbacks)
+    cb = callbacks.TrainingEtaSecondsCallback(total_steps=100)
+    args = types.SimpleNamespace(max_steps=100)
+    state = types.SimpleNamespace(global_step=0, max_steps=100)
+    control = object()
+    times = iter([0.0, 1.0])
+    monkeypatch.setattr(callbacks.time, "perf_counter", lambda: next(times))
+    cb.on_log(args, state, control)
+    state.global_step = 50
+    cb.on_log(args, state, control)
+    assert cb.gauge.value == 1.0

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -2,6 +2,7 @@
 
 from .augmenter import ActiveLearningAugmenter
 from .auto_feedback import build_reward_fn, extract_triplets
+from .callbacks import TrainingEtaSecondsCallback
 from .curriculum_dataloader import CurriculumDataLoader, compute_difficulty
 from .monitoring import EarlyStopping, EtaCallback, PrometheusLogger, init_wandb
 from .reward_fn import build_alias_reward_fn
@@ -27,4 +28,5 @@ __all__ = [
     "PrometheusLogger",
     "EtaCallback",
     "EarlyStopping",
+    "TrainingEtaSecondsCallback",
 ]

--- a/training/callbacks.py
+++ b/training/callbacks.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Prometheus callback to expose training ETA through the HF Trainer."""
+
+import time
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    from transformers import TrainerCallback  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+
+    class TrainerCallback:  # type: ignore
+        """Fallback base class when `transformers` is unavailable."""
+
+        pass
+
+
+try:  # pragma: no cover - optional dependency
+    from prometheus_client import Gauge
+except Exception:  # pragma: no cover - optional dependency
+    Gauge = None  # type: ignore
+
+
+class TrainingEtaSecondsCallback(TrainerCallback):
+    """Report remaining training time to Prometheus.
+
+    Parameters
+    ----------
+    total_steps:
+        Optional override for the total number of optimization steps. If not
+        provided, the callback will look for ``max_steps`` on the Trainer
+        ``args`` or ``state`` objects.
+
+    Notes
+    -----
+    The gauge ``training_eta_seconds`` is updated on every ``on_log`` event
+    using a smoothed step-rate estimate:
+
+    .. math::
+
+        ETA = \frac{steps_{tot} - steps_{done}}{steps/sec}
+
+    where ``steps/sec`` is derived from consecutive calls and exponentially
+    smoothed (factor 0.9).
+    """
+
+    def __init__(self, total_steps: Optional[int] = None) -> None:
+        if Gauge is None:  # pragma: no cover - optional dependency
+            raise ImportError("prometheus_client is not installed")
+        self.gauge = Gauge("training_eta_seconds", "ETA to finish")
+        self.total_steps = total_steps
+        self._last_time: Optional[float] = None
+        self._last_step: Optional[int] = None
+        self._rate: Optional[float] = None
+
+    def on_log(self, args, state, control, **kwargs):  # type: ignore[override]
+        """Hook executed by the Trainer to report metrics.
+
+        Parameters
+        ----------
+        args, state, control:
+            Objects provided by :class:`transformers.Trainer` describing the
+            current training state. Only ``max_steps`` and ``global_step`` are
+            accessed.
+        """
+
+        now = time.perf_counter()
+        step = getattr(state, "global_step", 0)
+        if self._last_time is not None and self._last_step is not None:
+            dt = now - self._last_time
+            ds = step - self._last_step
+            if dt > 0 and ds > 0:
+                inst_rate = ds / dt
+                self._rate = (
+                    inst_rate
+                    if self._rate is None
+                    else 0.9 * self._rate + 0.1 * inst_rate
+                )
+                steps_total = (
+                    self.total_steps
+                    or getattr(state, "max_steps", None)
+                    or getattr(args, "max_steps", None)
+                )
+                if self._rate and steps_total:
+                    eta = (steps_total - step) / self._rate
+                    self.gauge.set(eta)
+        self._last_time = now
+        self._last_step = step
+        return control


### PR DESCRIPTION
## Summary
- mark sheaf_diff endpoint, mapper overlap tuning, tokenizer snapshot, and training ETA gauge as completed in v2.1 checklist
- document roadmap progress and verification in AGENTS history

## Testing
- `pre-commit run --files AGENTS.md datacreek/utils/quality_metrics.py datacreek/utils/audio_validator.py datacreek/analysis/sheaf_hyper_bridge.py datacreek/routers/explain_router.py datacreek/analysis/mapper.py datacreek/utils/dataset_export.py training/callbacks.py tests/unit/test_quality_metrics.py tests/unit/test_audio_validator.py tests/unit/test_mapper.py tests/unit/test_dataset_export.py tests/unit/test_callbacks.py tests/unit/test_explain_router.py tests/unit/test_sheaf_hyper_bridge.py`
- `PYTHONPATH=. pytest tests/unit/test_quality_metrics.py::test_dynamic_snr_threshold_and_gate tests/unit/test_audio_validator.py tests/unit/test_mapper.py::test_tune_overlap_logs_metric tests/unit/test_mapper.py::test_autotune_mapper_overlap_increases_silhouette tests/unit/test_dataset_export.py tests/unit/test_callbacks.py tests/unit/test_explain_router.py::test_sheaf_diff tests/unit/test_explain_router.py::test_sheaf_diff_latency tests/unit/test_sheaf_hyper_bridge.py::test_top_k_incoherent_edges -q`

------
https://chatgpt.com/codex/tasks/task_e_688eca3ac7d8832f92ba76cf01c490fc