### PR TITLE
feat: add ingest filter sidecar, track embedding CPU cost, clip SmoothQuant scales, replay late hypergraph edges, enforce GPU credit quotas, optimise Laplacian weights, add ILP patch solver, type Neo4j edges, expose Ray Serve metrics, count late hypergraph edges, and track drift alerts

### DIFF
--- a/datacreek/analysis/embedding.py
+++ b/datacreek/analysis/embedding.py
@@ -1,0 +1,58 @@
+"""Embedding utilities with CPU usage Prometheus metrics.
+
+This module exposes a context manager recording the CPU seconds spent
+when computing embeddings for a given tenant.  The collected data feeds
+billing dashboards that combine CPU and GPU costs.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+from prometheus_client import Counter
+
+from metrics_prometheus import CpuCostTracker
+
+# Counter tracking CPU seconds consumed by embedding computation per tenant.
+# The metric follows the ``*_total`` naming convention so Prometheus exposes
+# ``embedding_cpu_seconds_total_total`` as the sample name.
+embedding_cpu_seconds_total = Counter(
+    "embedding_cpu_seconds_total",
+    "CPU seconds spent computing embeddings per tenant",
+    ["tenant"],
+)
+
+
+@contextmanager
+def track_embedding_cpu_seconds(
+    tenant: str, tracker: CpuCostTracker | None = None
+) -> Iterator[None]:
+    """Record CPU time spent computing embeddings for ``tenant``.
+
+    Parameters
+    ----------
+    tenant:
+        Tenant identifier associated with the embedding job.
+    tracker:
+        Optional :class:`~metrics_prometheus.cpu_billing.CpuCostTracker` used to
+        translate the measured CPU time into monetary cost.  When ``None`` (the
+        default) only the time counter is updated.
+
+    Notes
+    -----
+    The timer relies on :func:`time.perf_counter` which measures wall-clock
+    time with high resolution.  The recorded value is added to the
+    :data:`embedding_cpu_seconds_total` counter which can be joined with GPU
+    metrics to produce unified billing reports.
+    """
+
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        elapsed = time.perf_counter() - start
+        embedding_cpu_seconds_total.labels(tenant=tenant).inc(elapsed)
+        if tracker is not None:
+            tracker.record(tenant, elapsed)

--- a/datacreek/drift.py
+++ b/datacreek/drift.py
@@ -13,11 +13,24 @@ DAGs and in unit tests without pulling heavy dependencies such as NumPy.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from math import sqrt
+from typing import Dict
+
+from prometheus_client import Counter
+
 WARN_THRESHOLD: float = 0.07
 """Drift value above which the system should emit a warning."""
 
 CRIT_THRESHOLD: float = 0.10
 """Drift value above which the system must trigger retraining."""
+
+# Counter tracking how many drift alerts were raised for each tenant.  This can
+# be scraped by billing or monitoring systems to observe stability across
+# tenants over time.
+drift_alert_total = Counter(
+    "drift_alert_total", "Number of EWMA drift alerts by tenant", ["tenant"]
+)
 
 
 def drift_level(value: float) -> str:
@@ -51,3 +64,82 @@ def should_trigger_retrain(value: float) -> bool:
     """
 
     return value >= CRIT_THRESHOLD
+
+
+@dataclass
+class _EWMAState:
+    """Internal container holding the running statistics for a tenant."""
+
+    mu: float
+    sigma: float
+
+
+class TenantEWMA:
+    """Track per-tenant drift with an Exponentially Weighted Moving Average.
+
+    The detector maintains the mean :math:`\mu_t` and standard deviation
+    :math:`\sigma_t` of observed drift scores for each tenant using the
+    recursive formulas:
+
+    .. math::
+
+        \mu_t = \lambda d_t + (1 - \lambda) \mu_{t-1}\\
+        \sigma_t = \sqrt{\lambda (d_t - \mu_t)^2 + (1-\lambda) \sigma_{t-1}^2}
+
+    An alert is raised when the new drift score ``d_t`` exceeds the dynamic
+    threshold ``mu_t + 3 * sigma_t``.  This scheme adapts to each tenant's
+    typical drift level and reduces false positives for low-traffic tenants.
+
+    Parameters
+    ----------
+    lambda_:
+        Smoothing factor :math:`\lambda` in ``[0, 1]`` controlling how much
+        weight is given to the latest observation.
+    """
+
+    def __init__(self, lambda_: float) -> None:
+        self.lambda_ = lambda_
+        self._state: Dict[str, _EWMAState] = {}
+
+    def update(self, tenant: str, drift: float) -> bool:
+        """Update the running statistics for ``tenant`` with ``drift``.
+
+        Parameters
+        ----------
+        tenant:
+            Identifier for the tenant emitting the drift score.
+        drift:
+            Current drift measurement ``d_t``.
+
+        Returns
+        -------
+        bool
+            ``True`` if the updated score exceeds ``mu_t + 3*sigma_t`` and an
+            alert should be triggered, ``False`` otherwise.
+        """
+
+        state = self._state.get(tenant)
+        if state is None:
+            # First observation initialises the state without alerting.
+            self._state[tenant] = _EWMAState(mu=drift, sigma=0.0)
+            return False
+
+        mu_t = self.lambda_ * drift + (1 - self.lambda_) * state.mu
+        sigma_t = sqrt(
+            self.lambda_ * (drift - mu_t) ** 2 + (1 - self.lambda_) * state.sigma**2
+        )
+        alert = drift > mu_t + 3 * sigma_t
+        self._state[tenant] = _EWMAState(mu=mu_t, sigma=sigma_t)
+        if alert:
+            drift_alert_total.labels(tenant=tenant).inc()
+        return alert
+
+
+__all__ = [
+    "WARN_THRESHOLD",
+    "CRIT_THRESHOLD",
+    "drift_level",
+    "should_trigger_retrain",
+    "drift_alert_total",
+    "TenantEWMA",
+]

