### PR TITLE
feat: add quota management utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@
   | $P_\text{unit}$ | prix/min      |
 * [x] **Quota controller** : stop job si crédits < 0
 * [x] **Coût total** `gpu_cost_total{tenant}` via $C=t_\text{GPU}\times P_\text{unit}$
+* [x] **Admin** : top-up & mise à jour prix par tenant
 * **DoD** : job dépasse quota ⇒ état `failed_quota`
 
 ---
@@ -202,5 +203,7 @@ ingest  >>   build_dataset   >>  fine_tune_SFT
   tests self-contained.
 - Expanded fine-tuning DAG tests to ensure tenant ID propagates through all downstream tasks.
 - Introduced GPU cost tracking metric and helper computing $C=t_\text{GPU}\times P_\text{unit}$ with tests.
-
+- Added balance query and credit top-up methods to GPU quota controller with tests.
 - Formatted DAG and Ray Serve test files via pre-commit and reran targeted tests.
+- Added tenant price update method to GPU quota controller with tests.
+- Ensured tests can import local packages by inserting the repository root into ``sys.path``.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,13 @@ import os
 import sys
 import types
 
+# Ensure the repository root is importable so test modules can resolve local
+# packages such as ``metrics_prometheus`` and ``scripts`` without relying on
+# ``PYTHONPATH`` environment tweaks.
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
 os.environ.setdefault("DATACREEK_REQUIRE_PERSISTENCE", "0")
 os.environ.setdefault("DATACREEK_LIGHT_DATASET", "1")
 

--- a/tests/unit/test_gpu_billing.py
+++ b/tests/unit/test_gpu_billing.py
@@ -42,3 +42,23 @@ def test_exceeding_quota_raises_without_increment():
 
 def test_calculate_cost_helper():
     assert calculate_cost(2.0, 3.5) == 7.0
+
+
+def test_add_credits_and_get_remaining():
+    controller = QuotaController({})
+    assert controller.get_remaining("acme") == 0.0
+    new_balance = controller.add_credits("acme", 15)
+    assert new_balance == 15
+    assert controller.get_remaining("acme") == 15
+    controller.add_credits("acme", 5)
+    assert controller.get_remaining("acme") == 20
+
+
+def test_set_price_controls_subsequent_cost():
+    reset_metrics()
+    controller = QuotaController({"acme": 10})
+    returned = controller.set_price("acme", 0.25)
+    assert returned == 0.25
+    controller.consume("acme", 4)
+    cost_value = REGISTRY.get_sample_value("gpu_cost_total", {"tenant": "acme"})
+    assert cost_value == 1.0


### PR DESCRIPTION
## Summary
- expose helper methods on QuotaController to query remaining GPU credits and to add credits
- allow administrators to update per-tenant GPU pricing on the QuotaController
- ensure tests can import local packages by prepending repository root to `sys.path`

## Testing
- `pre-commit run --files AGENTS.md tests/conftest.py metrics_prometheus/gpu_billing.py tests/unit/test_gpu_billing.py`
- `PYTHONPATH=. pytest tests/unit/test_gpu_billing.py tests/unit/test_gpu_dashboard.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'networkx'; 164 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6891adeaf404832fb625ec1d835144f0