--- a/datacreek/gpu_quota_webhook.py
+++ b/datacreek/gpu_quota_webhook.py
@@ -1,0 +1,90 @@
+"""Admission webhook enforcing per-tenant GPU credit quotas.
+
+This module exposes a small :mod:`fastapi` application that estimates the
+GPU time required for a training job and rejects the request if the tenant lacks
+sufficient credits.  Remaining credits are exported via a Prometheus gauge so
+external billing systems can scrape the balance.
+
+The admission controller computes the expected GPU minutes using
+
+.. math::
+
+    E_{gpu} = t_{epoch} \cdot n_{epoch}
+
+where ``t_epoch`` is the duration in minutes of a single epoch and ``n_epoch``
+is the number of epochs in the submitted job.  When ``E_gpu`` exceeds the
+available credits the webhook responds with HTTP ``403`` to signal that the job
+should not be scheduled.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from prometheus_client import Counter, Gauge
+from pydantic import BaseModel
+
+from metrics_prometheus.gpu_billing import QuotaController, QuotaExceededError
+
+# Prometheus gauge tracking the remaining GPU credits for each tenant.  The
+# value follows ``credits_left = credits_0 - \int gpu\_minutes\,dt``.
+gpu_credits_left = Gauge(
+    "gpu_credits_left", "Remaining GPU credits for a tenant", ["tenant"]
+)
+
+# Counter tracking total admission requests and whether they were accepted or
+# rejected.  The ``status`` label records ``accepted`` or ``rejected`` to
+# simplify monitoring dashboards.
+gpu_requests_total = Counter(
+    "gpu_requests_total",
+    "GPU admission requests by tenant and status",
+    ["tenant", "status"],
+)
+
+
+class JobSpec(BaseModel):
+    """Specification of the training job submitted by a tenant."""
+
+    tenant: str
+    t_epoch: float  # minutes per epoch
+    n_epoch: int
+
+
+def create_app(controller: QuotaController | None = None) -> FastAPI:
+    """Return a FastAPI app enforcing GPU credit quotas.
+
+    Parameters
+    ----------
+    controller:
+        Instance managing the credit balance for each tenant.  A default empty
+        controller is created when omitted which grants no credits.
+    """
+
+    app = FastAPI()
+    qc = controller or QuotaController({})
+
+    @app.post("/mutate")
+    def mutate(job: JobSpec) -> dict[str, float]:
+        """Approve or reject the submitted job based on remaining credits.
+
+        The expected GPU time ``E_gpu`` is computed as ``t_epoch * n_epoch``.  If
+        the tenant lacks sufficient credits an HTTP 403 error is raised;
+        otherwise credits are decremented and the remaining balance is returned.
+        """
+
+        e_gpu = job.t_epoch * job.n_epoch
+        remaining = qc.get_remaining(job.tenant)
+        if remaining < e_gpu:
+            gpu_requests_total.labels(job.tenant, "rejected").inc()
+            raise HTTPException(status_code=403, detail="insufficient credits")
+        try:
+            new_balance = qc.consume(job.tenant, e_gpu)
+        except QuotaExceededError as exc:  # pragma: no cover - defensive
+            gpu_requests_total.labels(job.tenant, "rejected").inc()
+            # Consume may still raise if credits changed concurrently; surface
+            # the error as HTTP 403 to match admission semantics.
+            raise HTTPException(status_code=403, detail=str(exc))
+        gpu_requests_total.labels(job.tenant, "accepted").inc()
+        gpu_credits_left.labels(tenant=job.tenant).set(new_balance)
+        return {"credits_left": new_balance}
+
+    return app

--- a/datacreek/hypergraph.py
+++ b/datacreek/hypergraph.py
@@ -16,6 +16,9 @@ checklist is 500 ms:
 
 .. math::
    \text{p95 latency} < 0.5\,\text{s}
+
+The module also exposes a Prometheus counter ``late_edge_total`` that tracks
+how many edges arrive after the watermark and are routed to the late-event sink.
 """
 
 from __future__ import annotations
@@ -24,7 +27,24 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, List
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+import numpy as np
+
+try:  # optional Prometheus metric for late edges
+    from prometheus_client import Counter
+except Exception:  # pragma: no cover - metrics optional
+    Counter = None  # type: ignore
+
+# Prometheus counter incremented when an edge arrives after the watermark
+LATE_EDGE_TOTAL: Optional[Counter]
+if Counter is not None:
+    LATE_EDGE_TOTAL = Counter(
+        "late_edge_total",
+        "Hypergraph edges routed to the late-event sink",
+    )
+else:  # pragma: no cover - metrics optional
+    LATE_EDGE_TOTAL = None
 
 
 def process_edge_stream(
@@ -57,6 +77,73 @@ def process_edge_stream(
             _flush_batch(batch, hot_layer)
             batch = [event]
             window_start = event["ts"]
+    if batch:
+        _flush_batch(batch, hot_layer)
+
+
+def process_edge_stream_with_watermark(
+    events: Iterable[Dict[str, Any]],
+    hot_layer: "RedisGraphHotLayer",
+    *,
+    window: timedelta = timedelta(seconds=30),
+    max_out_of_order: timedelta = timedelta(minutes=10),
+    late_sink: Callable[[Dict[str, Any]], None] | None = None,
+) -> None:
+    """Stream edges with bounded out-of-orderness and late-event replay.
+
+    This helper mimics Flink's
+    :meth:`WatermarkStrategy.forBoundedOutOfOrderness` with a
+    ``max_out_of_order`` delay of 10 minutes by default.  Events that arrive
+    later than the watermark (``max_ts - max_out_of_order``) are considered
+    *late* and are forwarded to ``late_sink`` instead of being written to the
+    hot layer.  On-time events are grouped into 30 second tumbling windows and
+    flushed to ``hot_layer`` similarly to :func:`process_edge_stream`.
+
+    Parameters
+    ----------
+    events:
+        Iterable of event dictionaries with ``src``, ``dst`` and ``ts``
+        (:class:`datetime`).  The iterable is consumed in the given order to
+        simulate streaming arrival.
+    hot_layer:
+        Instance of :class:`RedisGraphHotLayer` receiving edge updates.
+    window:
+        Length of the tumbling window.  Defaults to 30 seconds.
+    max_out_of_order:
+        Maximum tolerated difference between the highest observed timestamp and
+        the current event before the event is considered late.  Defaults to
+        10 minutes.
+    late_sink:
+        Optional callback invoked with late events.  It can forward the event to
+        a Kafka topic such as ``late_edges``.
+    """
+
+    max_ts: datetime | None = None
+    batch: List[Dict[str, Any]] = []
+    window_start: datetime | None = None
+
+    for event in events:
+        ts = event["ts"]
+        if max_ts is None or ts > max_ts:
+            max_ts = ts
+        watermark = max_ts - max_out_of_order
+
+        if ts < watermark:
+            if LATE_EDGE_TOTAL is not None:  # pragma: no branch - metric optional
+                LATE_EDGE_TOTAL.inc()
+            if late_sink is not None:
+                late_sink(event)
+            continue
+
+        if window_start is None:
+            window_start = ts
+        if ts - window_start >= window:
+            _flush_batch(batch, hot_layer)
+            batch = []
+            window_start = ts
+
+        batch.append(event)
+
     if batch:
         _flush_batch(batch, hot_layer)
 
@@ -105,3 +192,80 @@ class RedisGraphHotLayer:
         sorted_lat = sorted(self.latencies)
         idx = int(0.95 * (len(sorted_lat) - 1))
         return sorted_lat[idx] * 1000
+
+
+def laplacian(B: np.ndarray, W: np.ndarray | None = None) -> np.ndarray:
+    """Compute the normalised Laplacian for a hypergraph edge type.
+
+    Parameters
+    ----------
+    B:
+        Incidence matrix with shape ``(n_nodes, n_edges)`` where ``B[i, j] = 1``
+        if node ``i`` participates in hyperedge ``j``.  The matrix corresponds
+        to :math:`B_t` in the specification.
+    W:
+        Diagonal matrix of hyperedge weights with shape ``(n_edges, n_edges)``.
+        When ``None`` the identity matrix is used, matching the default
+        :math:`W_t = I` (initial weight ``1`` for every hyperedge).
+
+    Returns
+    -------
+    numpy.ndarray
+        The Laplacian :math:`\mathcal{L}^{(t)}` defined as
+
+        .. math::
+
+           \mathcal{L}^{(t)} = I - D_t^{-1/2} B_t W_t D_t^{-1} B_t^\top D_t^{-1/2}
+
+        where :math:`D_t` is the diagonal matrix of node degrees.
+    """
+
+    n_nodes, n_edges = B.shape
+    if W is None:
+        W = np.eye(n_edges)
+    deg = B @ W @ np.ones(n_edges)
+    D = np.diag(np.maximum(deg, 1e-12))
+    D_inv_sqrt = np.linalg.inv(np.sqrt(D))
+    D_inv = np.linalg.inv(D)
+    return np.eye(n_nodes) - D_inv_sqrt @ B @ W @ D_inv @ B.T @ D_inv_sqrt
+
+
+def multiplex_laplacian(
+    B_list: List[np.ndarray],
+    alpha: np.ndarray,
+    W_list: List[np.ndarray] | None = None,
+) -> np.ndarray:
+    """Combine per-type Laplacians into a multiplex Laplacian.
+
+    Parameters
+    ----------
+    B_list:
+        List of incidence matrices for each edge type.
+    alpha:
+        Non‑negative weights for each type.  They are renormalised to ensure
+        :math:`\sum_t \alpha_t = 1` before combining the Laplacians.
+    W_list:
+        Optional list of weight matrices corresponding to ``B_list``.  When
+        ``None`` each edge type is assumed to have unit weights.
+
+    Returns
+    -------
+    numpy.ndarray
+        Multiplex Laplacian :math:`\Delta_\text{multi}` as in the checklist
+
+        .. math::
+
+           \Delta_\text{multi} = \sum_t \alpha_t\,\mathcal{L}^{(t)}.
+    """
+
+    if W_list is None:
+        W_list = [None] * len(B_list)
+
+    alpha = np.asarray(alpha, dtype=float)
+    if np.any(alpha < 0):
+        raise ValueError("alpha_t must be non-negative")
+    if not np.isclose(alpha.sum(), 1.0):
+        alpha = alpha / alpha.sum()
+
+    Ls = [laplacian(B, W) for B, W in zip(B_list, W_list)]
+    return sum(a * L for a, L in zip(alpha, Ls))

--- a/datacreek/smart_patch.py
+++ b/datacreek/smart_patch.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+from uuid import uuid4
+
+from ortools.linear_solver import pywraplp
+
+# Global registry storing chosen patch sets by opaque identifier.
+PATCHSET_REGISTRY: dict[str, List[str]] = {}
+
+
+@dataclass(frozen=True)
+class PatchCandidate:
+    r"""Candidate edge that may be patched.
+
+    Parameters
+    ----------
+    edge_id:
+        Identifier for the edge.
+    benefit:
+        Consistency gain :math:`c_e` obtained if the patch is applied.
+    risk:
+        Associated risk weight :math:`w_e` used in the budget constraint.
+    """
+
+    edge_id: str
+    benefit: float
+    risk: float
+
+
+def solve_patch_ilp(
+    candidates: Sequence[PatchCandidate], budget: float
+) -> Tuple[str, List[str]]:
+    r"""Solve the smart-patch ILP and store the resulting patch set.
+
+    The optimisation problem is
+
+    .. math::
+
+        \max_x \sum_e c_e x_e \quad\text{s.t.}\quad \sum_e w_e x_e \le B,\;x_e\in\{0,1\}
+
+    where :math:`c_e` is the expected consistency improvement for edge ``e`` and
+    :math:`w_e` is its risk. ``B`` is the total risk budget. Selected edge ids are
+    registered in :data:`PATCHSET_REGISTRY` under a generated patch set id.
+
+    Parameters
+    ----------
+    candidates:
+        Iterable of patch candidates.
+    budget:
+        Maximum total risk :math:`B` allowed.
+
+    Returns
+    -------
+    tuple[str, list[str]]
+        The patch set identifier and the list of selected edge ids.
+    """
+
+    solver = pywraplp.Solver.CreateSolver("SCIP")
+    if solver is None:  # pragma: no cover - solver missing in environment
+        raise RuntimeError("SCIP solver is not available")
+
+    edge_vars = {
+        cand.edge_id: solver.BoolVar(f"x_{cand.edge_id}") for cand in candidates
+    }
+
+    # Risk budget constraint: sum_e w_e x_e <= B
+    solver.Add(
+        sum(cand.risk * edge_vars[cand.edge_id] for cand in candidates) <= budget
+    )
+
+    # Objective: maximise total consistency gain.
+    objective = solver.Objective()
+    for cand in candidates:
+        objective.SetCoefficient(edge_vars[cand.edge_id], cand.benefit)
+    objective.SetMaximization()
+
+    status = solver.Solve()
+    if status != pywraplp.Solver.OPTIMAL:
+        raise RuntimeError("ILP solver did not find optimal solution")
+
+    selected = [
+        cand.edge_id
+        for cand in candidates
+        if edge_vars[cand.edge_id].solution_value() > 0.5
+    ]
+    patchset_id = uuid4().hex
+    PATCHSET_REGISTRY[patchset_id] = selected
+    return patchset_id, selected

--- a/ingest/ingest_filter.py
+++ b/ingest/ingest_filter.py
@@ -1,0 +1,146 @@
+"""FastAPI microservice performing pre-ingestion safety, language and audio checks.
+
+The service is designed to run as a side-car in front of the Kafka ingestion
+pipeline.  It exposes a single ``POST /filter`` endpoint that validates a
+payload using three stages:
+
+1. **Language identification** – payloads outside of French or English are
+   skipped and accounted by the ``lang_skipped_total`` Prometheus counter.  The
+   detection is deliberately lightweight for unit testing.
+2. **Audio signal-to-noise gate** – the caller provides the current audio SNR
+   and a history of previous SNR measurements.  The threshold is computed as
+
+   .. math::
+
+       \text{thr}_{SNR} = 6 + 0.5\,\sigma_{SNR}
+
+   where :math:`\sigma_{SNR}` is the standard deviation of the history.  When
+   the current SNR falls below this threshold the request is rejected with HTTP
+   422 and both ``filter_block_total`` and ``snr_block_total`` are incremented
+   to distinguish audio issues from toxicity blocks.
+3. **Toxicity/NSFW filter** – delegates to :func:`ingest.safety_filter.filter_text`
+   which combines a tiny transformer model and regex heuristics.  Failing the
+   filter also results in HTTP 422 and a counter increment.
+
+The service is meant to be deployed behind Envoy and returns HTTP 422 whenever
+validation fails so upstream components can drop the payload before it reaches
+Kafka.
+"""
+
+from __future__ import annotations
+
+from math import sqrt
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .safety_filter import filter_text
+
+try:  # optional Prometheus metrics
+    from prometheus_client import CollectorRegistry, Counter
+except Exception:  # pragma: no cover - metrics disabled
+    CollectorRegistry = Counter = None  # type: ignore
+
+# ---------------------------------------------------------------------------
+# Prometheus counters
+# ---------------------------------------------------------------------------
+FILTER_BLOCK_TOTAL: Optional[Counter]
+LANG_SKIPPED_TOTAL: Optional[Counter]
+SNR_BLOCK_TOTAL: Optional[Counter]
+if Counter is not None:
+    _REGISTRY = CollectorRegistry(auto_describe=True)
+    FILTER_BLOCK_TOTAL = Counter(
+        "filter_block_total",
+        "Payloads blocked by the ingest-filter side-car",
+        registry=_REGISTRY,
+    )
+    LANG_SKIPPED_TOTAL = Counter(
+        "lang_skipped_total",
+        "Payloads skipped due to unsupported language",
+        registry=_REGISTRY,
+    )
+    SNR_BLOCK_TOTAL = Counter(
+        "snr_block_total",
+        "Payloads rejected due to low signal-to-noise ratio",
+        registry=_REGISTRY,
+    )
+else:  # pragma: no cover - metrics disabled
+    FILTER_BLOCK_TOTAL = None
+    LANG_SKIPPED_TOTAL = None
+    SNR_BLOCK_TOTAL = None
+
+# Languages allowed for downstream BLIP/Whisper processing
+ALLOWED_LANGS = {"fr", "en"}
+
+
+class Payload(BaseModel):
+    """Input payload inspected by the ingest filter."""
+
+    text: str = ""
+    snr: float = 0.0
+    snr_history: List[float] = []
+
+
+def detect_language(text: str) -> str:
+    """Return a crude language ID using simple heuristics.
+
+    The implementation purposefully avoids external dependencies.  It merely
+    checks for a handful of accented characters to classify French and defaults
+    to English otherwise.
+    """
+
+    lower = text.lower()
+    if any(ch in lower for ch in "àâçéèêëîïôùûüÿœ") or "bonjour" in lower:
+        return "fr"
+    if "hola" in lower:
+        return "es"
+    return "en"
+
+
+def compute_snr_threshold(history: List[float]) -> float:
+    """Compute :math:`\text{thr}_{SNR}` from a history of SNR samples."""
+
+    if not history:
+        return 6.0
+    mean = sum(history) / len(history)
+    sigma = sqrt(sum((x - mean) ** 2 for x in history) / len(history))
+    return 6.0 + 0.5 * sigma
+
+
+def create_app() -> FastAPI:
+    """Return a configured FastAPI application for the ingest filter."""
+
+    app = FastAPI()
+
+    @app.post("/filter")
+    def filter_payload(payload: Payload) -> dict:
+        """Validate ``payload`` and return a status object.
+
+        Rejections raise :class:`HTTPException` with status 422.  Successful
+        payloads return ``{"status": "ok"}`` while unsupported languages result
+        in ``{"status": "lang_skipped"}``.
+        """
+
+        lang = detect_language(payload.text)
+        if lang not in ALLOWED_LANGS:
+            if LANG_SKIPPED_TOTAL is not None:  # pragma: no branch - metric optional
+                LANG_SKIPPED_TOTAL.inc()
+            return {"status": "lang_skipped", "lang": lang}
+
+        thr = compute_snr_threshold(payload.snr_history)
+        if payload.snr < thr:
+            if FILTER_BLOCK_TOTAL is not None:  # pragma: no branch - metric optional
+                FILTER_BLOCK_TOTAL.inc()
+            if SNR_BLOCK_TOTAL is not None:  # pragma: no branch - metric optional
+                SNR_BLOCK_TOTAL.inc()
+            raise HTTPException(status_code=422, detail="low_snr")
+
+        if filter_text(payload.text) is None:
+            if FILTER_BLOCK_TOTAL is not None:  # pragma: no branch - metric optional
+                FILTER_BLOCK_TOTAL.inc()
+            raise HTTPException(status_code=422, detail="blocked")
+
+        return {"status": "ok"}
+
+    return app

--- a/k8s/cron/gc.yaml
+++ b/k8s/cron/gc.yaml
@@ -1,0 +1,18 @@
+# CronJob to garbage-collect old checkpoints and keep cluster storage usage under control
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: checkpoint-gc
+spec:
+  # Runs once per day at midnight
+  schedule: "@daily"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: gc
+              image: datacreek/cron:latest
+              # Execute the checkpoint cleanup script
+              command: ["python", "/app/cleanup_checkpoints.py"]
+          restartPolicy: OnFailure

--- a/metrics_prometheus/__init__.py
+++ b/metrics_prometheus/__init__.py
@@ -1,5 +1,19 @@
 """Prometheus metrics utilities for Datacreek."""
 
-from .gpu_billing import QuotaController, QuotaExceededError, gpu_minutes_total
+from .cpu_billing import CpuCostTracker, cpu_cost_total, cpu_seconds_total
+from .gpu_billing import (
+    QuotaController,
+    QuotaExceededError,
+    gpu_cost_total,
+    gpu_minutes_total,
+)
 
-__all__ = ["gpu_minutes_total", "QuotaController", "QuotaExceededError"]
+__all__ = [
+    "gpu_minutes_total",
+    "gpu_cost_total",
+    "QuotaController",
+    "QuotaExceededError",
+    "cpu_seconds_total",
+    "cpu_cost_total",
+    "CpuCostTracker",
+]

--- a/metrics_prometheus/cpu_billing.py
+++ b/metrics_prometheus/cpu_billing.py
@@ -1,0 +1,64 @@
+"""CPU cost tracking for billing dashboards.
+
+This module provides a :class:`CpuCostTracker` that records per-tenant CPU
+usage and translates it to monetary cost.  The tracked data complements the
+GPU billing counters to surface a unified CPU+GPU cost view.
+
+The cost for a span of CPU time is computed with
+
+.. math::
+    C = t_{CPU}(s) \times P_{unit}
+
+where ``t_CPU`` is measured in seconds and ``P_unit`` is the per-second price
+configured for the tenant.  Recorded usage is exported via the Prometheus
+counters :data:`cpu_seconds_total` and :data:`cpu_cost_total`.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from prometheus_client import Counter
+
+# Counter accumulating raw CPU seconds per tenant.  This metric follows the
+# ``*_total`` naming convention so Prometheus exposes
+# ``cpu_seconds_total_total`` as the sample name.
+cpu_seconds_total = Counter(
+    "cpu_seconds_total", "CPU seconds consumed per tenant", ["tenant"]
+)
+
+# Counter accumulating the monetary CPU cost per tenant in the configured
+# currency.  Downstream billing dashboards can directly scrape this value to
+# display total charges.
+cpu_cost_total = Counter(
+    "cpu_cost_total", "Accumulated CPU cost per tenant", ["tenant"]
+)
+
+
+class CpuCostTracker:
+    """Track CPU usage and cost for a set of tenants.
+
+    Parameters
+    ----------
+    prices:
+        Optional mapping of tenant identifier to per-second CPU price.  Tenants
+        not present default to a price of ``0`` which effectively disables cost
+        tracking for them.
+    """
+
+    def __init__(self, prices: Dict[str, float] | None = None) -> None:
+        # Copy mappings so callers can pass in literals without side effects.
+        self._prices: Dict[str, float] = dict(prices or {})
+
+    def set_price(self, tenant: str, price: float) -> float:
+        """Set the per-second CPU price for *tenant* and return the new price."""
+
+        self._prices[tenant] = price
+        return price
+
+    def record(self, tenant: str, seconds: float) -> None:
+        """Record ``seconds`` of CPU time for *tenant* and update metrics."""
+
+        cpu_seconds_total.labels(tenant=tenant).inc(seconds)
+        price = self._prices.get(tenant, 0.0)
+        cpu_cost_total.labels(tenant=tenant).inc(seconds * price)

--- a/scripts/train_alpha.py
+++ b/scripts/train_alpha.py
@@ -1,0 +1,63 @@
+"""Meta-optimise multiplex weights ``alpha_t`` on validation Macro-F1.
+
+The script provides a :func:`train_alpha` helper implementing a projected
+gradient ascent step on the simplex.  External callers are expected to provide a
+``grad_fn`` that returns the gradient of the validation Macro-F1 with respect to
+``alpha``.  The routine keeps the weights non-negative and normalised so that
+
+.. math::
+
+   \sum_t \alpha_t = 1.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+
+
+def train_alpha(
+    alpha_init: np.ndarray,
+    grad_fn: Callable[[np.ndarray], np.ndarray],
+    *,
+    lr: float = 0.1,
+    steps: int = 100,
+) -> np.ndarray:
+    """Optimise ``alpha`` via projected gradient ascent.
+
+    Parameters
+    ----------
+    alpha_init:
+        Initial weights for each edge type.  They will be projected onto the
+        probability simplex.
+    grad_fn:
+        Callable returning the gradient of validation Macro-F1 with respect to
+        ``alpha`` at the current point.
+    lr:
+        Step size for the gradient ascent update.
+    steps:
+        Number of gradient steps to perform.
+
+    Returns
+    -------
+    numpy.ndarray
+        Optimised weights that satisfy the constraints ``alpha_t >= 0`` and
+        ``sum(alpha) == 1``.
+    """
+
+    alpha = np.asarray(alpha_init, dtype=float)
+    alpha = np.clip(alpha, 0, None)
+    alpha /= alpha.sum()
+
+    for _ in range(steps):
+        grad = grad_fn(alpha)
+        alpha = alpha + lr * grad
+        alpha = np.clip(alpha, 0, None)
+        alpha_sum = alpha.sum()
+        if alpha_sum == 0:
+            # Avoid division by zero; fall back to uniform distribution.
+            alpha = np.full_like(alpha, 1.0 / len(alpha))
+        else:
+            alpha /= alpha_sum
+    return alpha

--- a/tests/test_drift_ewma.py
+++ b/tests/test_drift_ewma.py
@@ -1,0 +1,32 @@
+"""Tests for adaptive drift threshold based on EWMA per tenant."""
+
+from math import sqrt
+
+import pytest
+from prometheus_client import REGISTRY
+
+from datacreek.drift import TenantEWMA, drift_alert_total
+
+
+def test_ewma_updates_state_correctly() -> None:
+    det = TenantEWMA(lambda_=0.2)
+    # First observation initializes the state without alert
+    assert not det.update("alice", 0.0)
+    # Second observation updates mean and sigma
+    alerted = det.update("alice", 0.5)
+    assert not alerted
+    state = det._state["alice"]
+    expected_mu = 0.2 * 0.5 + 0.8 * 0.0
+    expected_sigma = sqrt(0.2 * (0.5 - expected_mu) ** 2 + 0.8 * 0.0**2)
+    assert state.mu == pytest.approx(expected_mu)
+    assert state.sigma == pytest.approx(expected_sigma)
+
+
+def test_alert_triggers_on_large_drift() -> None:
+    det = TenantEWMA(lambda_=0.1)
+    drift_alert_total.clear()
+    for _ in range(5):
+        assert not det.update("bob", 0.1)
+    assert det.update("bob", 1.0)
+    sample = REGISTRY.get_sample_value("drift_alert_total", labels={"tenant": "bob"})
+    assert sample == 1

--- a/tests/test_embedding_cpu_metrics.py
+++ b/tests/test_embedding_cpu_metrics.py
@@ -1,0 +1,44 @@
+"""Tests for the embedding CPU usage Prometheus metric and cost tracking."""
+
+import time
+
+from prometheus_client import REGISTRY
+
+from datacreek.analysis.embedding import (
+    embedding_cpu_seconds_total,
+    track_embedding_cpu_seconds,
+)
+from metrics_prometheus.cpu_billing import CpuCostTracker, cpu_cost_total
+
+
+def reset_metrics() -> None:
+    embedding_cpu_seconds_total._metrics.clear()  # type: ignore[attr-defined]
+    cpu_cost_total._metrics.clear()  # type: ignore[attr-defined]
+
+
+def test_track_embedding_cpu_seconds_increments_counter() -> None:
+    """Counter should increase by the elapsed time inside the context."""
+    reset_metrics()
+    with track_embedding_cpu_seconds("alice"):
+        sum(i * i for i in range(1000))
+    value = REGISTRY.get_sample_value(
+        "embedding_cpu_seconds_total", {"tenant": "alice"}
+    )
+    assert value is not None and value > 0
+
+
+def test_context_manager_updates_cost_when_tracker_provided(monkeypatch) -> None:
+    """Supplying a cost tracker should increment the cost counter proportionally."""
+    reset_metrics()
+
+    times = iter([1.0, 3.0])  # 2 seconds elapsed
+    monkeypatch.setattr(time, "perf_counter", lambda: next(times))
+    tracker = CpuCostTracker(prices={"alice": 0.5})
+    with track_embedding_cpu_seconds("alice", tracker):
+        pass
+    seconds_value = REGISTRY.get_sample_value(
+        "embedding_cpu_seconds_total", {"tenant": "alice"}
+    )
+    cost_value = REGISTRY.get_sample_value("cpu_cost_total", {"tenant": "alice"})
+    assert seconds_value == 2.0
+    assert cost_value == 1.0

--- a/tests/test_gc_cron.py
+++ b/tests/test_gc_cron.py
@@ -1,0 +1,17 @@
+"""Validate configuration of the GC checkpoint CronJob."""
+
+from pathlib import Path
+
+import yaml
+
+
+def test_gc_cron_schedule_and_command():
+    """CronJob should run daily and invoke the cleanup script."""
+    manifest = yaml.safe_load(Path("k8s/cron/gc.yaml").read_text())
+    # Ensure the job triggers once per day
+    assert manifest["spec"]["schedule"] == "@daily"
+    container = manifest["spec"]["jobTemplate"]["spec"]["template"]["spec"][
+        "containers"
+    ][0]
+    cmd = container.get("args") or container.get("command") or []
+    assert any("cleanup_checkpoints.py" in part for part in cmd)

--- a/tests/test_gpu_quota_webhook.py
+++ b/tests/test_gpu_quota_webhook.py
@@ -1,0 +1,50 @@
+"""Tests for the GPU quota admission webhook."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from prometheus_client import REGISTRY
+
+from datacreek.gpu_quota_webhook import create_app, gpu_credits_left, gpu_requests_total
+from metrics_prometheus.gpu_billing import QuotaController
+
+
+def test_job_rejected_when_over_budget() -> None:
+    """Submitting a job whose expected GPU time exceeds credits returns 403."""
+
+    gpu_credits_left.clear()  # ensure a clean registry
+    gpu_requests_total.clear()
+    controller = QuotaController({"tenant-a": 50})
+    app = create_app(controller)
+    client = TestClient(app)
+
+    # First submit a small job consuming 20 minutes to leave 30 credits.
+    resp_ok = client.post(
+        "/mutate", json={"tenant": "tenant-a", "t_epoch": 10, "n_epoch": 2}
+    )
+    assert resp_ok.status_code == 200
+    assert resp_ok.json()["credits_left"] == 30
+    # Gauge and counter should reflect the accepted request
+    sample = REGISTRY.get_sample_value(
+        "gpu_credits_left", labels={"tenant": "tenant-a"}
+    )
+    assert sample == 30
+    accepted = REGISTRY.get_sample_value(
+        "gpu_requests_total", labels={"tenant": "tenant-a", "status": "accepted"}
+    )
+    assert accepted == 1
+
+    # Second job requires 40 minutes which exceeds remaining 30 credits
+    resp = client.post(
+        "/mutate", json={"tenant": "tenant-a", "t_epoch": 20, "n_epoch": 2}
+    )
+    assert resp.status_code == 403
+    # Balance and rejected counter should update accordingly
+    sample_after = REGISTRY.get_sample_value(
+        "gpu_credits_left", labels={"tenant": "tenant-a"}
+    )
+    assert sample_after == 30
+    rejected = REGISTRY.get_sample_value(
+        "gpu_requests_total", labels={"tenant": "tenant-a", "status": "rejected"}
+    )
+    assert rejected == 1

--- a/tests/test_hypergraph_laplacian.py
+++ b/tests/test_hypergraph_laplacian.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from datacreek.hypergraph import laplacian, multiplex_laplacian
+
+
+def test_laplacian_row_sums_zero():
+    B = np.array([[1, 0], [0, 1]])
+    L = laplacian(B)
+    assert np.allclose(L.sum(axis=1), 0)
+
+
+def test_multiplex_laplacian_composition():
+    B1 = np.array([[1, 0], [1, 1]])
+    B2 = np.array([[0, 1], [1, 0]])
+    alpha = np.array([0.5, 0.5])
+    L_multi = multiplex_laplacian([B1, B2], alpha)
+    expected = 0.5 * laplacian(B1) + 0.5 * laplacian(B2)
+    assert np.allclose(L_multi, expected)

--- a/tests/test_hypergraph_watermark.py
+++ b/tests/test_hypergraph_watermark.py
@@ -1,0 +1,42 @@
+import datetime as dt
+
+from datacreek.hypergraph import (
+    LATE_EDGE_TOTAL,
+    RedisGraphHotLayer,
+    process_edge_stream_with_watermark,
+)
+
+
+def test_late_event_within_bound_processed():
+    """An event 8 minutes late should still be written to the hot layer."""
+    base = dt.datetime(2024, 1, 1, 0, 0, 0)
+    events = [
+        {"src": "new", "dst": "later", "ts": base + dt.timedelta(minutes=10)},
+        # 8 minutes older than the current max timestamp
+        {"src": "old", "dst": "late", "ts": base + dt.timedelta(minutes=2)},
+    ]
+    hot = RedisGraphHotLayer()
+    late: list[dict] = []
+    process_edge_stream_with_watermark(events, hot, late_sink=late.append)
+
+    assert set(hot.neighbours("old")) == {"late"}
+    assert late == []
+
+
+def test_event_beyond_bound_goes_to_late_sink():
+    """Events older than the watermark are forwarded to the late sink."""
+    base = dt.datetime(2024, 1, 1, 0, 0, 0)
+    events = [
+        {"src": "new", "dst": "later", "ts": base + dt.timedelta(minutes=10)},
+        # 15 minutes older than the current max timestamp -> late
+        {"src": "old", "dst": "too_late", "ts": base - dt.timedelta(minutes=5)},
+    ]
+    hot = RedisGraphHotLayer()
+    late: list[dict] = []
+    start = LATE_EDGE_TOTAL._value.get() if LATE_EDGE_TOTAL is not None else 0.0
+    process_edge_stream_with_watermark(events, hot, late_sink=late.append)
+
+    assert hot.neighbours("old") == []
+    assert len(late) == 1 and late[0]["dst"] == "too_late"
+    if LATE_EDGE_TOTAL is not None:
+        assert LATE_EDGE_TOTAL._value.get() == start + 1

--- a/tests/test_ingest_filter_service.py
+++ b/tests/test_ingest_filter_service.py
@@ -1,0 +1,85 @@
+"""Tests for the ``ingest-filter`` pre-ingestion microservice."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import ingest.ingest_filter as ingest_filter
+
+
+def test_block_on_toxic_text(monkeypatch) -> None:
+    """Toxic payloads are rejected with HTTP 422 and increment the counter."""
+
+    def stub_filter(text: str, threshold: float = 0.7):  # pragma: no cover - stub
+        return None
+
+    monkeypatch.setattr(ingest_filter, "filter_text", stub_filter)
+    app = ingest_filter.create_app()
+    client = TestClient(app)
+
+    start = (
+        ingest_filter.FILTER_BLOCK_TOTAL._value.get()
+        if ingest_filter.FILTER_BLOCK_TOTAL is not None
+        else 0.0
+    )
+    snr_start = (
+        ingest_filter.SNR_BLOCK_TOTAL._value.get()
+        if ingest_filter.SNR_BLOCK_TOTAL is not None
+        else 0.0
+    )
+    resp = client.post(
+        "/filter",
+        json={"text": "bad", "snr": 10.0, "snr_history": [10.0, 10.0, 10.0]},
+    )
+    assert resp.status_code == 422
+    if ingest_filter.FILTER_BLOCK_TOTAL is not None:
+        assert ingest_filter.FILTER_BLOCK_TOTAL._value.get() == start + 1
+    if ingest_filter.SNR_BLOCK_TOTAL is not None:
+        assert ingest_filter.SNR_BLOCK_TOTAL._value.get() == snr_start
+
+
+def test_skip_on_unsupported_language() -> None:
+    """Languages outside the allow-list are skipped and counted."""
+
+    app = ingest_filter.create_app()
+    client = TestClient(app)
+
+    start = (
+        ingest_filter.LANG_SKIPPED_TOTAL._value.get()
+        if ingest_filter.LANG_SKIPPED_TOTAL is not None
+        else 0.0
+    )
+    resp = client.post(
+        "/filter", json={"text": "hola", "snr": 10.0, "snr_history": [10.0]}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "lang_skipped"
+    if ingest_filter.LANG_SKIPPED_TOTAL is not None:
+        assert ingest_filter.LANG_SKIPPED_TOTAL._value.get() == start + 1
+
+
+def test_block_on_low_snr() -> None:
+    """Audio below the dynamic SNR threshold is rejected."""
+
+    app = ingest_filter.create_app()
+    client = TestClient(app)
+
+    start = (
+        ingest_filter.FILTER_BLOCK_TOTAL._value.get()
+        if ingest_filter.FILTER_BLOCK_TOTAL is not None
+        else 0.0
+    )
+    snr_start = (
+        ingest_filter.SNR_BLOCK_TOTAL._value.get()
+        if ingest_filter.SNR_BLOCK_TOTAL is not None
+        else 0.0
+    )
+    resp = client.post(
+        "/filter",
+        json={"text": "hello", "snr": 5.0, "snr_history": [10.0, 8.0, 12.0]},
+    )
+    assert resp.status_code == 422
+    if ingest_filter.FILTER_BLOCK_TOTAL is not None:
+        assert ingest_filter.FILTER_BLOCK_TOTAL._value.get() == start + 1
+    if ingest_filter.SNR_BLOCK_TOTAL is not None:
+        assert ingest_filter.SNR_BLOCK_TOTAL._value.get() == snr_start + 1

--- a/tests/test_neo4j_schema.py
+++ b/tests/test_neo4j_schema.py
@@ -1,0 +1,45 @@
+"""Tests for Neo4j schema extension with typed edge labels."""
+
+from __future__ import annotations
+
+from datacreek.neo4j_fabric import extend_schema_with_edge_labels
+
+
+class DummyClient:
+    """Capture Cypher calls for verification."""
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def run(
+        self, tenant: str, cypher: str, **params
+    ) -> None:  # pragma: no cover - trivial
+        self.calls.append((tenant, cypher, params))
+
+
+def test_extend_schema_with_edge_labels() -> None:
+    """Edge labels and constraints are created for all supported types."""
+
+    client = DummyClient()
+    extend_schema_with_edge_labels(client, tenant="alpha")
+
+    assert client.calls == [
+        ("alpha", "MATCH (e:EDGE {type: 'DOC'}) SET e:EDGE_DOC", {}),
+        (
+            "alpha",
+            "CREATE CONSTRAINT edge_doc_id IF NOT EXISTS FOR (e:EDGE_DOC) REQUIRE e.id IS UNIQUE",
+            {},
+        ),
+        ("alpha", "MATCH (e:EDGE {type: 'USER'}) SET e:EDGE_USER", {}),
+        (
+            "alpha",
+            "CREATE CONSTRAINT edge_user_id IF NOT EXISTS FOR (e:EDGE_USER) REQUIRE e.id IS UNIQUE",
+            {},
+        ),
+        ("alpha", "MATCH (e:EDGE {type: 'TAG'}) SET e:EDGE_TAG", {}),
+        (
+            "alpha",
+            "CREATE CONSTRAINT edge_tag_id IF NOT EXISTS FOR (e:EDGE_TAG) REQUIRE e.id IS UNIQUE",
+            {},
+        ),
+    ]

--- a/tests/test_quant_utils.py
+++ b/tests/test_quant_utils.py
@@ -1,0 +1,30 @@
+"""Tests for SmoothQuant scale computation and bfloat4 quantization."""
+
+import pytest
+import torch
+
+from training.quant_utils import quantize_bfloat4, smoothquant_group_scales
+
+
+def test_smoothquant_scales_clip_outliers() -> None:
+    """Scales above the 99th percentile should be clipped."""
+    group_size = 4
+    # Create 100 groups: 99 normal, 1 outlier with 10x larger values
+    weights = torch.ones(100 * group_size)
+    weights = weights.reshape(100, group_size) * 127
+    weights[-1] = 1270  # last group has scale 10
+    raw_scales = weights.abs().max(dim=-1).values / 127.0
+    p99 = torch.quantile(raw_scales, 0.99)
+    clipped = smoothquant_group_scales(weights, group_size=group_size)
+    assert torch.all(clipped <= p99)
+    assert clipped[-1].item() == pytest.approx(p99.item())
+
+
+def test_quantize_bfloat4_range() -> None:
+    """Quantized values should lie within the signed 4-bit range."""
+    torch.manual_seed(0)
+    weights = torch.randn(2, 8) * 0.1
+    q, scales = quantize_bfloat4(weights, group_size=4)
+    assert q.dtype == torch.int8
+    assert q.min() >= -8 and q.max() <= 7
+    assert scales.shape[-1] == weights.shape[-1] // 4

--- a/tests/test_smart_patch.py
+++ b/tests/test_smart_patch.py
@@ -1,0 +1,12 @@
+from datacreek.smart_patch import PATCHSET_REGISTRY, PatchCandidate, solve_patch_ilp
+
+
+def test_solve_patch_ilp_selects_optimal_edges_and_stores_patchset():
+    candidates = [
+        PatchCandidate("e1", benefit=5, risk=4),
+        PatchCandidate("e2", benefit=4, risk=3),
+        PatchCandidate("e3", benefit=3, risk=2),
+    ]
+    patchset_id, selected = solve_patch_ilp(candidates, budget=5)
+    assert set(selected) == {"e2", "e3"}
+    assert PATCHSET_REGISTRY[patchset_id] == selected

--- a/tests/test_train_alpha.py
+++ b/tests/test_train_alpha.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+from scripts.train_alpha import train_alpha
+
+
+def test_train_alpha_projected_simplex():
+    def grad_fn(alpha):
+        return np.array([1.0, 0.0, -1.0])
+
+    alpha = train_alpha(np.array([0.3, 0.3, 0.4]), grad_fn, lr=0.5, steps=5)
+    assert np.isclose(alpha.sum(), 1.0)
+    assert np.all(alpha >= 0)
+    assert alpha[0] > alpha[2]

--- a/tests/unit/test_cpu_billing.py
+++ b/tests/unit/test_cpu_billing.py
@@ -1,0 +1,34 @@
+"""Tests for CPU cost Prometheus exporter and cost tracker."""
+
+from prometheus_client import REGISTRY
+
+from metrics_prometheus.cpu_billing import (
+    CpuCostTracker,
+    cpu_cost_total,
+    cpu_seconds_total,
+)
+
+
+def reset_metrics() -> None:
+    """Utility to clear counter state between tests."""
+    cpu_seconds_total._metrics.clear()  # type: ignore[attr-defined]
+    cpu_cost_total._metrics.clear()  # type: ignore[attr-defined]
+
+
+def test_record_increments_counters_and_cost() -> None:
+    reset_metrics()
+    tracker = CpuCostTracker(prices={"acme": 0.02})
+    tracker.record("acme", 5.0)
+    seconds_value = REGISTRY.get_sample_value("cpu_seconds_total", {"tenant": "acme"})
+    cost_value = REGISTRY.get_sample_value("cpu_cost_total", {"tenant": "acme"})
+    assert seconds_value == 5.0
+    assert cost_value == 0.1
+
+
+def test_set_price_controls_subsequent_cost() -> None:
+    reset_metrics()
+    tracker = CpuCostTracker(prices={"acme": 0.01})
+    tracker.set_price("acme", 0.05)
+    tracker.record("acme", 2.0)
+    cost_value = REGISTRY.get_sample_value("cpu_cost_total", {"tenant": "acme"})
+    assert cost_value == 0.1


### PR DESCRIPTION
## Summary
- reset AGENTS for v3.1 checklist
- add ingest-filter sidecar with language gating, audio SNR thresholding, dedicated `snr_block_total` metric and Prometheus metrics
- track embedding CPU seconds and cost per tenant with Prometheus
- adapt drift thresholds per tenant with EWMA detector
- schedule daily checkpoint cleanup via Kubernetes CronJob
- clip SmoothQuant per-group scales at the 99th percentile and quantize to bfloat4
- replay late hypergraph edges with a Flink-style watermark and side output
- enforce GPU credit quotas via admission webhook
- compute per-type Laplacians and optimise multiplex weights with a meta-gradient script
- select edge patches via an ILP solver using OR-Tools and store patch sets
- extend Neo4j schema with typed edge labels and unique constraints
- expose per-tenant Ray Serve request counters and latency histograms
- count hypergraph edges that arrive past the watermark via `late_edge_total`
- track GPU admission requests and label them as accepted or rejected
- track per-tenant drift alerts with a `drift_alert_total` Prometheus counter
- document verification of embedding CPU metric in checklist history

## Testing
- `pre-commit run --files AGENTS.md datacreek/analysis/embedding.py tests/test_embedding_cpu_metrics.py`
- `pytest tests/test_embedding_cpu_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_689298ac915c832f860bedb4b936c347